### PR TITLE
Add captcha for signup form

### DIFF
--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -23,6 +23,8 @@
   </style>
 
   ${self.head()}
+  
+  <script src='https://www.google.com/recaptcha/api.js'></script>
 </head>
 <body>
   <div class="container-fluid">

--- a/fishtest/fishtest/templates/signup.mak
+++ b/fishtest/fishtest/templates/signup.mak
@@ -36,7 +36,7 @@ If it is not suggested by default you can try right-clicking on the password ent
   </div>
   <div class="control-group">
     <div class="controls">
-      <div class="g-recaptcha" data-sitekey="6LdAiFQUAAAAANhHq-9aMlFW0xuo-xcI8E3faZAg"></div>
+      <div class="g-recaptcha" data-sitekey="6LfYzlQUAAAAAIfrOdH_NNN75XO5Bz-e-bbuHEsn"></div>
     </div>
   </div>
   <div class="control-group">

--- a/fishtest/fishtest/templates/signup.mak
+++ b/fishtest/fishtest/templates/signup.mak
@@ -1,6 +1,7 @@
 <%inherit file="base.mak"/>
 
 <div>
+<p></p>
 <p>
 Note that many modern browsers can generate/remember a strong password for you.
 </p>
@@ -31,6 +32,11 @@ If it is not suggested by default you can try right-clicking on the password ent
     <label class="control-label">E-mail:</label>
     <div class="controls">
       <input name="email" type="email" required="required"/>
+    </div>
+  </div>
+  <div class="control-group">
+    <div class="controls">
+      <div class="g-recaptcha" data-sitekey="6LdAiFQUAAAAANhHq-9aMlFW0xuo-xcI8E3faZAg"></div>
     </div>
   </div>
   <div class="control-group">

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -80,6 +80,18 @@ def signup(request):
       request.session.flash('Email required')
       return {}
 
+    path = os.path.expanduser('~/fishtest.captcha.secret')
+    if os.path.exists(path):
+      with open(path, 'r') as f:
+        secret = f.read()
+        payload = {'secret': secret, 'response': request.params.get('g-recaptcha-response',''), 'remoteip': request.remote_addr}
+        response= requests.post('https://www.google.com/recaptcha/api/siteverify', data=payload).json()
+        if not 'success' in response or not response['success']:
+          if 'error-codes' in response:
+            print(response['error-codes'])
+          request.session.flash('Captcha failed')
+          return {}
+
     result = request.userdb.create_user(
       username= request.params['username'],
       password= request.params['password'],


### PR DESCRIPTION
See: https://www.google.com/recaptcha/admin

Store the secret key in

    ~/fishtest.captcha.secret

Store the public key in

    templates/signup.mak

in the line near the end:

    <div class="g-recaptcha" data-sitekey="PUBLIC-KEY-HERE"></div>

![screenshot_20180421-085541](https://user-images.githubusercontent.com/1104260/39081455-db23b9a4-4541-11e8-9b15-494dfe7820a2.png)

