### PR TITLE
Display a simple message when there are no tasks.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -76,6 +76,7 @@ def worker(worker_info, password, remote):
 
   # No tasks ready for us yet, just wait...
   if 'task_waiting' in req:
+    print 'No tasks available at this time, waiting...'
     time.sleep(10)
     return
 


### PR DESCRIPTION
When there are no tasks, the worker script will simply sleep and wait until there is a task. However, no output is generated when this happens, so the user may think an error has occurred. This change adds a message so that the user knows the worker is waiting for a task.

Note that as implemented, the worker will display the message repeatedly if it needs to wait for an extended period of time.
