### PR TITLE
PGO

### DIFF
--- a/fishtest/fishtest/builder.py
+++ b/fishtest/fishtest/builder.py
@@ -26,28 +26,28 @@ FISHCOOKING_URL = 'https://github.com/mcostalba/FishCooking'
 LINUX32 = {
   'system': 'linux',
   'architecture': '32',
-  'make_cmd': 'make build ARCH=x86-32 COMP=gcc',
+  'make_cmd': 'make profile-build ARCH=x86-32 COMP=gcc',
   'gcc_alias': '',
   'native': True,
 }
 LINUX64 = {
   'system': 'linux',
   'architecture': '64',
-  'make_cmd': 'make build ARCH=x86-64-modern COMP=gcc',
+  'make_cmd': 'make profile-build ARCH=x86-64-modern COMP=gcc',
   'gcc_alias': '',
   'native': True,
 }
 WIN32 = {
   'system': 'windows',
   'architecture': '32',
-  'make_cmd': 'make build ARCH=x86-32 COMP=mingw',
+  'make_cmd': 'make profile-build ARCH=x86-32 COMP=mingw',
   'gcc_alias': 'i686-w64-mingw32-c++',
   'native': False,
 }
 WIN64 = {
   'system': 'windows',
   'architecture': '64',
-  'make_cmd': 'make build ARCH=x86-64 COMP=mingw',
+  'make_cmd': 'make profile-build ARCH=x86-64 COMP=mingw',
   'gcc_alias': 'x86_64-w64-mingw32-c++',
   'native': False,
 }

--- a/worker/games.py
+++ b/worker/games.py
@@ -42,11 +42,11 @@ HTTP_TIMEOUT = 5.0
 FISHCOOKING_URL = 'https://github.com/mcostalba/FishCooking'
 ARCH = 'ARCH=x86-64-modern' if is_64bit() else 'ARCH=x86-32'
 EXE_SUFFIX = ''
-MAKE_CMD = 'make build COMP=gcc ' + ARCH
+MAKE_CMD = 'make profile-build COMP=gcc ' + ARCH
 
 if IS_WINDOWS:
   EXE_SUFFIX = '.exe'
-  MAKE_CMD = 'mingw32-make build COMP=mingw ' + ARCH
+  MAKE_CMD = 'mingw32-make profile-build COMP=mingw ' + ARCH
 
 def binary_filename(sha):
   system = platform.uname()[0].lower()


### PR DESCRIPTION
We've (re)learnt recently that the compiler can really optimize differently
with PGO, making use of profiling information collected at runtime. Whether a
patch is a clear speedup or a clear speed regression can be radically different
with and without PGO. Often fishtest is being used to verify non functional
changes that are supposed to speedup the engine (or simplifications that are
supposed not to slow it down). To be able to rely on fishtest for that, it must
use PGO.