### PR TITLE
Reduce HTTP connection pool size

### DIFF
--- a/worker/requests/adapters.py
+++ b/worker/requests/adapters.py
@@ -25,7 +25,7 @@ from .packages.urllib3.exceptions import HTTPError as _HTTPError
 from .cookies import extract_cookies_to_jar
 from .exceptions import ConnectionError, Timeout, SSLError
 
-DEFAULT_POOLSIZE = 10
+DEFAULT_POOLSIZE = 1
 DEFAULT_RETRIES = 0
 
 


### PR DESCRIPTION
The client side HTTP connection pool creates unnecessary load on server because when connection pool is not fully occupied, previously created connections are not reused.
We are reporting to server single-threaded, meaning that we'd never use more than one connection ever, pooling more than one of them makes no sense.