### PR TITLE
fix count of finished runs

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -164,7 +164,7 @@ class RunDb:
       result[0] += list(c)
       result[1] += c.count()
     else:
-      result[1] += self.old_runs.find().count()
+      result[1] += self.old_runs.find(q).count()
       
     return result
 


### PR DESCRIPTION
I believe this corrects the number of finished tests (and pages of them) listed on user pages (which I believe occurs when the number in the runs db exceeds one page).