### PR TITLE
Increase the time waiting for a new game result.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -14,7 +14,7 @@ from optparse import OptionParser
 from games import run_games
 from updater import update
 
-WORKER_VERSION = 56
+WORKER_VERSION = 57
 ALIVE = True
 
 HTTP_TIMEOUT = 5.0
@@ -166,7 +166,7 @@ def main():
   global ALIVE
   while ALIVE:
     if not success:
-      time.sleep(300)
+      time.sleep(1800)
     success = worker(worker_info, args[1], remote)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This should increase the maximum allowed game duration
to 30 minutes, and allows tests with longer time controls.
Also bump up worker version.

This change worked recently for CoffeeOne.
I propose to run a test of about 1,000 games at 5min+3sec.

I chose a limit of 30 minutes as I think this is a good compromise
between the maximum game duration, and the time an unattended PC
must wait until the hanging process is being killed.