### PR TITLE
Revert "Fix a race condition on periodic lock cleanup"

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -288,15 +288,13 @@ class RunDb:
     with self.run_lock:
       self.purge_count = self.purge_count + 1
       if self.purge_count > 100000:
-        old = time.time() - 10000
-        self.active_runs = {k: v for k, v in self.active_runs.iteritems() if v['time'] >= old}
+        self.active_runs.clear()
         self.purge_count = 0
       if id in self.active_runs:
-        active_lock = self.active_runs[id]['lock']
-        self.active_runs[id]['time'] = time.time()
+        active_lock = self.active_runs[id]
       else:
         active_lock = threading.Lock()
-        self.active_runs[id] = { 'time': time.time(), 'lock': active_lock }
+        self.active_runs[id] = active_lock
       return active_lock
 
   def update_task(self, run_id, task_id, stats, nps, spsa):


### PR DESCRIPTION
Reverts glinscott/fishtest#179

The official server uses python 2.6.6 that does not support this syntax.

```
# Python 2.7 and 3.x
mydict = { k:v for k,v in mydict.items() if k!=val }
# before Python 2.7
mydict = dict((k,v) for k,v in mydict.iteritems() if k!=val)
```