### PR TITLE
Re-introduce concurrency in verify_signature()

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -25,7 +25,11 @@ if IS_WINDOWS:
   EXE_SUFFIX = '.exe'
   MAKE_CMD = 'mingw32-make build COMP=mingw ' + ARCH
 
-def verify_signature(engine, signature, remote, payload):
+def verify_signature(engine, signature, remote, payload, concurrency):
+  busy_process = subprocess.Popen([engine], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+  busy_process.stdin.write('setoption name Threads value %d\n' % (concurrency-1))
+  busy_process.stdin.write('go infinite\n')
+
   bench_sig = ''
   print 'Verifying signature of %s ...' % (os.path.basename(engine))
   with open(os.devnull, 'wb') as f:
@@ -44,6 +48,9 @@ def verify_signature(engine, signature, remote, payload):
     requests.post(remote + '/api/stop_run', data=json.dumps(payload))
     raise Exception('Wrong bench in %s Expected: %s Got: %s' % (engine, signature, bench_sig))
 
+  busy_process.stdin.write('quit\n')
+  busy_process.wait()
+  
   return bench_nps
 
 def setup(item, testing_dir):
@@ -212,9 +219,9 @@ def run_games(worker_info, password, remote, run, task_id):
     os.remove('results.pgn')
 
   # Verify signatures are correct
-  base_nps = verify_signature(new_engine, run['args']['new_signature'], remote, result)
+  base_nps = verify_signature(new_engine, run['args']['new_signature'], remote, result, games_concurrency)
   if not regression_test:
-    verify_signature(base_engine, run['args']['base_signature'], remote, result)
+    verify_signature(base_engine, run['args']['base_signature'], remote, result, games_concurrency)
 
   # Benchmark to adjust cpu scaling
   scaled_tc = adjust_tc(run['args']['tc'], base_nps)


### PR DESCRIPTION
Re-introduce concurrency in verify_signature()
Tested on Linux / Windows 7 without problems ; if a windows user could double-check, it would be great :-)
