### PR TITLE
Fix missing runs from Overview page

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -153,7 +153,8 @@ class RunDb:
     return list(self.get_unfinished_runs()) + self.get_finished_runs()[0]
 
   def get_unfinished_runs(self):
-    return self.runs.find({'finished': False},
+    with self.run_lock:
+      return self.runs.find({'finished': False},
                           sort=[('last_updated', DESCENDING), ('start_time', DESCENDING)])
 
   def get_finished_runs(self, skip=0, limit=0, username='', success_only=False):


### PR DESCRIPTION
This is caused by a MongoDb index combined with a search
which skips some entries while being updated, see:

https://blog.meteor.com/mongodb-queries-dont-always-return-all-matching-documents-654b6594a827

Performance impact should be small because this is only called from the cached Overview page.

Edit: Note that there is still a smaller race condition, because this prevents acquiring new update locks while the overview is building, but updates might be already in flight. So it will reduce the chance but not completely reduce it to 0. Acquiring all run locks looks like overkill.
