### PR TITLE
Delete the pgns collection from the backup

### DIFF
--- a/fishtest/utils/backup.sh
+++ b/fishtest/utils/backup.sh
@@ -6,6 +6,7 @@ source ~/.bashrc
 cd ~/backup
 ~/mongodb/bin/mongodump && \
 rm -f dump.tar.gz && \
+rm -f dump/fishtest_new/pgns.* && \
 tar -czvf dump.tar.gz dump && \
 rm -rf dump
 


### PR DESCRIPTION
The pgns collection has a big size.
This can trigger:
* the bandwidth limit of the production server
* the size limit of the boto package used to upload to s3