### PR TITLE
Regularize space in base.mak

### DIFF
--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -26,7 +26,7 @@
         <ul class="nav nav-list">
           <li class="nav-header">Tests</li>
           <li><a href="/tests">Overview</a></li>
-					<li><a href="/tests?success_only=1">Greens</a></li>
+          <li><a href="/tests?success_only=1">Greens</a></li>
           <li><a href="/tests/run">New</a></li>
           <li class="nav-header">Misc</li>
           <li><a href="/users">Users</a></li>


### PR DESCRIPTION
This patch intends to regularize the indentation in base.mak that was broken after adding the green link (spaces replaced by tabs). No other changes.