### PR TITLE
fix base_nps in SMP tests with HT

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -406,8 +406,8 @@ def run_games(worker_info, password, remote, run, task_id):
     os.remove('results.pgn')
 
   # Verify signatures are correct
-  base_nps = verify_signature(new_engine, run['args']['new_signature'], remote, result, games_concurrency)
-  verify_signature(base_engine, run['args']['base_signature'], remote, result, games_concurrency)
+  base_nps = verify_signature(new_engine, run['args']['new_signature'], remote, result, games_concurrency * threads)
+  verify_signature(base_engine, run['args']['base_signature'], remote, result, games_concurrency * threads)
 
   # Benchmark to adjust cpu scaling
   scaled_tc, tc_limit = adjust_tc(run['args']['tc'], base_nps, int(worker_info['concurrency']))


### PR DESCRIPTION
In verify_signature 'concurrency' was wrongly set to 'games_concurrency' instead of 'games_concurrency * threads'

In verify_signature() are started 2 instance of the engine:
- the first one with 'go infinite' and number of threads 'concurrency - 1': in order to load the CPU
- the second one with 'bench' and one thread: in order to compute bench signature and bench nps

In this way:
1. worker with virtual cores are rated correctly in SMP tests
2. worker without virtual cores are rated with the correct setting for TurboBoost (minor effect)

Tested with my worker (4-cores with HT)

With 'concurrency = 3', in all tests, my worker is rated @ 2.24 Mnps

With 'concurrency = 7'
  a. in 1-thread tests, the worker is rated @ 1.40 Mnps (TC scaled as with 7 slow cores)
  b. in 7-threads tests, the worker is rated @ 1.40 Mnps (TC scaled as with 7 slow cores)

Before the fix, with 'concurrency = 7' 
  c. in 7-threads tests, the worker was rated @ 2.24 Mnps (TC scaled as with 7 fast cores, wrong!)