### PR TITLE
Remove print to fix unicode handling

### DIFF
--- a/fishtest/utils/scavenge.py
+++ b/fishtest/utils/scavenge.py
@@ -35,7 +35,6 @@ def get_idle_users(days):
 
 def scavenge_users(scavenge=True, days=28):
     for u in get_idle_users(days):
-      print(u['username'])
       if scavenge:
         rundb.userdb.users.remove({'_id': u['_id']})
 


### PR DESCRIPTION
Print fails on the production server because it cannot handle unicode output