### PR TITLE
Update adapters.py

### DIFF
--- a/worker/requests/adapters.py
+++ b/worker/requests/adapters.py
@@ -26,7 +26,7 @@ from .cookies import extract_cookies_to_jar
 from .exceptions import ConnectionError, Timeout, SSLError
 
 DEFAULT_POOLSIZE = 1
-DEFAULT_RETRIES = 3
+DEFAULT_RETRIES = 0
 
 
 class BaseAdapter(object):

--- a/worker/requests/adapters.py
+++ b/worker/requests/adapters.py
@@ -25,8 +25,8 @@ from .packages.urllib3.exceptions import HTTPError as _HTTPError
 from .cookies import extract_cookies_to_jar
 from .exceptions import ConnectionError, Timeout, SSLError
 
-DEFAULT_POOLSIZE = 10
-DEFAULT_RETRIES = 0
+DEFAULT_POOLSIZE = 1
+DEFAULT_RETRIES = 3
 
 
 class BaseAdapter(object):


### PR DESCRIPTION
1. The client side HTTP connection pool creates unnecessary load on server because when connection pool is not fully occupied, previously created connections are not reused.
2. We are reporting to server single-threaded, meaning that we'd never use more than one connection ever, pooling more than one of them makes no sense.
3. Make use of internal retry mechanism instead of throwing exceptions right away to reduces chances of getting stuck at 0.00.