### PR TITLE
Add link to official stockfish to menu

### DIFF
--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -39,6 +39,7 @@
           <li><a href="/regression">Regression</a></li>
           <!--<li><a href="http://bit.ly/11QsIkd" target="_blank">Regression</a></li>-->
           <li><a href="http://abrok.eu/stockfish/" target="_blank">Compiles</a></li>
+          <li><a href="https://github.com/official-stockfish/Stockfish" target="_blank">SF-github</a></li>          
           <li class="nav-header">Admin</li>
           <li><a href="/signup">Register</a></li>
         </ul>


### PR DESCRIPTION
I miss direct link to official-stockfish/Stockfish github in main menu.