### PR TITLE
Use old mongodb method to drop users

### DIFF
--- a/fishtest/utils/scavenge.py
+++ b/fishtest/utils/scavenge.py
@@ -37,7 +37,7 @@ def scavenge_users(scavenge=True, days=28):
     for u in get_idle_users(days):
       print(u['username'])
       if scavenge:
-        rundb.userdb.users.delete_one({'username': u['username']})
+        rundb.userdb.users.remove({'_id': u['_id']})
 
 def main():
   scavenge_tasks(scavenge=True)


### PR DESCRIPTION
This fixes scavenge.py for the current MongoDb software in production.

Followup for #246 
