### PR TITLE
Show change of throughput in action history

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -135,6 +135,11 @@ def actions(request):
       if before != after:
         item['description'].append('games changed from %s to %s' % (before, after))
 
+      before = action['data']['before']['args']['throughput']
+      after = action['data']['after']['args']['throughput']
+      if before != after:
+        item['description'].append('throughput changed from %s to %s' % (before, after))
+
       item['description'] = 'modify: ' + ','.join(item['description'])
     else:
       item['run'] = action['data']['args']['new_tag']


### PR DESCRIPTION
The action history does not show a meaningful message when the throughput is changed (`modify:`). With this PR, `'throughput changed from %s to %s' % (before, after)` is added to the message.