### PR TITLE
Restore old waiting time of 5 minutes to check for new tasks.

### DIFF
--- a/fishtest/fishtest/api.py
+++ b/fishtest/fishtest/api.py
@@ -142,7 +142,7 @@ def request_version(request):
   token = authenticate(request)
   if 'error' in token: return json.dumps(token)
 
-  return json.dumps({'version': 59})
+  return json.dumps({'version': 60})
 
 @view_config(route_name='api_request_spsa', renderer='string')
 def request_spsa(request):

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -14,7 +14,7 @@ from optparse import OptionParser
 from games import run_games
 from updater import update
 
-WORKER_VERSION = 59
+WORKER_VERSION = 60
 ALIVE = True
 
 HTTP_TIMEOUT = 5.0
@@ -166,7 +166,7 @@ def main():
   global ALIVE
   while ALIVE:
     if not success:
-      time.sleep(1800)
+      time.sleep(300)
     success = worker(worker_info, args[1], remote)
 
 if __name__ == '__main__':


### PR DESCRIPTION
30 minutes is not really necessary and was mistakenly increased by me.
Bump up worker version to 60 to force updating.