### PR TITLE
Do not POST SPSA parameters from worker

### DIFF
--- a/fishtest/fishtest/api.py
+++ b/fishtest/fishtest/api.py
@@ -96,6 +96,7 @@ def update_task(request):
   if 'error' in token: return json.dumps(token)
 
   result = request.rundb.update_task(
+    worker=request.json_body['unique_key'],
     run_id=request.json_body['run_id'],
     task_id=int(request.json_body['task_id']),
     stats=request.json_body['stats'],
@@ -149,4 +150,4 @@ def request_spsa(request):
   run_id = request.json_body['run_id']
   task_id = int(request.json_body['task_id'])
 
-  return json.dumps(request.rundb.request_spsa(run_id, task_id))
+  return json.dumps(request.rundb.request_spsa(request.json_body['unique_key'], run_id, task_id))

--- a/fishtest/tests/test_rundb.py
+++ b/fishtest/tests/test_rundb.py
@@ -39,11 +39,12 @@ class CreateRunDBTest(unittest.TestCase):
     print(util.find_run()['args'])
     
   def test_20_update_task(self):
-    r= rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': 997, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker2')
+    worker_id = 'travis'
+    r= rundb.update_task(worker_id, run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-3, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker2')
     self.assertEqual(r, {'task_alive': False})
-    r= rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': 997, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
+    r= rundb.update_task(worker_id, run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-3, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
     self.assertEqual(r, {'task_alive': True})
-    r= rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': 998, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
+    r= rundb.update_task(worker_id, run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-2, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
     self.assertEqual(r, {'task_alive': False})
 
   def test_30_finish(self):

--- a/worker/games.py
+++ b/worker/games.py
@@ -238,8 +238,6 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
         spsa['wins'] = wld[0]
         spsa['losses'] = wld[1]
         spsa['draws'] = wld[2]
-        if spsa['num_games'] == spsa['wins'] + spsa['losses'] + spsa['draws']:
-            spsa['w_params'] = w_params
 
       try:
         req = requests.post(remote + '/api/update_task', data=json.dumps(result), headers={'Content-type': 'application/json'}, timeout=HTTP_TIMEOUT).json()
@@ -311,6 +309,7 @@ def launch_cutechess(cmd, remote, result, spsa_tuning, games_to_play, tc_limit):
 def run_games(worker_info, password, remote, run, task_id):
   task = run['tasks'][task_id]
   result = {
+    'unique_key': worker_info['unique_key'],
     'username': worker_info['username'],
     'password': password,
     'run_id': str(run['_id']),


### PR DESCRIPTION
but store them in the fishtest server to reduce network traffic
and significant unmarshalling time for SPSA runs with many parameters.

This reduces #253 significantly and is a followup to #155 

Only drawback is an increase in memory usage of the server, about 50 bytes per SPSA parameter per worker. So 200 workers working on a 500 parameter run adds 5 megabyte to the worker memory usage.