### PR TITLE
Unique_key from task + 2 fixes

### DIFF
--- a/fishtest/fishtest/api.py
+++ b/fishtest/fishtest/api.py
@@ -96,7 +96,6 @@ def update_task(request):
   if 'error' in token: return json.dumps(token)
 
   result = request.rundb.update_task(
-    worker=request.json_body['unique_key'],
     run_id=request.json_body['run_id'],
     task_id=int(request.json_body['task_id']),
     stats=request.json_body['stats'],
@@ -150,4 +149,4 @@ def request_spsa(request):
   run_id = request.json_body['run_id']
   task_id = int(request.json_body['task_id'])
 
-  return json.dumps(request.rundb.request_spsa(request.json_body['unique_key'], run_id, task_id))
+  return json.dumps(request.rundb.request_spsa(run_id, task_id))

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -646,6 +646,8 @@ def format_results(run_results, run):
   return result
 
 UUID_MAP = defaultdict(dict)
+key_lock = threading.Lock()
+
 def get_worker_key(task):
   global UUID_MAP
 
@@ -655,9 +657,10 @@ def get_worker_key(task):
   cores = str(task['worker_info']['concurrency'])
 
   uuid = task['worker_info'].get('unique_key', '')
-  if uuid not in UUID_MAP[username]:
-    next_idx = len(UUID_MAP[username])
-    UUID_MAP[username][uuid] = next_idx
+  with key_lock:
+    if uuid not in UUID_MAP[username]:
+      next_idx = len(UUID_MAP[username])
+      UUID_MAP[username][uuid] = next_idx
 
   worker_key = '%s-%scores' % (username, cores)
   suffix = UUID_MAP[username][uuid]

--- a/fishtest/tests/test_rundb.py
+++ b/fishtest/tests/test_rundb.py
@@ -34,17 +34,16 @@ class CreateRunDBTest(unittest.TestCase):
     print(run['tasks'][0])
     self.assertFalse(run['tasks'][0][u'active'])
     run['tasks'][0][u'active'] = True
-    run['tasks'][0][u'worker_info'] = {'username': 'worker1'}
+    run['tasks'][0][u'worker_info'] = {'username': 'worker1', 'unique_key': 'travis'}
     
     print(util.find_run()['args'])
     
   def test_20_update_task(self):
-    worker_id = 'travis'
-    r= rundb.update_task(worker_id, run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-3, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker2')
+    r= rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-3, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker2')
     self.assertEqual(r, {'task_alive': False})
-    r= rundb.update_task(worker_id, run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-3, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
+    r= rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-3, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
     self.assertEqual(r, {'task_alive': True})
-    r= rundb.update_task(worker_id, run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-2, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
+    r= rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-2, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
     self.assertEqual(r, {'task_alive': False})
 
   def test_30_finish(self):

--- a/worker/games.py
+++ b/worker/games.py
@@ -290,7 +290,7 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
         time.sleep(random.randint(failed_updates*failed_updates, 4 * failed_updates*failed_updates))
 
   if datetime.datetime.now() >= end_time:
-    printout(datetime.datetime.now()+' is past end time '+end_time)
+    printout(str(datetime.datetime.now())+' is past end time '+str(end_time))
     kill_process(p)
 
   return { 'task_alive': True }
@@ -339,7 +339,6 @@ def launch_cutechess(cmd, remote, result, spsa_tuning, games_to_play, tc_limit):
 def run_games(worker_info, password, remote, run, task_id):
   task = run['tasks'][task_id]
   result = {
-    'unique_key': worker_info['unique_key'],
     'username': worker_info['username'],
     'password': password,
     'run_id': str(run['_id']),


### PR DESCRIPTION
A small optimization for #261 

In addition add a lock to get_worker_key() because it has a race condition.

Fix print issue introduced in #162

8a2da7b