### PR TITLE
Update iteration limit when modifying SPSA run

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -378,6 +378,8 @@ def tests_modify(request):
 
     run['finished'] = False
     run['args']['num_games'] = num_games
+    if 'spsa' in run['args']:
+        run['args']['spsa']['num_iter'] = int(num_games / 2)
     run['args']['priority'] = int(request.POST['priority'])
     run['args']['throughput'] = int(request.POST['throughput'])
     request.rundb.runs.save(run)


### PR DESCRIPTION
Increasing the number of games during an SPSA run (e.g., from 10000 to 20000) can result in something like:
9806/5000 iterations
20000/20000 games played

Update the number of iterations when modifying the number of games so that the results are more consistent:
9806/10000 iterations
20000/20000 games played