### PR TITLE
Switch master and the patch in master diff

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -48,7 +48,7 @@ var spsa_history_url = '${run_args[0][1]}/spsa_history';
   </form>
 %if not run.get('approved', False):
   <span>
-    <a href="https://github.com/official-stockfish/Stockfish/compare/master...${run['args']['resolved_base'][:7]}" target="_blank">Master diff</a>
+    <a href="https://github.com/official-stockfish/Stockfish/compare/${run['args']['resolved_base'][:7]}...master" target="_blank">Master diff</a>
     <form action="/tests/approve" method="POST" style="display:inline">
       <input type="hidden" name="run-id" value="${run['_id']}">
       <button type="submit" class="btn btn-success">


### PR DESCRIPTION
Before this patch, in unapproved test run, the master diff link is broken because it makes Github attempting to compare the master against the patch, which gives normally nothing. Instead, it should compare the patch against the master to see the diffs.