### PR TITLE
Adjust worker timings

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -118,7 +118,7 @@ def setup(item, testing_dir):
         blob_json = blob_request.json()
         if blob_request.status_code == requests.codes.ok:
           break
-        sleep(5)
+        sleep(HTTP_TIMEOUT)
       with open(os.path.join(testing_dir, item), 'wb+') as f:
         f.write(b64decode(blob_json['content']))
       break
@@ -287,7 +287,7 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
           printout('Too many failed update attempts')
           kill_process(p)
           break
-        time.sleep(random.randint(failed_updates*failed_updates, 4 * failed_updates*failed_updates))
+        time.sleep(HTTP_TIMEOUT)
 
   if datetime.datetime.now() >= end_time:
     printout(datetime.datetime.now()+' is past end time '+end_time)

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -60,7 +60,7 @@ def worker(worker_info, password, remote):
 
   try:
     print 'Will fetch task soon...'
-    time.sleep(random.randint(1,30))
+    time.sleep(random.randint(1,10))
     t0 = datetime.utcnow()
     req = requests.post(remote + '/api/request_version', data=json.dumps(payload), headers={'Content-type': 'application/json'}, timeout=HTTP_TIMEOUT)
     req = json.loads(req.text)
@@ -91,7 +91,8 @@ def worker(worker_info, password, remote):
   # No tasks ready for us yet, just wait...
   if 'task_waiting' in req:
     printout('No tasks available at this time, waiting...\n')
-    time.sleep(random.randint(10,60))
+    # Note that after this sleep we have another ALIVE HTTP_TIMEOUT...
+    time.sleep(random.randint(1,10))
     return
 
   success = True
@@ -179,7 +180,7 @@ def main():
   global ALIVE
   while ALIVE:
     if not success:
-      time.sleep(300)
+      time.sleep(HTTP_TIMEOUT)
     success = worker(worker_info, args[1], remote)
 
 if __name__ == '__main__':


### PR DESCRIPTION
With recent changes to smaller chunk sizes and speedups reduce the startup time
to 1-10s from 1-30s for increased efficiency with fast workers.

Also remove the progressive quadratic delay after failed update_task
calls. These made no real sense, because cutechess-cli keeps on playing
while we wait and will be kiled after about 3*TC seconds.