### PR TITLE
Add exception handling of download & build process

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -110,31 +110,35 @@ def setup_engine(destination, worker_dir, sha, repo_url, concurrency):
   if os.path.exists(destination): os.remove(destination)
   """Download and build sources in a temporary directory then move exe to destination"""
   tmp_dir = tempfile.mkdtemp()
-  os.chdir(tmp_dir)
+  
+  try:
+    os.chdir(tmp_dir)
+    with open('sf.gz', 'wb+') as f:
+      f.write(requests.get(github_api(repo_url) + '/zipball/' + sha, timeout=HTTP_TIMEOUT).content)
+    zip_file = ZipFile('sf.gz')
+    zip_file.extractall()
+    zip_file.close()
 
-  with open('sf.gz', 'wb+') as f:
-    f.write(requests.get(github_api(repo_url) + '/zipball/' + sha, timeout=HTTP_TIMEOUT).content)
-  zip_file = ZipFile('sf.gz')
-  zip_file.extractall()
-  zip_file.close()
+    for name in zip_file.namelist():
+      if name.endswith('/src/'):
+        src_dir = name
+    os.chdir(src_dir)
 
-  for name in zip_file.namelist():
-    if name.endswith('/src/'):
-      src_dir = name
-  os.chdir(src_dir)
+    custom_make = os.path.join(worker_dir, 'custom_make.txt')
+    if os.path.exists(custom_make):
+      with open(custom_make, 'r') as m:
+        make_cmd = m.read().strip()
+      subprocess.check_call(make_cmd, shell=True)
+    else:
+      subprocess.check_call(MAKE_CMD + ' -j %s' % (concurrency), shell=True)
 
-  custom_make = os.path.join(worker_dir, 'custom_make.txt')
-  if os.path.exists(custom_make):
-    with open(custom_make, 'r') as m:
-      make_cmd = m.read().strip()
-    subprocess.check_call(make_cmd, shell=True)
-  else:
-    subprocess.check_call(MAKE_CMD + ' -j %s' % (concurrency), shell=True)
-
-  shutil.move('stockfish'+ EXE_SUFFIX, destination)
-  os.chdir(worker_dir)
-  shutil.rmtree(tmp_dir)
-
+    shutil.move('stockfish'+ EXE_SUFFIX, destination)
+  except:
+    raise Exception('Failed to setup engine for %s' % (sha))
+  finally:
+    os.chdir(worker_dir)
+    shutil.rmtree(tmp_dir)
+    
 def kill_process(p):
   if IS_WINDOWS:
     # Kill doesn't kill subprocesses on Windows

--- a/worker/test_worker.py
+++ b/worker/test_worker.py
@@ -3,6 +3,7 @@ import worker
 import os
 import os.path
 import subprocess
+import games
 
 class workerTest(unittest.TestCase):
 
@@ -25,6 +26,11 @@ class workerTest(unittest.TestCase):
     p = subprocess.Popen(["python" , "worker.py"], stderr = subprocess.PIPE)
     result = p.stderr.readline()
     self.assertEqual(result, 'worker.py [username] [password]\n')
+
+  def test_setup_exception(self): 
+    cwd = os.getcwd()
+    with self.assertRaises(Exception):
+      games.setup_engine('foo', cwd, 'foo', 'https://foo', 1)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
In case of an exception occurred during the download & build process, add a catch block so that temp directory cleanup is not skipped.

This also gives an opportunity to retry a few times instead of going through the expensive request_task process in case of a recoverable failure.