### PR TITLE
Make the worker a standalone application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ python:
   - "2.6"
 # command to run tests
 script: 
-  - python setup.py test
+  - cd worker && python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-#!/usr/bin/python
-
-from setuptools import setup, find_packages
-
-setup(
-    name="fishtest",
-    version="0.1",
-    packages=find_packages()
-)

--- a/worker/games.py
+++ b/worker/games.py
@@ -5,7 +5,6 @@ import json
 import os
 import stat
 import random
-import requests
 import subprocess
 import shutil
 import sys
@@ -16,6 +15,7 @@ import traceback
 import platform
 import struct
 import zipfile
+import requests
 from base64 import b64decode
 from zipfile import ZipFile
 

--- a/worker/setup.py
+++ b/worker/setup.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+
+from setuptools import setup, find_packages
+
+setup(
+    name = "fishtest_worker",
+    version = "0.1",
+    packages = find_packages(),
+    test_suite = "test_worker"
+)

--- a/worker/test_worker.py
+++ b/worker/test_worker.py
@@ -1,8 +1,8 @@
 import unittest
 import worker
-import worker.worker
 import os
 import os.path
+import subprocess
 
 class workerTest(unittest.TestCase):
 
@@ -10,9 +10,8 @@ class workerTest(unittest.TestCase):
     if os.path.exists('foo.txt'):
       os.remove('foo.txt')
    
-    
   def test_config_setup(self):      
-    config = worker.worker.setup_config_file('foo.txt')
+    config = worker.setup_config_file('foo.txt')
         
     self.assertTrue(config.has_section('login'))
     self.assertTrue(config.has_section('parameters'))
@@ -21,9 +20,11 @@ class workerTest(unittest.TestCase):
     self.assertTrue(config.has_option('parameters', 'host'))
     self.assertTrue(config.has_option('parameters', 'port'))
     self.assertTrue(config.has_option('parameters', 'concurrency'))
-
-
-    
+        
+  def test_worker_script(self):
+    p = subprocess.Popen(["python" , "worker.py"], stderr = subprocess.PIPE)
+    result = p.stderr.readline()
+    self.assertEqual(result, 'worker.py [username] [password]\n')
 
 if __name__ == "__main__":
   unittest.main()

--- a/worker/updater.py
+++ b/worker/updater.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import os
-import requests
 import shutil
 import sys
 from zipfile import ZipFile


### PR DESCRIPTION
The actual application to be launched should be the fishtest worker.

This version solves locally all issues of https://github.com/glinscott/fishtest/pull/213