### PR TITLE
Fix race condition between user action and cache

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -26,7 +26,9 @@ last_time = 0
 
 def clear_cache():
   global last_time
+  building.acquire()
   last_time = 0
+  building.release()
 
 def cached_flash(request, requestString):
   clear_cache()


### PR DESCRIPTION
After user actions like "Approve" the old cache could be shown
if a cache rebuild was in progress during the action.

Fixes https://github.com/glinscott/fishtest/issues/172