### PR TITLE
Scale increment

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -185,8 +185,8 @@ def adjust_tc(tc, base_nps, concurrency):
   scaled_tc = '%.2f' % (time_tc * factor)
   tc_limit = time_tc * factor * 3
   if increment > 0.0:
-    scaled_tc += '+%.2f' % (increment)
-    tc_limit += increment * 200
+    scaled_tc += '+%.2f' % (increment * factor)
+    tc_limit += increment * factor * 200
   if num_moves > 0:
     scaled_tc = '%d/%s' % (num_moves, scaled_tc)
     tc_limit *= 100.0 / num_moves


### PR DESCRIPTION
Without that we cannot test time management patches correctly, because each
worker uses a different increment/base ratio.

This problem is also known to cause chi-square to fail for tcs where the
increment is not small respective to the base, like 5+0.05 for example
(for the same reason).

Now with C++11 std::chrono, SF uses a sub millisecond precision on every
platform. The only constraint is that the Timer thread only checks for
time every 5 msec, but that's still 10x less than our 50msec increment,
so no risk to go below that.