### PR TITLE
Replace hard-coded value by chunk size

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -255,10 +255,10 @@ class RunDb:
         task_id = idx
 
     # Recalculate internal priority based on task start date and throughput
-    # Formula: - second_since_epoch - played_and_allocated_tasks * 3600 * 1000 / games_throughput
+    # Formula: - second_since_epoch - played_and_allocated_tasks * 3600 * chunk_size / games_throughput
     # With default value 'throughput = 1000', this means that the priority is unchanged as long as we play at rate '1000 games / hour'.
     if (run['args']['throughput'] != None and run['args']['throughput'] != 0):
-      run['args']['internal_priority'] = - time.mktime(run['start_time'].timetuple()) - task_id * 3600 * 1000 * run['args']['threads'] / run['args']['throughput']
+      run['args']['internal_priority'] = - time.mktime(run['start_time'].timetuple()) - task_id * 3600 * self.chunk_size * run['args']['threads'] / run['args']['throughput']
     self.runs.save(run)
 
     return {'run': run, 'task_id': task_id}


### PR DESCRIPTION
The internal priority formula implicitly uses the chunk size, so make this dependency explicit by replacing the hard-coded value.