### PR TITLE
Raise worker version number to 64

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -16,7 +16,7 @@ from games import run_games
 from updater import update
 from datetime import datetime
 
-WORKER_VERSION = 63
+WORKER_VERSION = 64
 ALIVE = True
 
 HTTP_TIMEOUT = 15.0


### PR DESCRIPTION
Raise the worker version number to 64.
The server version number will be raised next week, view:
https://github.com/glinscott/fishtest/pull/267