### PR TITLE
Use cache lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 python:
-  - "2.6"
+  - "2.7"
+services:
+  - mongodb
+before_script:
+  - sleep 5
 # command to run tests
 script: 
-  - cd worker && python setup.py test
+  - (cd worker && python setup.py test) && python setup.py test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pyramid
+bson
+pymongo
+scipy
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+
+from setuptools import setup, find_packages
+
+setup(
+    name = "fishtest",
+    version = "0.1",
+    packages = find_packages(),
+    test_suite = "test_server"
+)

--- a/test_server.py
+++ b/test_server.py
@@ -1,0 +1,34 @@
+import unittest
+import time
+
+from fishtest.fishtest.rundb import RunDb
+
+rundb = None
+run_id = None
+  
+class CreateServerTest(unittest.TestCase):
+
+  def tearDown(self):
+    # Shutdown flush thread:
+    rundb.timer = None
+    time.sleep(2)
+
+  def test_create_run(self):
+    global rundb, run_id
+    rundb= RunDb()
+    run_id = rundb.new_run('master', 'master', 100000, '10+0.01', 'book', 10, 1, '', '')
+    print(' '); print(run_id)
+    run = rundb.get_run(run_id)
+    print(run['tasks'][0])
+    self.assertFalse(run['tasks'][0][u'active'])
+    run['tasks'][0][u'active'] = True
+    
+  def test_update_task(self):
+    r= rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': 997}, 1000000, '')
+    self.assertEqual(r, {'task_alive': True})
+    r= rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': 998}, 1000000, '')
+    self.assertEqual(r, {'task_alive': False})
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
This is a folluwup to

https://github.com/glinscott/fishtest/pull/178

Now that we have a buffer cache we should use that lock
instead of the update_task lock. This should handle
the periodic flush thread and give a small performance boost.

Also add a simple Travis-CI test