### PR TITLE
do not purge time losses

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -600,8 +600,7 @@ def calculate_residuals(run):
       # Special case crashes or time losses
       stats = task.get('stats', {})
       crashes = stats.get('crashes', 0)
-      time_losses = stats.get('time_losses', 0)
-      if crashes + time_losses > 3:
+      if crashes > 3:
         task['residual'] = 8.0
 
       if abs(task['residual']) < 2.0:


### PR DESCRIPTION
At the moment, we are trying to fix time loss issues. And fishtest is really not helping because it auto-purges all time losses!

This hack was never needed in the first place. Point is that machines with many time losses are already more likely to behave differently from the rest in terms of (W,L,D) joint distribution, and be burged by the chi-square test. Sounds statistics are enough, no need to add homegrown hacks on top of chi-square.

Ideally, we want to know which version lost on time (test or master). But that requires a bit more work.