### PR TITLE
Fix a race condition on periodic lock cleanup

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -288,13 +288,15 @@ class RunDb:
     with self.run_lock:
       self.purge_count = self.purge_count + 1
       if self.purge_count > 100000:
-        self.active_runs.clear()
+        old = time.time() - 10000
+        self.active_runs = {k: v for k, v in self.active_runs.iteritems() if v['time'] >= old}
         self.purge_count = 0
       if id in self.active_runs:
-        active_lock = self.active_runs[id]
+        active_lock = self.active_runs[id]['lock']
+        self.active_runs[id]['time'] = time.time()
       else:
         active_lock = threading.Lock()
-        self.active_runs[id] = active_lock
+        self.active_runs[id] = { 'time': time.time(), 'lock': active_lock }
       return active_lock
 
   def update_task(self, run_id, task_id, stats, nps, spsa):


### PR DESCRIPTION
Do not erase the dictionary but remove entries
last used over 10000 seconds ago.

This is not critical, but the right way to clean up old entries.