### PR TITLE
Implement PGN upload/download and database clone

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -65,6 +65,9 @@ def main(global_config, **settings):
   config.add_route('api_request_spsa', '/api/request_spsa')
   config.add_route('api_active_runs', '/api/active_runs')
   config.add_route('api_get_run', '/api/get_run/{id}')
+  config.add_route('api_upload_pgn', '/api/upload_pgn')
+  config.add_route('api_download_pgn', '/api/pgn/{id}')
+  config.add_route('api_download_pgn_100', '/api/pgn_100/{skip}')
 
   config.scan()
   return config.make_wsgi_app()

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -172,7 +172,11 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
       active_style = ''
   %>
   <tr class="${active_style}">
-   <td>${idx}</td>
+   %if int(str(task['worker_info']['version']).split(':')[0]) > 64:
+     <td><a href="/api/pgn/${'%s-%d'%(run['_id'],idx)}.pgn">${idx}</a></td>
+   %else:
+     <td>${idx}</td>
+   %endif
    %if approver:
      <td><a href="/user/${task['worker_info']['username']}">${task['worker_key']}</a></td>
    %else:
@@ -189,7 +193,7 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
 
    %if 'spsa' not in run['args']:
    <td style="background-color:${task['residual_color']}">${'%.3f' % (task['residual'])}</td>
-	 %endif
+   %endif
   </tr>
   %endfor
  </tbody>

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -172,7 +172,7 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
       active_style = ''
   %>
   <tr class="${active_style}">
-   %if int(str(task['worker_info']['version']).split(':')[0]) > 64:
+   %if int(str(task['worker_info']['version']).split(':')[0]) > 65:
      <td><a href="/api/pgn/${'%s-%d'%(run['_id'],idx)}.pgn">${idx}</a></td>
    %else:
      <td>${idx}</td>

--- a/fishtest/utils/clone_fish.py
+++ b/fishtest/utils/clone_fish.py
@@ -1,0 +1,58 @@
+import requests
+import bz2
+
+from pymongo import MongoClient, ASCENDING, DESCENDING
+from bson.binary import Binary
+
+#fish_host = 'http://localhost:6543'
+fish_host =  'http://94.198.98.239' # 'http://tests.stockfishchess.org'
+
+conn = MongoClient('localhost')
+
+#conn.drop_database('fish_clone')
+
+db = conn['fish_clone']
+
+pgndb = db['pgns']
+runs = db['runs']
+
+pgndb.ensure_index([('run_id', ASCENDING)])
+
+def main():
+  """clone a fishtest database with PGNs and runs with the REST API"""
+  
+  skip = 0
+  count = 0
+  in_sync = False
+  loaded = {}
+  while True:
+    pgn_list = requests.get(fish_host + '/api/pgn_100/' + str(skip)).json()
+    for pgn_file in pgn_list:
+      print(pgn_file)
+      if pgndb.find_one({'run_id': pgn_file}):
+        print('Already copied: %s' % (pgn_file))
+        if not pgn_file in loaded:
+          in_sync = True
+          break
+      else:
+        run_id = pgn_file.split('-')[0]
+        if not runs.find_one({'_id': run_id}):
+          print('New run: ' + run_id)
+          run = requests.get(fish_host + '/api/get_run/' + run_id).json()
+          runs.insert(run)
+        pgn = requests.get(fish_host + '/api/pgn/' + pgn_file)
+        pgndb.insert(dict(pgn_bz2=Binary(bz2.compress(pgn.content)), run_id= pgn_file))
+        loaded[pgn_file] = True
+        count += 1
+    skip += len(pgn_list)
+    if in_sync or len(pgn_list) < 100:
+      break
+
+  print('Copied:  %6d PGN files (~ %8d games)' % (count, 250 * count))
+  count = pgndb.count()
+  print('Database:%6d PGN files (~ %8d games)' % (count, 250 * count))
+  count = runs.count()
+  print('Database:%6d runs' % (count))
+  
+if __name__ == '__main__':
+  main()

