### PR TITLE
Spsa boundary tweak

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -363,8 +363,11 @@ class RunDb:
       value = min(max(param['theta'] + increment, param['min']), param['max'])
     else: #clipping == 'careful':
       inc = min(abs(increment), abs(param['theta'] - param['min']) / 2, abs(param['theta'] - param['max']) / 2)
-      inc_sgn = 0 if increment == 0 else increment / abs(increment)
-      value = param['theta'] + inc_sgn * inc
+      if inc > 0:
+          inc_sgn = 0 if increment == 0 else increment / abs(increment)
+          value = param['theta'] + inc_sgn * inc
+      else: #revert to old behavior to bounce off boundary
+          value = min(max(param['theta'] + increment, param['min']), param['max'])
 
     #'deterministic' rounding calls round() inside the worker.
     #'randomized' says 4.p should be 5 with probability p, 4 with probability 1-p,

--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -356,7 +356,7 @@ class RunDb:
     self.runs.save(run)
     return True
 
-  def spsa_param_clip_round(param, increment, clipping, rounding):
+  def spsa_param_clip_round(self, param, increment, clipping, rounding):
     value = 0.0
 
     if clipping == 'old':
@@ -408,14 +408,14 @@ class RunDb:
       flip = 1 if bool(random.getrandbits(1)) else -1
       result['w_params'].append({
         'name': param['name'],
-        'value': spsa_param_clip_round(param, c * flip, spsa['clipping'], spsa['rounding']),
+        'value': self.spsa_param_clip_round(param, c * flip, spsa['clipping'], spsa['rounding']),
         'R': R,
         'c': c,
         'flip': flip,
       })
       result['b_params'].append({
         'name': param['name'],
-        'value': spsa_param_clip_round(param, -c * flip, spsa['clipping'], spsa['rounding']),
+        'value': self.spsa_param_clip_round(param, -c * flip, spsa['clipping'], spsa['rounding']),
       })
 
     return result
@@ -435,7 +435,7 @@ class RunDb:
       R = spsa_results['w_params'][idx]['R']
       c = spsa_results['w_params'][idx]['c']
       flip = spsa_results['w_params'][idx]['flip']
-      param['theta'] = spsa_param_clip_round(param, R * c * result * flip, spsa['clipping'], 'deterministic'),
+      param['theta'] = self.spsa_param_clip_round(param, R * c * result * flip, spsa['clipping'], 'deterministic')
       summary.append({
         'theta': param['theta'],
         'R': R,

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -110,6 +110,15 @@
 Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
     </div>
   </div>
+  <div class="control-group stop_rule spsa">
+    <label class="control-label">SPSA clipping:</label>
+    <div class="controls">
+      <select name="spsa_clipping">
+        <option value="old">old</option>
+        <option value="careful">careful</option>
+      </select>
+    </div>
+  </div>
   <div class="control-group">
     <label class="control-label">Time Control:</label>
     <div class="controls">

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -119,6 +119,15 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
       </select>
     </div>
   </div>
+  <div class="control-group stop_rule spsa">
+    <label class="control-label">SPSA rounding:</label>
+    <div class="controls">
+      <select name="spsa_rounding">
+        <option value="deterministic">deterministic</option>
+        <option value="randomized">randomized</option>
+      </select>
+    </div>
+  </div>
   <div class="control-group">
     <label class="control-label">Time Control:</label>
     <div class="controls">

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -301,6 +301,7 @@ def validate_form(request):
       'raw_params': request.POST['spsa_raw_params'],
       'iter': 0,
       'num_iter': int(data['num_games'] / 2),
+      'clipping': request.POST['spsa_clipping'],
     }
     data['spsa']['params'] = parse_spsa_params(request.POST['spsa_raw_params'], data['spsa'])
   else:
@@ -678,7 +679,8 @@ def tests_view(request):
     if name == 'spsa' and value != '-':
       params = ['param: %s, best: %.2f, start: %.2f, min: %.2f, max: %.2f, c %f, a %f' % \
                 (p['name'], p['theta'], p['start'], p['min'], p['max'], p['c'], p['a']) for p in value['params']]
-      value = 'Iter: %d, A: %d, alpha %f, gamma %f\n%s' % (value['iter'], value['A'], value['alpha'], value['gamma'], '\n'.join(params))
+      value = 'Iter: %d, A: %d, alpha %f, gamma %f, clipping %s\n%s' % (value['iter'], value['A'], value['alpha'], \
+                value['gamma'], value['clipping'] if 'clipping' in value else 'old', '\n'.join(params))
 
     if 'tests_repo' in run['args']:
       if name == 'new_tag':

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -302,6 +302,7 @@ def validate_form(request):
       'iter': 0,
       'num_iter': int(data['num_games'] / 2),
       'clipping': request.POST['spsa_clipping'],
+      'rounding': request.POST['spsa_rounding'],
     }
     data['spsa']['params'] = parse_spsa_params(request.POST['spsa_raw_params'], data['spsa'])
   else:
@@ -679,8 +680,10 @@ def tests_view(request):
     if name == 'spsa' and value != '-':
       params = ['param: %s, best: %.2f, start: %.2f, min: %.2f, max: %.2f, c %f, a %f' % \
                 (p['name'], p['theta'], p['start'], p['min'], p['max'], p['c'], p['a']) for p in value['params']]
-      value = 'Iter: %d, A: %d, alpha %f, gamma %f, clipping %s\n%s' % (value['iter'], value['A'], value['alpha'], \
-                value['gamma'], value['clipping'] if 'clipping' in value else 'old', '\n'.join(params))
+      value = 'Iter: %d, A: %d, alpha %f, gamma %f, clipping %s, rounding %s\n%s' % (value['iter'], value['A'], value['alpha'], value['gamma'],
+              value['clipping'] if 'clipping' in value else 'old',
+              value['rounding'] if 'rounding' in value else 'deterministic',
+              '\n'.join(params))
 
     if 'tests_repo' in run['args']:
       if name == 'new_tag':


### PR DESCRIPTION
I was watching some recent tunings by Fisherman, and saw spsa reverse its trend after its bounds were changed:
http://tests.stockfishchess.org/tests/view/575a7d0f0ebc59029919b385
http://tests.stockfishchess.org/tests/view/575ae6ee0ebc59029919b39d

There's a chance that the current behavior at boundaries is to blame (though I'm not sure), so I created the present pull request.  It contains two changes: one attempting to make spsa more stable at boundaries, and one to make it more stable in general by replacing the round() with a randomized rounding that in expectation gives a smoother function.

It's possible that neither of these changes are improvements, so I've added options to the new run page to enable or disable them (they are disabled by default).  I can post on the mailing list so people know to try them; if they like them, maybe they can become default, or if they dislike them, we can remove them.

Note that the first two commits in this pull request have a more detailed explanation of their behavior.  (The third third commit fixes some typos.)