### PR TITLE
Fix OSError raised by Popen.kill() with a terminated PID

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -88,8 +88,7 @@ def verify_signature(engine, signature, remote, payload, concurrency):
 
   finally:
     if concurrency > 1:
-      busy_process.stdin.write('quit\n')
-      busy_process.kill()
+      busy_process.communicate('quit\n')
 
   return bench_nps
 


### PR DESCRIPTION
With MSYS2 python, using Popen.kill() with a terminated PID raises an OSError
https://bugs.python.org/issue6973
Drop the Popen.kill() call, and use Popen.communicate(), that wait for process to terminate, to end the subprocess used to load the CPU.