### PR TITLE
Set max waitress connections to max nr of workers

### DIFF
--- a/fishtest/production.ini
+++ b/fishtest/production.ini
@@ -22,6 +22,8 @@ mako.directories = fishtest:templates
 use = egg:waitress#main
 host = 0.0.0.0
 port = 6543
+# Match connection limit with max number of workers
+connection_limit = 500
 
 ###
 # logging configuration


### PR DESCRIPTION
Waitress default is 100.

If we have 200 workers with 8 cores and TC = 10s+0.1s
then this results in about 160 game result updates per second.

If a few expensive requests like the /tests, api/request_run or
api/request_spsa cause a delay of more then 0.625s then requests
will be dropped because the backlog is > 100 requests

Most of these dropped requests could have been processed quickly
and each worker will never have more than one outstanding request.
In addition default worker timeout is 5s.

Raising max connections from 100 to 500 (300 in original proposal, see comments) does better match
current number of workers.