### PR TITLE
Drop the pserve option --monitor-restart in start.sh

### DIFF
--- a/fishtest/start.sh
+++ b/fishtest/start.sh
@@ -3,4 +3,4 @@
 pkill -f pserve
 
 cd /home/fishtest/fishtest/fishtest
-nohup stdbuf -oL pserve --monitor-restart production.ini >nohup.out &
+nohup stdbuf -oL pserve production.ini >nohup.out &


### PR DESCRIPTION
The pserve option --monitor-restart, already deprecated in Pyramid 1.6.x and 1.7.x,
was dropped with Pyramid 1.8.x.
Option deleted from start.sh to run fishtest server with latest Pyramid.

To restart the server on failure better to use systemd. View the [fishtest server setup script](https://github.com/glinscott/fishtest/wiki/Fishtest-server-setup) for an example of systemd configuration to autostart and restart on failure the fishtest server (and to start/stop the Pyramid Debug Toolbar).