### PR TITLE
Flush pserve buffered output

### DIFF
--- a/fishtest/start.sh
+++ b/fishtest/start.sh
@@ -1,6 +1,6 @@
-#!/bin/zsh
+#!/bin/sh
 
 pkill -f pserve
 
 cd /home/fishtest/fishtest/fishtest
-nohup pserve --monitor-restart production.ini >nohup.out &
+nohup stdbuf -oL pserve --monitor-restart production.ini >nohup.out &


### PR DESCRIPTION
pserve log is always empty.
Flush the pserve buffered output according
this [stackoverflow post](https://stackoverflow.com/questions/25674613/python-nohup-out-dont-show-print-statement)

While here use /bin/sh for better generality.