### PR TITLE
Add caching of data for /tests view

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -15,6 +15,9 @@ def main(global_config, **settings):
                         session_factory=session_factory,
                         root_factory='fishtest.models.RootFactory')
 
+  config.include('pyramid_mako')
+  config.include('pyramid_beaker')
+
   # Authentication
   with open(os.path.expanduser('~/fishtest.secret'), 'r') as f:
     secret = f.read()

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -15,6 +15,8 @@ from pyramid.view import view_config, forbidden_view_config
 from pyramid.httpexceptions import HTTPFound, HTTPBadRequest
 
 import stat_util
+import pyramid_beaker
+from beaker.cache import cache_region
 
 @view_config(route_name='home', renderer='mainpage.mak')
 def mainpage(request):
@@ -749,7 +751,12 @@ def post_result(run):
 
 @view_config(route_name='tests', renderer='tests.mak')
 @view_config(route_name='tests_user', renderer='tests.mak')
+def tests_cached(request):
+    return tests(request)
+
+@cache_region('short_term', 'tests_view')
 def tests(request):
+  
   username = request.matchdict.get('username', '')
   success_only = len(request.params.get('success_only', '')) > 0
 

--- a/fishtest/production.ini
+++ b/fishtest/production.ini
@@ -14,6 +14,10 @@ pyramid.default_locale_name = en
 
 mako.directories = fishtest:templates
 
+beaker.cache.regions = short_term
+beaker.cache.short_term.type = memory
+beaker.cache.short_term.expire = 5
+
 ###
 # wsgi server configuration
 ###

--- a/fishtest/setup.py
+++ b/fishtest/setup.py
@@ -6,8 +6,10 @@ README = ''
 CHANGES = ''
 
 requires = [
+    'pyramid_mako',
     'pyramid',
     'pyramid_debugtoolbar',
+    'pyramid_beaker',
     'waitress',
     'psutil',
     'pymongo',


### PR DESCRIPTION
This is a first quick hack.

It adds the caching of the DATA for the /tests view (5s timeout). 

The HTML template conversion itself is still executed, not clear for me how to do caching for that and if it is really needed. 

If you can get this to work in YOUR test environment then adding caching to other critical spots is easy.
I tested this by adding some random data and verifying that it remained constant on refreshes for 5 seconds.
