### PR TITLE
increase spsa iter count only with completed games

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -367,14 +367,11 @@ class RunDb:
 
     spsa = run['args']['spsa']
 
-    # Increment the iter counter
-    spsa['iter'] += 1 
-    self.runs.save(run)
-
     # Generate the next set of tuning parameters
+    iter_local = spsa['iter'] + 1 #assume at least one completed, and avoid division by zero
     for param in spsa['params']:
-      a = param['a'] / (spsa['A'] + spsa['iter']) ** spsa['alpha']
-      c = param['c'] / spsa['iter'] ** spsa['gamma']
+      a = param['a'] / (spsa['A'] + iter_local) ** spsa['alpha']
+      c = param['c'] / iter_local ** spsa['gamma']
       R = a / c ** 2
       flip = 1 if bool(random.getrandbits(1)) else -1
       result['w_params'].append({
@@ -388,13 +385,13 @@ class RunDb:
         'name': param['name'],
         'value': min(max(param['theta'] - c * flip, param['min']), param['max']),
       })
-      
+
     return result
 
   def update_spsa(self, run, spsa_results):
     spsa = run['args']['spsa']
 
-    spsa['iter'] += int(spsa_results['num_games'] / 2) - 1
+    spsa['iter'] += int(spsa_results['num_games'] / 2)
 
     # Update the current theta based on the results from the worker
     # Worker wins/losses are always in terms of w_params


### PR DESCRIPTION
Prior to this patch, spsa iteration count is increased when spsa work is
requested, not only when it is completed.  The spsa iteration count is
important to convergence as it affects the step size.  This has been
a problem recently as there have been many disconnecting clients; e.g.,
checking the most recently completed spsa run
http://tests.stockfishchess.org/tests/view/573fc6890ebc59301a354f99
the final iteration count is 60837 instead of 20000.  See also related fishcooking thread
https://groups.google.com/forum/#!topic/fishcooking/Np13OpEO1_w