### PR TITLE
Increase default SPRT game limit to 1000000

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -300,7 +300,7 @@ def validate_form(request):
       'drawelo': 240.0,
     }
     # Arbitrary limit on number of games played.  Shouldn't be hit in practice
-    data['num_games'] = 128000
+    data['num_games'] = 1000000
   elif stop_rule == 'spsa':
     data['num_games'] = int(request.POST['num-games'])
     if data['num_games'] <= 0:


### PR DESCRIPTION
Currently, SPRT tests have a 128000 game limit, meaning that at most 128
workers can be assigned to a test, unless the limit is manually
increased. With the recent increase of fishtest machines, we are hitting
this limit quite often. The 128 chunks can get assigned quickly when the
test has barely started. As a result, some machines become idle.

This patch allows 1000 chunks to be assigned to a test by default.