### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
 .*
 *~
-fishtest/build
+fishtest/nohup.out
 fishtest/fishtest.egg-info


### PR DESCRIPTION
Delete the build folder, useless after the retirement of the engine build server.
Add the log of the pserve process.