### PR TITLE
Wait longer when satisfying HTTP requests

### DIFF
--- a/fishtest/fishtest/api.py
+++ b/fishtest/fishtest/api.py
@@ -142,7 +142,7 @@ def request_version(request):
   token = authenticate(request)
   if 'error' in token: return json.dumps(token)
 
-  return json.dumps({'version': 61})
+  return json.dumps({'version': 63})
 
 @view_config(route_name='api_request_spsa', renderer='string')
 def request_spsa(request):

--- a/worker/games.py
+++ b/worker/games.py
@@ -38,7 +38,7 @@ def is_64bit():
     return is_windows_64bit()
   return '64' in platform.architecture()[0]
 
-HTTP_TIMEOUT = 5.0
+HTTP_TIMEOUT = 10.0
 
 FISHCOOKING_URL = 'https://github.com/mcostalba/FishCooking'
 ARCH = 'ARCH=x86-64-modern' if is_64bit() else 'ARCH=x86-32'
@@ -265,7 +265,7 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
         sys.stderr.write('Exception from calling update_task:\n')
         traceback.print_exc(file=sys.stderr)
         failed_updates += 1
-        if failed_updates > 5:
+        if failed_updates > 10:
           print('Too many failed update attempts')
           kill_process(p)
           break

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -14,10 +14,10 @@ from optparse import OptionParser
 from games import run_games
 from updater import update
 
-WORKER_VERSION = 61
+WORKER_VERSION = 63
 ALIVE = True
 
-HTTP_TIMEOUT = 5.0
+HTTP_TIMEOUT = 10.0
 
 def setup_config_file(config_file):
   ''' Config file setup, adds defaults if not existing '''


### PR DESCRIPTION
This is an attempt to make the problem described [here](https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/kA28W9fyCGQ) less damaging.

Just increase the timeout in the HTTP request from 5 to 10 secs and the number of repeating attempts from 5 to 10.