### PR TITLE
Make book_depth = 0 disable the opening book

### DIFF
--- a/fishtest/fishtest/api.py
+++ b/fishtest/fishtest/api.py
@@ -142,7 +142,7 @@ def request_version(request):
   token = authenticate(request)
   if 'error' in token: return json.dumps(token)
 
-  return json.dumps({'version': 60})
+  return json.dumps({'version': 61})
 
 @view_config(route_name='api_request_spsa', renderer='string')
 def request_spsa(request):

--- a/worker/games.py
+++ b/worker/games.py
@@ -415,7 +415,9 @@ def run_games(worker_info, password, remote, run, task_id):
   # Handle book or pgn file
   pgn_cmd = []
   book_cmd = []
-  if book.endswith('.pgn') or book.endswith('.epd'):
+  if book_depth <= 0:
+    pass
+  elif book.endswith('.pgn') or book.endswith('.epd'):
     plies = 2 * int(book_depth)
     pgn_cmd = ['-openings', 'file=%s' % (book), 'format=%s' % (book[-3:]), 'order=random', 'plies=%d' % (plies)]
   else:

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -14,7 +14,7 @@ from optparse import OptionParser
 from games import run_games
 from updater import update
 
-WORKER_VERSION = 60
+WORKER_VERSION = 61
 ALIVE = True
 
 HTTP_TIMEOUT = 5.0


### PR DESCRIPTION
Currently, setting Book Depth to 0 breaks the worker, which loops with an error.
To allow testing from the start position, i.e. no starting book, this change makes Book Depth 0 miss out all of the book arguments in the cutechess command.