### PR TITLE
Fix mako templates on Pyramid 1.5

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -15,6 +15,8 @@ def main(global_config, **settings):
                         session_factory=session_factory,
                         root_factory='fishtest.models.RootFactory')
 
+  config.include('pyramid_mako')
+
   # Authentication
   with open(os.path.expanduser('~/fishtest.secret'), 'r') as f:
     secret = f.read()

--- a/fishtest/setup.py
+++ b/fishtest/setup.py
@@ -8,6 +8,7 @@ CHANGES = ''
 requires = [
     'pyramid',
     'pyramid_debugtoolbar',
+    'pyramid_mako',
     'waitress',
     'psutil',
     'pymongo',


### PR DESCRIPTION
As of Pyramid 1.5, Mako templates are no longer configured by default.
See http://docs.pylonsproject.org/projects/pyramid/en/1.5-branch/whatsnew-1.5.html

This probably breaks things on Pyramid <1.5 so you should keep it around for when you update.
