### PR TITLE
Throughput and internal priority. Better balancing between tests.

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -141,6 +141,12 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
     </div>
   </div>
   <div class="control-group">
+    <label class="control-label">Throughput:</label>
+    <div class="controls">
+      <input name="throughput" value="${args.get('throughput', 1000)}">
+    </div>
+  </div>
+  <div class="control-group">
     <label class="control-label">Test Repo:</label>
     <div class="controls">
       <input name="tests-repo" value="${args.get('tests_repo', tests_repo)}" ${'readonly' if re_run else ''}>

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -78,6 +78,9 @@ var spsa_history_url = '${run_args[0][1]}/spsa_history';
     <label class="control-label">Adjust priority (higher is more urgent):</label>
     <input name="priority" value="${run['args']['priority']}">
 
+    <label class="control-label">Adjust throughput:</label>
+    <input name="throughput" value="${run['args']['throughput']}">
+
     <input type="hidden" name="run" value="${run['_id']}" />
     <button type="submit" class="btn btn-primary">Modify</button>
   </form>

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -310,6 +310,7 @@ def validate_form(request):
 
   data['threads'] = int(request.POST['threads'])
   data['priority'] = int(request.POST['priority'])
+  data['throughput'] = int(request.POST['throughput'])
 
   if data['threads'] <= 0:
     raise Exception('Threads must be >= 1')
@@ -371,6 +372,7 @@ def tests_modify(request):
     run['finished'] = False
     run['args']['num_games'] = num_games
     run['args']['priority'] = int(request.POST['priority'])
+    run['args']['throughput'] = int(request.POST['throughput'])
     request.rundb.runs.save(run)
 
     request.actiondb.modify_run(authenticated_userid(request), before, run)
@@ -640,7 +642,7 @@ def tests_view(request):
   for name in ['new_tag', 'new_signature', 'new_options', 'resolved_new',
                'base_tag', 'base_signature', 'base_options', 'resolved_base',
                'sprt', 'num_games', 'spsa', 'tc', 'threads', 'book', 'book_depth',
-               'priority', 'username', 'tests_repo', 'info']:
+               'priority', 'internal_priority', 'username', 'tests_repo', 'info']:
 
     if not name in run['args']:
       continue


### PR DESCRIPTION
All tests are run in parallel and ordered by constantly changing internal priority rather than being processed one by one.

This has several advantages:
- No long running test should get stuck at the end of the queue. Instead these are progressing slowly.
- After a test has been approved in fishtest, the execution starts immediately, so a developer can immediately get feedback if the test is promising or not.

python is not my strongest language, so please review carefully :-)

I'm still running some internal tests in my local fishtest instance, but I'm submitting this for early review to get feedback...