### PR TITLE
SLightly wider column

### DIFF
--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -42,8 +42,8 @@
           <li><a href="https://github.com/glinscott/fishtest" target="_blank">Github</a></li>
           <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/fishcooking" target="_blank">Forum</a></li>
           <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/fishcooking_results" target="_blank">History</a></li>
-          <li><a href="https://hxim.github.io/Stockfish-Evaluation-Guide/" target="_blank">EvalGuide</a></li>
-	  <li><a href="https://github.com/glinscott/fishtest/wiki/Regression-Tests" target="_blank">Regression</a></li>
+          <li><a href="https://hxim.github.io/Stockfish-Evaluation-Guide/" target="_blank">Eval&shy;Guide</a></li>
+	  <li><a href="https://github.com/glinscott/fishtest/wiki/Regression-Tests" target="_blank">Regres&shy;sion</a></li>
           <li><a href="http://abrok.eu/stockfish/" target="_blank">Compiles</a></li>
           <li><a href="https://github.com/official-stockfish/Stockfish" target="_blank">SF-github</a></li>
           <li class="nav-header">Admin</li>

--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -36,7 +36,7 @@
     <td style="width:2%"><a href="/tests/user/${run['args'].get('username','')}">${run['args'].get('username','')[:2]}</td>
     <td style="width:16%"><a href="/tests/view/${run['_id']}">${run['args']['new_tag'][:23]}</a></td>
     <td style="width:2%">${base.diff_url(run)}</td>
-    <td style="min-width:305px;width:305px"><%include file="elo_results.mak" args="run=run" /></td>
+    <td style="min-width:300px;width:300px"><%include file="elo_results.mak" args="run=run" /></td>
     <td style="width:14%">
     %if 'sprt' in run['args']:
     <a href="http://hardy.uhasselt.be/Toga/live_elo.html?${str(run['_id'])}" target="_blank">sprt</a>

--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -36,7 +36,7 @@
     <td style="width:2%"><a href="/tests/user/${run['args'].get('username','')}">${run['args'].get('username','')[:2]}</td>
     <td style="width:16%"><a href="/tests/view/${run['_id']}">${run['args']['new_tag'][:23]}</a></td>
     <td style="width:2%">${base.diff_url(run)}</td>
-    <td style="min-width:300px;width:300px"><%include file="elo_results.mak" args="run=run" /></td>
+    <td style="min-width:41;width:41"><%include file="elo_results.mak" args="run=run" /></td>
     <td style="width:14%">
     %if 'sprt' in run['args']:
     <a href="http://hardy.uhasselt.be/Toga/live_elo.html?${str(run['_id'])}" target="_blank">sprt</a>

--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -36,7 +36,7 @@
     <td style="width:2%"><a href="/tests/user/${run['args'].get('username','')}">${run['args'].get('username','')[:2]}</td>
     <td style="width:16%"><a href="/tests/view/${run['_id']}">${run['args']['new_tag'][:23]}</a></td>
     <td style="width:2%">${base.diff_url(run)}</td>
-    <td style="min-width:41;width:41"><%include file="elo_results.mak" args="run=run" /></td>
+    <td style="min-width:41em;width:41em"><%include file="elo_results.mak" args="run=run" /></td>
     <td style="width:14%">
     %if 'sprt' in run['args']:
     <a href="http://hardy.uhasselt.be/Toga/live_elo.html?${str(run['_id'])}" target="_blank">sprt</a>

--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -36,7 +36,7 @@
     <td style="width:2%"><a href="/tests/user/${run['args'].get('username','')}">${run['args'].get('username','')[:2]}</td>
     <td style="width:16%"><a href="/tests/view/${run['_id']}">${run['args']['new_tag'][:23]}</a></td>
     <td style="width:2%">${base.diff_url(run)}</td>
-    <td style="min-width:41em;width:41em"><%include file="elo_results.mak" args="run=run" /></td>
+    <td style="min-width:305px;width:305px"><%include file="elo_results.mak" args="run=run" /></td>
     <td style="width:14%">
     %if 'sprt' in run['args']:
     <a href="http://hardy.uhasselt.be/Toga/live_elo.html?${str(run['_id'])}" target="_blank">sprt</a>

--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -36,7 +36,7 @@
     <td style="width:2%"><a href="/tests/user/${run['args'].get('username','')}">${run['args'].get('username','')[:2]}</td>
     <td style="width:16%"><a href="/tests/view/${run['_id']}">${run['args']['new_tag'][:23]}</a></td>
     <td style="width:2%">${base.diff_url(run)}</td>
-    <td style="min-width:285px;width:285px"><%include file="elo_results.mak" args="run=run" /></td>
+    <td style="min-width:305px;width:305px"><%include file="elo_results.mak" args="run=run" /></td>
     <td style="width:14%">
     %if 'sprt' in run['args']:
     <a href="http://hardy.uhasselt.be/Toga/live_elo.html?${str(run['_id'])}" target="_blank">sprt</a>

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -14,7 +14,7 @@ var spsa_history_url = '${run_args[0][1]}/spsa_history';
 <h3>${run['args']['new_tag']} vs ${run['args']['base_tag']} ${base.diff_url(run)}</h3>
 
 <div class="row-fluid">
-<div class="span4">
+<div class="span6">
 <%include file="elo_results.mak" args="run=run" />
 </div>
 </div>


### PR DESCRIPTION
on the main page, colored boxes containing LLR results can overflow if the number of tests exceeds 100000, causing the numbers to be split on two lines.

This patch (unfortunately untested), widens the column by a bit to give space for 2 more digits.

Would need somebody to have a look at the result on the dev server if the result is fine.