### PR TITLE
Restore LTC at 60 seconds

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -195,7 +195,7 @@ $(function() {
   $('#slow_test').click(function() {
     $('input[name=sprt_elo0]').val('0');
     $('input[name=sprt_elo1]').val('5');
-    $('input[name=tc]').val('40+0.4');
+    $('input[name=tc]').val('60+0.4');
   });
 });
 </script>


### PR DESCRIPTION
The sensible point of a LTC game is the average search depth (specially at midgame) not the average game duration.

Scalability issue are more and more important and the number of tests that pass STC and fail LTC is sensible (even now with SPRT[0,5] for both cases). This means that we really want to test a patch at a good average search depth rate. Ideally we want an even higher value of LTC, but given our current resoruces 60 seconds is an acceptable compromise.

This patch restores average search depth and has the draw back of increasing testing time by 40 secs on average. This is more then acceptable IMO considering the current rate of tests that fail LTC after STC (scalability sensible) and the fact that only few tests reach LTC, so total testing time is not so impacted.