### PR TITLE
Protect elo formula from math domain error

### DIFF
--- a/fishtest/fishtest/stat_util.py
+++ b/fishtest/fishtest/stat_util.py
@@ -24,7 +24,7 @@ def phi_inv(p):
   return math.sqrt(2)*erf_inv(2*p-1)
 
 def elo(x):
-  if x <= 0:
+  if x <= 0 or x >= 1:
     return 0.0
   return -400*math.log10(1/x-1)
 


### PR DESCRIPTION
If the Elo difference in a fixed number of games test is huge, the calculation of the statistical error in `get_elo` will fail for `mu_max >= 1`. I encountered this error on my fishtest instance for chess variants (http://35.161.250.236:6543/tests), but it is not very likely to occur in the main fishtest instance, since Elo differences usually are much smaller there.