### PR TITLE
Add config file

### DIFF
--- a/worker/fishtest.cfg
+++ b/worker/fishtest.cfg
@@ -1,0 +1,9 @@
+[login]
+username =
+password =
+
+[parameters]
+host = 54.235.120.254
+port = 6543
+concurrency = 1
+


### PR DESCRIPTION
This allows worker.py to use a config file.
Usage from the command line doesn't change the first time you launch worker.py, but after that parameters are stored in the config file, and you can simply launch 'python worker.py'
Each time you provide new parameters from the command line, the config file is updated.
