### PR TITLE
Drop /bin/zsh and use /bin/sh

### DIFF
--- a/fishtest/start_dev.sh
+++ b/fishtest/start_dev.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/sh
 
-#nohup pserve development.ini --reload >nohup.out 2>&1 &
+#nohup stdbuf -oL pserve development.ini --reload >nohup.out 2>&1 &
 pserve development.ini --reload

--- a/fishtest/utils/backup.sh
+++ b/fishtest/utils/backup.sh
@@ -1,6 +1,4 @@
-#!/bin/zsh
-
-source ~/.zshrc
+#!/bin/sh
 
 cd ~/backup
 ~/mongodb/bin/mongodump


### PR DESCRIPTION
Use /bin/sh in scripts to simplify the server requirements.

Add the line buffering for the nohup output in the commented out instruction.