### PR TITLE
Drop useless instruction in start.sh

### DIFF
--- a/fishtest/start.sh
+++ b/fishtest/start.sh
@@ -1,6 +1,5 @@
 #!/bin/zsh
 
-pkill -f start_fishtest
 pkill -f pserve
 
 cd /home/fishtest/fishtest/fishtest


### PR DESCRIPTION
There is not a start_fishtest process to be killed