### PR TITLE
Make rundb thread safe

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -3,6 +3,7 @@ import os
 import random
 import math
 import time
+import threading
 from datetime import datetime
 from bson.objectid import ObjectId
 from pymongo import MongoClient, ASCENDING, DESCENDING
@@ -13,6 +14,10 @@ from regressiondb import RegressionDb
 from views import parse_tc
 
 import stat_util
+from synchro import synchronized
+
+# reentrant lock for task management
+lock = threading.RLock()
 
 class RunDb:
   def __init__(self, db_name='fishtest_new'):
@@ -28,9 +33,11 @@ class RunDb:
 
     self.chunk_size = 1000
 
+  @synchronized(lock)
   def build_indices(self):
     self.runs.ensure_index([('finished', ASCENDING), ('last_updated', DESCENDING)])
 
+  @synchronized(lock)
   def generate_tasks(self, num_games):
     tasks = []
     remaining = num_games
@@ -44,6 +51,7 @@ class RunDb:
       remaining -= task_size
     return tasks
 
+  @synchronized(lock)
   def new_run(self, base_tag, new_tag, num_games, tc, book, book_depth, threads, base_options, new_options,
               info='',
               resolved_base='',
@@ -111,6 +119,7 @@ class RunDb:
     }
 
     # Check for an existing approval matching the git commit SHAs
+    @synchronized(lock)
     def get_approval(sha):
       q = { '$or': [{ 'args.resolved_base': sha }, { 'args.resolved_new': sha }], 'approved': True }
       return self.runs.find_one(q)
@@ -123,6 +132,7 @@ class RunDb:
 
     return self.runs.insert(new_run)
 
+  @synchronized(lock)
   def get_machines(self):
     machines = []
     for run in self.runs.find({'tasks': {'$elemMatch': {'active': True}}}):
@@ -150,6 +160,7 @@ class RunDb:
   def get_runs(self):
     return list(self.get_unfinished_runs()) + self.get_finished_runs()[0]
 
+  @synchronized(lock)
   def get_unfinished_runs(self):
     return self.runs.find({'finished': False},
                           sort=[('last_updated', DESCENDING), ('start_time', DESCENDING)])
@@ -175,6 +186,7 @@ class RunDb:
       
     return result
 
+  @synchronized(lock)
   def get_results(self, run):
     if not run['results_stale']:
       return run['results']
@@ -198,6 +210,7 @@ class RunDb:
 
     return results
 
+  @synchronized(lock)
   def request_task(self, worker_info):
     # Check for blocked user or ip
     if self.userdb.is_blocked(worker_info):
@@ -265,6 +278,7 @@ class RunDb:
 
     return {'run': run, 'task_id': task_id}
 
+  @synchronized(lock)
   def update_task(self, run_id, task_id, stats, nps, spsa):
     run = self.get_run(run_id)
     if task_id >= len(run['tasks']):
@@ -318,6 +332,7 @@ class RunDb:
 
     return {'task_alive': task['active']}
 
+  @synchronized(lock)
   def failed_task(self, run_id, task_id):
     run = self.get_run(run_id)
     if task_id >= len(run['tasks']):
@@ -333,6 +348,7 @@ class RunDb:
 
     return {}
 
+  @synchronized(lock)
   def stop_run(self, run_id):
     run = self.get_run(run_id)
     prune_idx = len(run['tasks'])
@@ -351,6 +367,7 @@ class RunDb:
 
     return {}
 
+  @synchronized(lock)
   def approve_run(self, run_id, approver):
     run = self.get_run(run_id)
     # Can't self approve
@@ -387,6 +404,7 @@ class RunDb:
 
     return value
 
+  @synchronized(lock)
   def request_spsa(self, run_id, task_id):
     run = self.get_run(run_id)
 
@@ -428,7 +446,8 @@ class RunDb:
       })
 
     return result
-
+  
+  @synchronized(lock)
   def update_spsa(self, run, spsa_results):
     spsa = run['args']['spsa']
     if 'clipping' not in spsa:

--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -16,8 +16,9 @@ from views import parse_tc
 import stat_util
 from synchro import synchronized
 
-# reentrant lock for task management
+# reentrant locks for run and task management
 lock = threading.RLock()
+task_lock = threading.RLock()
 
 class RunDb:
   def __init__(self, db_name='fishtest_new'):
@@ -132,7 +133,7 @@ class RunDb:
 
     return self.runs.insert(new_run)
 
-  @synchronized(lock)
+  @synchronized(task_lock)
   def get_machines(self):
     machines = []
     for run in self.runs.find({'tasks': {'$elemMatch': {'active': True}}}):
@@ -278,7 +279,7 @@ class RunDb:
 
     return {'run': run, 'task_id': task_id}
 
-  @synchronized(lock)
+  @synchronized(task_lock)
   def update_task(self, run_id, task_id, stats, nps, spsa):
     run = self.get_run(run_id)
     if task_id >= len(run['tasks']):

--- a/fishtest/fishtest/synchro.py
+++ b/fishtest/fishtest/synchro.py
@@ -1,0 +1,8 @@
+def synchronized(lock):
+    """ Synchronization decorator """
+    def wrap(f):
+        def threadSafeFunction(*args, **kw):
+            with lock:
+                return f(*args, **kw)
+        return threadSafeFunction
+    return wrap


### PR DESCRIPTION
This is work in progress to make fishtest thread safe

Currently the fishtest server has limited capability to handle requests concurrently.
Some requests, especially those resulting in large amounts of network traffic, will cause the server to block for a while. In addition some views show inconsistent data due to concurrent querying/updating of MongoDb data.

With **gunicorn** fishtest can be started with multiple threads, but master is not thread safe.
The current waitress webserver also has threading capability, but appears to synchronize access to the update APIs.

Note that a multiple process setup will not work either, because we need to share the SPRT/SPSA and task state, so a single process with multiple threads is currently the preferred solution.

See https://github.com/glinscott/fishtest/issues/133 for info about gunicorn.

The code changes in this PR are currently being tested.

Focus is on reliability, not on optimal multi threaded efficiency.

Update: almost 100000 game updates in multiple SPSA runs including the mega SPSA  tune_imbalance3 and running an automated CURL stress query on Overview, no problems detected while running the whole day.

If others want to test/review it, I think it's ready.