### PR TITLE
Sets Default to Maximum Number of HT Cores - 1

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -21,11 +21,16 @@ def setup_config_file(config_file):
   ''' Config file setup, adds defaults if not existing '''
   config = SafeConfigParser()
   config.read(config_file)
+  
+  try:
+    cpu_count = str(multiprocessing.cpu_count() - 1)
+  except:
+    cpu_count = str(3)
 
   defaults = [('login', 'username', ''), ('login', 'password', ''),
               ('parameters', 'host', 'tests.stockfishchess.org'),
               ('parameters', 'port', '80'),
-              ('parameters', 'concurrency', '3')]
+              ('parameters', 'concurrency', cpu_count)]
 
   for v in defaults:
     if not config.has_section(v[0]):


### PR DESCRIPTION
Current concurrency default of 3 cores fails to make use of additional processing power available on many machines. My edit sets the initial default to the total number of cores available, minus one to keep the user's computer running smoothly.
