### PR TITLE
Do not change bounds when switching time control

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -205,16 +205,12 @@ $(function() {
   $('select[name=stop_rule]').change(update_visibility);
 
   $('#fast_test').click(function() {
-    $('input[name=sprt_elo0]').val('0');
-    $('input[name=sprt_elo1]').val('5');
     $('input[name=tc]').val('10+0.1');
     $('input[name=new-options]').val('Hash=4');
     $('input[name=base-options]').val('Hash=4');
   });
 
   $('#slow_test').click(function() {
-    $('input[name=sprt_elo0]').val('0');
-    $('input[name=sprt_elo1]').val('5');
     $('input[name=tc]').val('60+0.6');
     $('input[name=new-options]').val('Hash=64');
     $('input[name=base-options]').val('Hash=64');


### PR DESCRIPTION
Since SPRT bounds are not directly related to the choice of time control, automatically resetting the bounds when changing time control might be surprising for the user.