### PR TITLE
Show time stamps on test details page

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -85,18 +85,24 @@ var spsa_history_url = '${run_args[0][1]}/spsa_history';
     <button type="submit" class="btn btn-primary">Modify</button>
   </form>
 
+  %if 'spsa' not in run['args']:
   <hr>
 
-  %if 'spsa' not in run['args']:
   <h4>Stats</h4>
   <table class="table table-condensed">
     <tr><td>chi^2</td><td>${'%.2f' % (chi2['chi2'])}</td></tr>
     <tr><td>dof</td><td>${chi2['dof']}</td></tr>
     <tr><td>p-value</td><td>${'%.2f' % (chi2['p'] * 100)}%</td></tr>
   </table>
-	%endif
+  %endif
 
-  
+  <hr>
+
+  <h4>Time</h4>
+  <table class="table table-condensed">
+    <tr><td>start time</td><td>${run['start_time'].strftime("%Y-%m-%d %H:%M:%S")}</td></tr>
+    <tr><td>last updated</td><td>${run['last_updated'].strftime("%Y-%m-%d %H:%M:%S")}</td></tr>
+  </table>
 </div>
 
 </div>


### PR DESCRIPTION
Currently, the start date is only shown in the list of tests, but not in the detailed view of a test. This PR adds a table (below stats on the right) where the start and last updated times are displayed.