### PR TITLE
Add option for disabling auto-purge per test

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -58,6 +58,7 @@ class RunDb:
               spsa=None,
               username=None,
               tests_repo=None,
+              auto_purge=True,
               throughput=1000,
               priority=0):
     if start_time == None:
@@ -83,6 +84,7 @@ class RunDb:
       'new_signature': new_signature,
       'username': username,
       'tests_repo': tests_repo,
+      'auto_purge': auto_purge,
       'throughput': throughput,
       'priority': priority,
       'internal_priority': - time.mktime(start_time.timetuple()),

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -15,6 +15,10 @@
       padding:1px;
       line-height:13px
     }
+    .checkbox.inline {
+      margin-left: 20px;
+      margin-right: 0;
+    }
   </style>
 
   ${self.head()}

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -165,6 +165,12 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
     </div>
   </div>
   <div class="control-group">
+    <label class="control-label">Advanced:</label>
+    <div class="controls checkbox inline">
+      <input name="auto-purge" type="checkbox" checked="checked" value="True">Auto-purge
+    </div>
+  </div>
+  <div class="control-group">
     <label class="control-label">Priority:</label>
     <div class="controls">
       <input name="priority" value="${args.get('priority', 0)}">

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -269,6 +269,8 @@ def validate_form(request):
     data['base_signature'] = data['new_signature']
     data['base_options'] = data['new_options']
 
+  data['auto_purge'] = request.POST.get('auto-purge') is not None
+
   # In case of reschedule use old data, otherwise resolve sha and update user's tests_repo
   if 'resolved_base' in request.POST:
     data['resolved_base'] = request.POST['resolved_base']
@@ -670,7 +672,8 @@ def tests_view(request):
   for name in ['new_tag', 'new_signature', 'new_options', 'resolved_new',
                'base_tag', 'base_signature', 'base_options', 'resolved_base',
                'sprt', 'num_games', 'spsa', 'tc', 'threads', 'book', 'book_depth',
-               'priority', 'internal_priority', 'username', 'tests_repo', 'info']:
+               'auto_purge', 'priority', 'internal_priority', 'username', 'tests_repo',
+               'info']:
 
     if not name in run['args']:
       continue
@@ -773,7 +776,7 @@ def tests(request):
     # when the run was finished, not when it is first viewed)
     if state == 'finished':
       purged = 0
-      if 'spsa' not in run['args'] and run['args']['threads'] == 1:
+      if run['args'].get('auto_purge', True) and 'spsa' not in run['args'] and run['args']['threads'] == 1:
         while purge_run(request.rundb, run) and purged < 5:
           purged += 1
           run = request.rundb.get_run(run['_id'])


### PR DESCRIPTION
This is a proposal to add an option for disabling auto-purge on a per-test basis. This might be useful if for certain tests it is expected that there will be a big statistical fluctuation, e.g., when using no/small opening book, when testing patches that give different speed-ups depending on the architecture, for time management tests, etc. By disabling auto-purge for such tests, one can avoid to bias the result and/or wasting too much resources by reapeatedly purging results.

Test submission page looks like this: http://35.161.250.236:6543/tests/run
An intentionally problematic test (in terms of fluctuations) where auto-purge was disabled: http://35.161.250.236:6543/tests/view/5a6474bb6e23db7297acc507