### PR TITLE
Don't use profile-build in fishtest

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -43,11 +43,11 @@ HTTP_TIMEOUT = 5.0
 FISHCOOKING_URL = 'https://github.com/mcostalba/FishCooking'
 ARCH = 'ARCH=x86-64-modern' if is_64bit() else 'ARCH=x86-32'
 EXE_SUFFIX = ''
-MAKE_CMD = 'make profile-build COMP=gcc ' + ARCH
+MAKE_CMD = 'make build COMP=gcc ' + ARCH
 
 if IS_WINDOWS:
   EXE_SUFFIX = '.exe'
-  MAKE_CMD = 'mingw32-make profile-build COMP=mingw ' + ARCH
+  MAKE_CMD = 'mingw32-make build COMP=mingw ' + ARCH
 
 def binary_filename(sha):
   system = platform.uname()[0].lower()


### PR DESCRIPTION
Don't use profile-build because it is not deterministic. In particular the same source, comiled twice on the same machine can yield to a couple od binaries that have diferent speed.

This is a big no-no for fishtest becuase introduces a random bias that could affect testing result.

See https://groups.google.com/forum/?fromgroups=#!searchin/fishcooking/profiling%7Csort:date/fishcooking/4_ausUwMXP0/eebU5xZZFAAJ