### PR TITLE
Make update_task synchronous for each active run

### DIFF
--- a/fishtest/production.ini
+++ b/fishtest/production.ini
@@ -24,6 +24,7 @@ host = 0.0.0.0
 port = 6543
 # Match connection limit with max number of workers
 connection_limit = 500
+threads = 8
 
 ###
 # logging configuration


### PR DESCRIPTION
This prevents:

- A slow down due to parallel execution of the stop run and SPSA logic
  which overwrites the computed results of other threads
- Concurrent overwriting saves to the MongoDb
- Stopped runs which display an LLR of <= 2.94 instead of >= 2.95
- Display artifacts in Last Updated time

but still allows concurrent updates by tasks of different runs.

This is important because update_task is the most executed (> 99%) API call.