--- a/fishtest/utils/create_pgndb.py
+++ b/fishtest/utils/create_pgndb.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from pymongo import MongoClient, ASCENDING, DESCENDING
+
+conn = MongoClient('localhost')
+
+db = conn['fishtest_new']
+
+db.drop_collection('pgns')
+
+db.create_collection('pgns', capped=True, size=50000)

--- a/fishtest/utils/index_pending.py
+++ b/fishtest/utils/index_pending.py
@@ -21,7 +21,7 @@ db_name='fishtest_new'
 conn = MongoClient(os.getenv('FISHTEST_HOST') or 'localhost')
 db = conn[db_name]
 runs = db['runs']
-
+pgns = db['pgns']
 
 
 def printout(s):
@@ -30,8 +30,11 @@ def printout(s):
 
 
 # create indexes:
-printout("Creating index ...")
-runs.create_index([('tasks.pending', ASCENDING)])
+#printout("Creating index ...")
+#runs.create_index([('tasks.pending', ASCENDING)])
+
+printout("Creating pgn index ...")
+pgns.ensure_index([('run_id', ASCENDING)])
 
 # IF INDEX NEEDS TO BE DROPPED, COMMENT OUT ABOVE 2 LINES, AND UNCOMMENT NEXT 2:
 # printout("\nDropping index ...")
@@ -41,3 +44,4 @@ runs.create_index([('tasks.pending', ASCENDING)])
 # display current list of indexes
 printout("\nCurrent Indexes:")
 pprint.pprint(runs.index_information(), stream=None, indent=1, width=80, depth=None)
+pprint.pprint(pgns.index_information(), stream=None, indent=1, width=80, depth=None)

--- a/fishtest/utils/purge_pgn.py
+++ b/fishtest/utils/purge_pgn.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+from __future__ import print_function
+
+import os, sys
+import re
+from datetime import datetime, timedelta
+
+from fishtest.rundb import RunDb
+
+rundb = RunDb()
+
+def purge_pgn(days):
+  """Purge old PGNs except LTC (>= 20s) runs"""
+  
+  deleted_runs = 0
+  deleted_tasks = 0
+  saved_runs = 0
+  saved_tasks = 0
+  
+  run_count = 0
+  for run in rundb.runs.find({'finished': True, 'deleted': {'$exists': False}}):
+    
+    run_count += 1
+    if run_count % 10 == 0:
+      print('Run: %05d' % (run_count), end='\r')
+    
+    skip = False
+    if    (re.match('^([2-9][0-9])|(1[0-9][0-9])', run['args']['tc']) \
+       and run['last_updated'] > datetime.utcnow() - timedelta(days=20*days)) \
+       or run['last_updated'] > datetime.utcnow() - timedelta(days=days):
+      saved_runs += 1
+      skip = True
+    else:
+      deleted_runs += 1
+
+    for idx, task in enumerate(run['tasks']):
+      key = str(run['_id']) + '-' + str(idx)
+      for pgn in rundb.pgndb.find({'run_id': key}): # We can have multiple PGNs per task
+        if skip:
+          saved_tasks += 1
+        else:
+          rundb.pgndb.remove({'_id': pgn['_id']})
+          deleted_tasks += 1
+  
+  print('PGN runs/tasks saved:  %5d/%7d' % (saved_runs, saved_tasks))
+  print('PGN runs/tasks purged: %5d/%7d' % (deleted_runs, deleted_tasks)) 
+
+def main():
+  purge_pgn(days=8)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
See #140 

PGN-files are stored gzip compressed in a new MongoDb collection ('pgns') with as only additional attribute the creating run_id-task_id.

Currently only a minimal API to retrieve the PGNs and a link in the task list.

About 200 kbyte compressed storage for a 250 game task (compression to 25% original size).

Also add a simple clone script which uses the REST APIs to make a copy of the run and PGN data in a fishtest database.