### PR TITLE
Compile in worker subdir.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -128,7 +128,7 @@ def setup(item, testing_dir):
 def setup_engine(destination, worker_dir, sha, repo_url, concurrency):
   if os.path.exists(destination): os.remove(destination)
   """Download and build sources in a temporary directory then move exe to destination"""
-  tmp_dir = tempfile.mkdtemp()
+  tmp_dir = tempfile.mkdtemp(dir=worker_dir)
   
   try:
     os.chdir(tmp_dir)


### PR DESCRIPTION
fixes the cornercase described in issue #125 for those systems where /tmp/ is noexec. Since we anyway need the worker dir to be writable, and exec, we can as well compile there.