### PR TITLE
Keep the zipped MongoDB dump

### DIFF
--- a/fishtest/utils/backup.sh
+++ b/fishtest/utils/backup.sh
@@ -1,13 +1,17 @@
 #!/bin/sh
 
+# Load the AWS variables when scheduled with cron
+source ~/.bashrc
+
 cd ~/backup
-~/mongodb/bin/mongodump
-rm -f dump.tar.gz
-tar cvzf dump.tar.gz dump
+~/mongodb/bin/mongodump && \
+rm -f dump.tar.gz && \
+tar -czvf dump.tar.gz dump && \
+rm -rf dump
 
 DAY=$(date +%Y%m%d --utc -d '1 hour')
 mkdir -p archive/$DAY
 mv dump.tar.gz archive/$DAY
 s3put -b fishtest -p /home/fishtest/ archive/$DAY/dump.tar.gz
-# Don't keep the archives locally, we've filled the HD up multiple times
-rm archive/$DAY/dump.tar.gz
+# Keep only the latest archive locally, we've filled the HD up multiple times
+mv archive/$DAY/dump.tar.gz .


### PR DESCRIPTION
The size of the DB is increasead, so keep locally a zipped copy of
the MongoDB dump in order to have more free HD space for the server maintenance.
This speed up also the copy of the DB on the development server.