### PR TITLE
Fix SPSA games end time calculation

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -453,6 +453,7 @@ def run_games(worker_info, password, remote, run, task_id):
 
   if spsa_tuning:
     games_to_play = games_concurrency * 2
+    tc_limit *= 2
     pgnout = []
   else:
     games_to_play = games_remaining


### PR DESCRIPTION
This caused premature worker exits