### PR TITLE
Add page navigation at bottom

### DIFF
--- a/fishtest/fishtest/templates/tests.mak
+++ b/fishtest/fishtest/templates/tests.mak
@@ -83,6 +83,18 @@
 
 <%include file="run_table.mak" args="runs=runs['finished']"/>
 
+<h3>
+%if len(pages) > 3:
+ <span class="pagination pagination-small">
+  <ul>
+  %for page in pages:
+   <li class="${page['state']}"><a href="${page['url']}">${page['idx']}</a></li>
+  %endfor
+  </ul>
+ </span>
+%endif
+</h3>
+
 <script type="text/javascript">
 if ($.cookie('pending_state') == 'Hide') {
   $('#pending').addClass('in');


### PR DESCRIPTION
When scrolling through the test results I think it would be convenient to also have a pagination at the bottom, because you otherwise have to scroll back to the top before you can go to the next page.