### PR TITLE
Feed a random seed to cutechess.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -13,6 +13,7 @@ import threading
 import time
 import traceback
 import platform
+import struct
 import zipfile
 from base64 import b64decode
 from zipfile import ZipFile
@@ -445,6 +446,7 @@ def run_games(worker_info, password, remote, run, task_id):
     cmd = [ cutechess, '-repeat', '-rounds', str(games_to_play), '-tournament', 'gauntlet'] + pgnout + \
           ['-resign', 'movecount=3', 'score=400', '-draw', 'movenumber=34',
            'movecount=8', 'score=20', '-concurrency', str(games_concurrency)] + pgn_cmd + \
+          ['-srand', "%d" % struct.unpack("<L", os.urandom(struct.calcsize("<L")))] + \
           ['-engine', 'name=stockfish', 'cmd=stockfish'] + new_options + ['_spsa_'] + \
           ['-engine', 'name=base', 'cmd=base'] + base_options + ['_spsa_'] + \
           ['-each', 'proto=uci', 'tc=%s' % (scaled_tc)] + nodestime_cmd + threads_cmd + book_cmd

--- a/worker/games.py
+++ b/worker/games.py
@@ -444,9 +444,9 @@ def run_games(worker_info, password, remote, run, task_id):
   while games_remaining > 0:
     # Run cutechess-cli binary
     cmd = [ cutechess, '-repeat', '-rounds', str(games_to_play), '-tournament', 'gauntlet'] + pgnout + \
+          ['-srand', "%d" % struct.unpack("<L", os.urandom(struct.calcsize("<L")))] + \
           ['-resign', 'movecount=3', 'score=400', '-draw', 'movenumber=34',
            'movecount=8', 'score=20', '-concurrency', str(games_concurrency)] + pgn_cmd + \
-          ['-srand', "%d" % struct.unpack("<L", os.urandom(struct.calcsize("<L")))] + \
           ['-engine', 'name=stockfish', 'cmd=stockfish'] + new_options + ['_spsa_'] + \
           ['-engine', 'name=base', 'cmd=base'] + base_options + ['_spsa_'] + \
           ['-each', 'proto=uci', 'tc=%s' % (scaled_tc)] + nodestime_cmd + threads_cmd + book_cmd


### PR DESCRIPTION
Cutechess presently uses the current time, in seconds, to seed its RNG.
This makes it very easy for various machines in fishtest to choose the
same random seed on the same workload, particularly when a large number
of machines join a machine pool for a specific test.

The fix here is to pass a random integer to cutechess via the "-srand"
option.  A platform-independent seed is chosen using os.urandom(),
which raises an exception if a randomness source is unavailable.

Cutechess only uses 32 bits of random state (a "quint32"), and the
parser for -srand requires an unsigned integer (although the
Mersenne::initialize routine just takes an int), so the routine here
generates an unsigned integer.

Issue originally discovered by VoyagerOne at
https://groups.google.com/forum/#!topic/fishcooking/CW7Vlwur8CQ