### PR TITLE
add index on tasks.pending to speed up query of new tasks

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -30,6 +30,10 @@ class RunDb:
 
   def build_indices(self):
     self.runs.ensure_index([('finished', ASCENDING), ('last_updated', DESCENDING)])
+    self.runs.ensure_index([('tasks.pending', ASCENDING)],
+                           partialFilterExpression = { 'tasks': { '$elemMatch': {'pending': True} } } )
+    self.runs.ensure_index([('tasks.active', ASCENDING)],
+                           partialFilterExpression = { 'tasks': { '$elemMatch': {'active': True} } } )
 
   def generate_tasks(self, num_games):
     tasks = []

--- a/fishtest/utils/index.py
+++ b/fishtest/utils/index.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python
+import os, sys
+
+# For tasks
+sys.path.append(os.path.expanduser('~/fishtest/fishtest'))
+from fishtest.rundb import RunDb
+
+def create_indices():
+  rundb = RunDb()
+  rundb.build_indices()
+
+def main():
+  create_indices()
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This index should speed up the finding of a new task when a worker has finished the previous one. Gives only a marginal gain on my home test, but I only have a handful of tests in the database at the moment. Should give a useful gain (possibly a very large gain) on a large db.