### PR TITLE
Introduce Extra Statistics for the Worker

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -268,21 +268,21 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
         if 'White' in line:
           if 'adjudication' in line:
             result['losses']['loss_a'] += 1
-            if 'mated' in line:
-              result['wins']['win_m'] += 1
-            if 'time' in line:
-              result['wins']['win_t'] += 1
-            if 'illegal' in line:
-              result['wins']['win_i'] += 1
+          if 'mated' in line:
+            result['wins']['win_m'] += 1
+          if 'time' in line:
+            result['wins']['win_t'] += 1
+          if 'illegal' in line:
+            result['wins']['win_i'] += 1
         if 'Black' in line:
-            if 'adjudication' in line:
-              result['wins']['win_a'] += 1
-            if 'mated' in line:
-              result['losses']['loss_m'] += 1
-            if 'time' in line:
-              result['losses']['loss_t'] += 1
-            if 'illegal' in line:
-              result['losses']['loss_i'] += 1
+          if 'adjudication' in line:
+            result['wins']['win_a'] += 1
+          if 'mated' in line:
+            result['losses']['loss_m'] += 1
+          if 'time' in line:
+            result['losses']['loss_t'] += 1
+          if 'illegal' in line:
+            result['losses']['loss_i'] += 1
     
     # Parse line like this (draws):
     # Finished game 73 (stockfish vs base): 1/2-1/2 {Draw by adjudication}

--- a/worker/games.py
+++ b/worker/games.py
@@ -16,9 +16,10 @@ import traceback
 import platform
 import struct
 import requests
-import worker_stats
 from base64 import b64decode
 from zipfile import ZipFile
+from worker_stats import worker_stats
+from worker_stats import print_details
 
 try:
   from Queue import Queue, Empty

--- a/worker/games.py
+++ b/worker/games.py
@@ -18,8 +18,7 @@ import struct
 import requests
 from base64 import b64decode
 from zipfile import ZipFile
-from worker_stats import worker_stats
-from worker_stats import print_details
+from worker_stats import *
 
 try:
   from Queue import Queue, Empty

--- a/worker/games.py
+++ b/worker/games.py
@@ -16,9 +16,9 @@ import traceback
 import platform
 import struct
 import requests
+import worker_stats
 from base64 import b64decode
 from zipfile import ZipFile
-import worker_stats
 
 try:
   from Queue import Queue, Empty
@@ -242,7 +242,7 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
     if 'on time' in line:
       result['stats']['time_losses'] += 1
 
-    # Generate extra statistics
+    # Generate extra statistics on W/L/D
     if 'Finished' in line:
       worker_stats(result, line)
 
@@ -265,6 +265,7 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
         t0 = datetime.datetime.utcnow()
         req = requests.post(remote + '/api/update_task', data=json.dumps(result), headers={'Content-type': 'application/json'}, timeout=HTTP_TIMEOUT).json()
         failed_updates = 0
+        # Print details from worker_statistics to output
         print_details(result)
         print("Task updated successfully in %ss" % ((datetime.datetime.utcnow() - t0).total_seconds()))
 

--- a/worker/games.py
+++ b/worker/games.py
@@ -240,7 +240,7 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
 
     if 'on time' in line:
       result['stats']['time_losses'] += 1
-
+    
     # Parse line like this (wins and losses):
     # Finished game 35 (New-1fd2593 vs Base-3d6995e): 0-1 {Black wins by adjudication}
     if 'White' or 'Black' in line:
@@ -300,7 +300,7 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
             result['draws']['draw_f'] += 1
         if 'Draw by stalemate' in segm:
             result['draws']['draw_s'] += 1
-    
+            
     # Parse line like this:
     # Score of stockfish vs base: 0 - 0 - 1  [0.500] 1
     if 'Score' in line:
@@ -449,7 +449,11 @@ def run_games(worker_info, password, remote, run, task_id):
   if len(engines) > 25:
     engines.sort(key=os.path.getmtime)
     for old_engine in engines[:len(engines)-25]:
-      os.remove(old_engine)
+      try:
+         os.remove(old_engine)
+      except:
+         print('Note: failed to remove an old engine binary ' + str(old_engine))
+         pass
 
   # create new engines
   sha_new = run['args']['resolved_new']

--- a/worker/games.py
+++ b/worker/games.py
@@ -244,45 +244,45 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
     # Parse line like this (wins and losses):
     # Finished game 35 (New-1fd2593 vs Base-3d6995e): 0-1 {Black wins by adjudication}
     if 'White' or 'Black' in line:
-    w_segm = line.split('vs')
-    if 'New' in w_segm[0]:
+      w_segm = line.split('vs')
+      if 'New' in w_segm[0]:
         if 'White' in line:
-            if 'adjudication' in line:
-                result['wins']['win_a'] += 1
+          if 'adjudication' in line:
+            result['wins']['win_a'] += 1
+          if 'mated' in line:
+            result['losses']['loss_m'] += 1
+          if 'time' in line:
+            result['losses']['loss_t'] += 1
+          if 'illegal' in line:
+            result['losses']['loss_i'] += 1
+        if 'Black' in line:
+          if 'adjudication' in line:
+            result['losses']['loss_a'] += 1
+          if 'mated' in line:
+            result['wins']['win_m'] += 1
+          if 'time' in line:
+            result['wins']['win_t'] += 1
+          if 'illegal' in line:
+            result['wins']['win_i'] += 1
+      if 'Base' in w_segm[0]:
+        if 'White' in line:
+          if 'adjudication' in line:
+            result['losses']['loss_a'] += 1
             if 'mated' in line:
-                result['losses']['loss_m'] += 1
+              result['wins']['win_m'] += 1
             if 'time' in line:
-                result['losses']['loss_t'] += 1
+              result['wins']['win_t'] += 1
             if 'illegal' in line:
-                result['losses']['loss_i'] += 1
+              result['wins']['win_i'] += 1
         if 'Black' in line:
             if 'adjudication' in line:
-                result['losses']['loss_a'] += 1
+              result['wins']['win_a'] += 1
             if 'mated' in line:
-                result['wins']['win_m'] += 1
+              result['losses']['loss_m'] += 1
             if 'time' in line:
-                result['wins']['win_t'] += 1
+              result['losses']['loss_t'] += 1
             if 'illegal' in line:
-                result['wins']['win_i'] += 1
-    if 'Base' in w_segm[0]:
-        if 'White' in line:
-            if 'adjudication' in line:
-                result['losses']['loss_a'] += 1
-            if 'mated' in line:
-                result['wins']['win_m'] += 1
-            if 'time' in line:
-                result['wins']['win_t'] += 1
-            if 'illegal' in line:
-                result['wins']['win_i'] += 1
-        if 'Black' in line:
-            if 'adjudication' in line:
-                result['wins']['win_a'] += 1
-            if 'mated' in line:
-                result['losses']['loss_m'] += 1
-            if 'time' in line:
-                result['losses']['loss_t'] += 1
-            if 'illegal' in line:
-                result['losses']['loss_i'] += 1
+              result['losses']['loss_i'] += 1
     
     # Parse line like this (draws):
     # Finished game 73 (stockfish vs base): 1/2-1/2 {Draw by adjudication}

--- a/worker/games.py
+++ b/worker/games.py
@@ -242,6 +242,24 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
       result['stats']['time_losses'] += 1
 
     # Parse line like this:
+    # Finished game 73 (stockfish vs base): 1/2-1/2 {Draw by adjudication}
+    if 'Finished' in line:
+        segm = line.split('{')
+        segm = segm[1]
+        segm = segm[:-1]
+        if 'Draw by adjudication' in segm:
+            result['details']['draw_a'] += 1
+        if 'Draw by 3-fold repetition' in segm:
+            result['details']['draw_r'] += 1
+        if 'Draw by insufficient mating material' in segm:
+            result['details']['draw_i'] += 1
+        if 'Draw by fifty moves rule' in segm:
+            result['details']['draw_f'] += 1
+        if 'Draw by stalemate' in segm:
+            result['details']['draw_s'] += 1
+        print('D: a={0} r={1} i={2} f={3} s={4}'.format(repr(result['details']['draw_a']), repr(result['details']['draw_r']), repr(result['details']['draw_i']), repr(result['details']['draw_f']), repr(result['details']['draw_s'])))
+    
+    # Parse line like this:
     # Score of stockfish vs base: 0 - 0 - 1  [0.500] 1
     if 'Score' in line:
       chunks = line.split(':')
@@ -336,6 +354,7 @@ def run_games(worker_info, password, remote, run, task_id):
     'run_id': str(run['_id']),
     'task_id': task_id,
     'stats': {'wins':0, 'losses':0, 'draws':0, 'crashes':0, 'time_losses':0},
+    'details': {'draw_a':0, 'draw_r':0, 'draw_i':0, 'draw_f':0, 'draw_s':0}
   }
 
   # Have we run any games on this task yet?

--- a/worker/games.py
+++ b/worker/games.py
@@ -324,6 +324,7 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
         print('L: a={0} m={1} t={2} i={3}'.format(repr(result['losses']['loss_a']), repr(result['losses']['loss_m']), repr(result['losses']['loss_t']), repr(result['losses']['loss_i'])))
         print('D: a={0} r={1} i={2} f={3} s={4}'.format(repr(result['draws']['draw_a']), repr(result['draws']['draw_r']), repr(result['draws']['draw_i']), repr(result['draws']['draw_f']), repr(result['draws']['draw_s'])))
         print("Task updated successfully in %ss" % ((datetime.datetime.utcnow() - t0).total_seconds()))
+        print(' ')
 
         if not req['task_alive']:
           # This task is no longer neccesary

--- a/worker/games.py
+++ b/worker/games.py
@@ -344,8 +344,9 @@ def run_games(worker_info, password, remote, run, task_id):
     'task_id': task_id,
     'stats': {'wins':0, 'losses':0, 'draws':0, 'crashes':0, 'time_losses':0},
     'details': {'draw_a':0, 'draw_r':0, 'draw_i':0, 'draw_f':0, 'draw_s':0,
-                'win_a':0, 'win_m':0, 'win_t':0, 'win_i':0,
-                'loss_a':0, 'loss_m':0, 'loss_t':0, 'loss_i':0}
+                'win_a':0, 'win_m':0, 'win_t':0, 'win_i':0, 'win_c':0,
+                'loss_a':0, 'loss_m':0, 'loss_t':0, 'loss_i':0, 'loss_c':0,
+                'win_white':0, 'win_black':0, 'loss_white':0, 'loss_black':0,}
   }
 
   # Have we run any games on this task yet?

--- a/worker/games.py
+++ b/worker/games.py
@@ -241,23 +241,65 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
     if 'on time' in line:
       result['stats']['time_losses'] += 1
 
-    # Parse line like this:
+    # Parse line like this (wins and losses):
+    # Finished game 35 (New-1fd2593 vs Base-3d6995e): 0-1 {Black wins by adjudication}
+    if 'White' or 'Black' in line:
+    w_segm = line.split('vs')
+    if 'New' in w_segm[0]:
+        if 'White' in line:
+            if 'adjudication' in line:
+                result['wins']['win_a'] += 1
+            if 'mated' in line:
+                result['losses']['loss_m'] += 1
+            if 'time' in line:
+                result['losses']['loss_t'] += 1
+            if 'illegal' in line:
+                result['losses']['loss_i'] += 1
+        if 'Black' in line:
+            if 'adjudication' in line:
+                result['losses']['loss_a'] += 1
+            if 'mated' in line:
+                result['wins']['win_m'] += 1
+            if 'time' in line:
+                result['wins']['win_t'] += 1
+            if 'illegal' in line:
+                result['wins']['win_i'] += 1
+    if 'Base' in w_segm[0]:
+        if 'White' in line:
+            if 'adjudication' in line:
+                result['losses']['loss_a'] += 1
+            if 'mated' in line:
+                result['wins']['win_m'] += 1
+            if 'time' in line:
+                result['wins']['win_t'] += 1
+            if 'illegal' in line:
+                result['wins']['win_i'] += 1
+        if 'Black' in line:
+            if 'adjudication' in line:
+                result['wins']['win_a'] += 1
+            if 'mated' in line:
+                result['losses']['loss_m'] += 1
+            if 'time' in line:
+                result['losses']['loss_t'] += 1
+            if 'illegal' in line:
+                result['losses']['loss_i'] += 1
+    
+    # Parse line like this (draws):
     # Finished game 73 (stockfish vs base): 1/2-1/2 {Draw by adjudication}
     if 'Finished' in line:
         segm = line.split('{')
         segm = segm[1]
         segm = segm[:-1]
         if 'Draw by adjudication' in segm:
-            result['details']['draw_a'] += 1
+            result['draws']['draw_a'] += 1
         if 'Draw by 3-fold repetition' in segm:
-            result['details']['draw_r'] += 1
+            result['draws']['draw_r'] += 1
         if 'Draw by insufficient mating material' in segm:
-            result['details']['draw_i'] += 1
+            result['draws']['draw_i'] += 1
         if 'Draw by fifty moves rule' in segm:
-            result['details']['draw_f'] += 1
+            result['draws']['draw_f'] += 1
         if 'Draw by stalemate' in segm:
-            result['details']['draw_s'] += 1
-        print('D: a={0} r={1} i={2} f={3} s={4}'.format(repr(result['details']['draw_a']), repr(result['details']['draw_r']), repr(result['details']['draw_i']), repr(result['details']['draw_f']), repr(result['details']['draw_s'])))
+            result['draws']['draw_s'] += 1
     
     # Parse line like this:
     # Score of stockfish vs base: 0 - 0 - 1  [0.500] 1
@@ -278,6 +320,9 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
         t0 = datetime.datetime.utcnow()
         req = requests.post(remote + '/api/update_task', data=json.dumps(result), headers={'Content-type': 'application/json'}, timeout=HTTP_TIMEOUT).json()
         failed_updates = 0
+        print('W: a={0} m={1} t={2} i={3}'.format(repr(result['wins']['win_a']), repr(result['wins']['win_m']), repr(result['wins']['win_t']), repr(result['wins']['win_i'])))
+        print('L: a={0} m={1} t={2} i={3}'.format(repr(result['losses']['loss_a']), repr(result['losses']['loss_m']), repr(result['losses']['loss_t']), repr(result['losses']['loss_i'])))
+        print('D: a={0} r={1} i={2} f={3} s={4}'.format(repr(result['draws']['draw_a']), repr(result['draws']['draw_r']), repr(result['draws']['draw_i']), repr(result['draws']['draw_f']), repr(result['draws']['draw_s'])))
         print("Task updated successfully in %ss" % ((datetime.datetime.utcnow() - t0).total_seconds()))
 
         if not req['task_alive']:
@@ -354,7 +399,9 @@ def run_games(worker_info, password, remote, run, task_id):
     'run_id': str(run['_id']),
     'task_id': task_id,
     'stats': {'wins':0, 'losses':0, 'draws':0, 'crashes':0, 'time_losses':0},
-    'details': {'draw_a':0, 'draw_r':0, 'draw_i':0, 'draw_f':0, 'draw_s':0}
+    'draws': {'draw_a':0, 'draw_r':0, 'draw_i':0, 'draw_f':0, 'draw_s':0},
+    'wins': {'win_a':0, 'win_m':0, 'win_t':0, 'win_i':0},
+    'losses': {'loss_a':0, 'loss_m':0, 'loss_t':0, 'loss_i':0}
   }
 
   # Have we run any games on this task yet?

--- a/worker/worker_stats.py
+++ b/worker/worker_stats.py
@@ -1,0 +1,72 @@
+def worker_stats(result, line):
+    # Parse line like this (wins and losses):
+    # Finished game 35 (New-1fd2593 vs Base-3d6995e): 0-1 {Black wins by adjudication}
+    if 'White' or 'Black' in line:
+        w_segm = line.split('vs')
+        if 'New' in w_segm[0]:
+            if 'White' in line:
+                if 'adjudication' in line:
+                    result['details']['win_a'] += 1
+                if 'mated' in line:
+                    result['details']['loss_m'] += 1
+                if 'time' in line:
+                    result['details']['loss_t'] += 1
+                if 'illegal' in line:
+                    result['details']['loss_i'] += 1
+            if 'Black' in line:
+                if 'adjudication' in line:
+                    result['details']['loss_a'] += 1
+                if 'mated' in line:
+                    result['details']['win_m'] += 1
+                if 'time' in line:
+                    result['details']['win_t'] += 1
+                if 'illegal' in line:
+                    result['details']['win_i'] += 1
+        if 'Base' in w_segm[0]:
+            if 'White' in line:
+                if 'adjudication' in line:
+                    result['details']['loss_a'] += 1
+                if 'mated' in line:
+                    result['details']['win_m'] += 1
+                if 'time' in line:
+                    result['details']['win_t'] += 1
+                if 'illegal' in line:
+                    result['details']['win_i'] += 1
+            if 'Black' in line:
+                if 'adjudication' in line:
+                    result['details']['win_a'] += 1
+                if 'mated' in line:
+                    result['details']['loss_m'] += 1
+                if 'time' in line:
+                    result['details']['loss_t'] += 1
+                if 'illegal' in line:
+                    result['details']['loss_i'] += 1
+
+    # Parse line like this (draws):
+    # Finished game 73 (stockfish vs base): 1/2-1/2 {Draw by adjudication}
+    if 'Finished' in line:
+        segm = line.split('{')
+        segm = segm[1]
+        segm = segm[:-1]
+        if 'Draw by adjudication' in segm:
+            result['details']['draw_a'] += 1
+        if 'Draw by 3-fold repetition' in segm:
+            result['details']['draw_r'] += 1
+        if 'Draw by insufficient mating material' in segm:
+            result['details']['draw_i'] += 1
+        if 'Draw by fifty moves rule' in segm:
+            result['details']['draw_f'] += 1
+        if 'Draw by stalemate' in segm:
+            result['details']['draw_s'] += 1
+
+def print_details(result):
+    total_w = result['details']['win_a'] + result['details']['win_m'] + result['details']['win_t'] + result['details']['win_i']
+    total_l = result['details']['loss_a'] + result['details']['loss_m'] + result['details']['loss_t'] + result['details']['loss_i']
+    total_d = result['details']['draw_a'] + result['details']['draw_r'] + result['details']['draw_i'] + result['details']['draw_f'] + result['details']['draw_s']
+    total_wld = total_w + total_l + total_d
+    
+    # Print result to output
+    if total_wld > 0:
+        print('W[{0}%]: a={1} m={2} t={3} i={4}'.format("%.1f" % ((float(total_w) / total_wld)*100), result['details']['win_a'], result['details']['win_m'], result['details']['win_t'], result['details']['win_i']))
+        print('L[{0}%]: a={1} m={2} t={3} i={4}'.format("%.1f" % ((float(total_l) / total_wld)*100), result['details']['loss_a'], result['details']['loss_m'], result['details']['loss_t'], result['details']['loss_i']))
+        print('D[{0}%]: a={1} r={2} i={3} f={4} s={5}'.format("%.1f" % ((float(total_d) / total_wld)*100), result['details']['draw_a'], result['details']['draw_r'], result['details']['draw_i'], result['details']['draw_f'], result['details']['draw_s']))

--- a/worker/worker_stats.py
+++ b/worker/worker_stats.py
@@ -1,3 +1,6 @@
+import datetime
+import sys
+
 def worker_stats(result, line):
     # Parse line like this (wins and losses):
     # Finished game 35 (New-1fd2593 vs Base-3d6995e): 0-1 {Black wins by adjudication}
@@ -67,6 +70,13 @@ def print_details(result):
     
     # Print result to output
     if total_wld > 0:
+        print('Total: {0} W: {1} L: {2} D: {3}'.format(total_wld, total_w, total_l, total_d))
         print('W[{0}%]: a={1} m={2} t={3} i={4}'.format("%.1f" % ((float(total_w) / total_wld)*100), result['details']['win_a'], result['details']['win_m'], result['details']['win_t'], result['details']['win_i']))
         print('L[{0}%]: a={1} m={2} t={3} i={4}'.format("%.1f" % ((float(total_l) / total_wld)*100), result['details']['loss_a'], result['details']['loss_m'], result['details']['loss_t'], result['details']['loss_i']))
         print('D[{0}%]: a={1} r={2} i={3} f={4} s={5}'.format("%.1f" % ((float(total_d) / total_wld)*100), result['details']['draw_a'], result['details']['draw_r'], result['details']['draw_i'], result['details']['draw_f'], result['details']['draw_s']))
+
+def check_time():
+    cur_time = str(datetime.datetime.now().time())
+    th = cur_time.split(':')
+    if 8 <= int(th[0]) <= 21:
+        sys.exit()

--- a/worker/worker_stats.py
+++ b/worker/worker_stats.py
@@ -6,7 +6,17 @@ def worker_stats(result, line):
     # Finished game 35 (New-1fd2593 vs Base-3d6995e): 0-1 {Black wins by adjudication}
     if 'White' or 'Black' in line:
         w_segm = line.split('vs')
+
+        # If New is playing White
         if 'New' in w_segm[0]:
+            # Determine if New with white won or lost
+            if '1-0' in line:
+                result['details']['win_white'] += 1
+            elif '0-1' in line:
+                result['details']['loss_white'] += 1
+                
+            # Determine reason for termination when 'White' is in line and New is
+            # on the white side
             if 'White' in line:
                 if 'adjudication' in line:
                     result['details']['win_a'] += 1
@@ -16,6 +26,11 @@ def worker_stats(result, line):
                     result['details']['loss_t'] += 1
                 elif 'illegal' in line:
                     result['details']['loss_i'] += 1
+                elif 'disconnects' in line or 'connection stalls' in line:
+                    result['details']['loss_c'] += 1 
+
+            # Determine reason for termination when 'Black' is in line and New is
+            # on the white side
             elif 'Black' in line:
                 if 'adjudication' in line:
                     result['details']['loss_a'] += 1
@@ -25,7 +40,19 @@ def worker_stats(result, line):
                     result['details']['win_t'] += 1
                 elif 'illegal' in line:
                     result['details']['win_i'] += 1
+                elif 'disconnects' in line or 'connection stalls' in line:
+                    result['details']['win_c'] += 1
+
+        # If New is playing Black
         elif 'Base' in w_segm[0]:
+            # Determine if New with black won or lost
+            if '1-0' in line:
+                result['details']['loss_black'] += 1
+            elif '0-1' in line:
+                result['details']['win_black'] += 1
+
+            # Determine reason for termination when 'White' is in line and New is
+            # on the black side
             if 'White' in line:
                 if 'adjudication' in line:
                     result['details']['loss_a'] += 1
@@ -35,6 +62,11 @@ def worker_stats(result, line):
                     result['details']['win_t'] += 1
                 elif 'illegal' in line:
                     result['details']['win_i'] += 1
+                elif 'disconnects' in line or 'connection stalls' in line:
+                    result['details']['win_c'] += 1
+
+            # Determine reason for termination when 'Black' is in line and New is
+            # on the black side
             elif 'Black' in line:
                 if 'adjudication' in line:
                     result['details']['win_a'] += 1
@@ -44,9 +76,11 @@ def worker_stats(result, line):
                     result['details']['loss_t'] += 1
                 elif 'illegal' in line:
                     result['details']['loss_i'] += 1
+                elif 'disconnects' in line or 'connection stalls' in line:
+                    result['details']['loss_c'] += 1
 
     # Parse line like this (draws):
-    # Finished game 73 (stockfish vs base): 1/2-1/2 {Draw by adjudication}
+    # Finished game 73 (New-1fd2593 vs Base-3d6995e): 1/2-1/2 {Draw by adjudication}
     if 'Finished' in line:
         segm = line.split('{')
         segm = segm[1]
@@ -63,14 +97,18 @@ def worker_stats(result, line):
             result['details']['draw_s'] += 1
 
 def print_details(result):
-    total_w = result['details']['win_a'] + result['details']['win_m'] + result['details']['win_t'] + result['details']['win_i']
-    total_l = result['details']['loss_a'] + result['details']['loss_m'] + result['details']['loss_t'] + result['details']['loss_i']
+    # Calculate totals
+    total_w = result['details']['win_a'] + result['details']['win_m'] + result['details']['win_t'] + result['details']['win_i'] + result['details']['win_c']
+    total_l = result['details']['loss_a'] + result['details']['loss_m'] + result['details']['loss_t'] + result['details']['loss_i'] + result['details']['loss_c']
     total_d = result['details']['draw_a'] + result['details']['draw_r'] + result['details']['draw_i'] + result['details']['draw_f'] + result['details']['draw_s']
     total_wld = total_w + total_l + total_d
     
-    # Print result to output
+    # Print result for New to output
+    # For Overview: w=white; b=black
+    # For Win/Loss: a=adjudication; m=mated; t=time; i=illegal move; c=crash
+    # For Draw:     a=adjudication; r=repetition; i=insufficient material; f=50 moves; s=stalemate
     if total_wld > 0:
-        print('Total: {0} W: {1} L: {2} D: {3}'.format(total_wld, total_w, total_l, total_d))
-        print('W[{0}%]: a={1} m={2} t={3} i={4}'.format("%.1f" % ((float(total_w) / total_wld)*100), result['details']['win_a'], result['details']['win_m'], result['details']['win_t'], result['details']['win_i']))
-        print('L[{0}%]: a={1} m={2} t={3} i={4}'.format("%.1f" % ((float(total_l) / total_wld)*100), result['details']['loss_a'], result['details']['loss_m'], result['details']['loss_t'], result['details']['loss_i']))
-        print('D[{0}%]: a={1} r={2} i={3} f={4} s={5}'.format("%.1f" % ((float(total_d) / total_wld)*100), result['details']['draw_a'], result['details']['draw_r'], result['details']['draw_i'], result['details']['draw_f'], result['details']['draw_s']))
+        print('Total: {0}, W: {1} (w={2} b={3}), L: {4} (w={5} b={6}), D: {7}'.format(total_wld, total_w, result['details']['win_white'], result['details']['win_black'], total_l, result['details']['loss_white'], result['details']['loss_black'], total_d))
+        print('Wins   [{0}%]: a={1} m={2} t={3} i={4} c={5}'.format("%.1f" % ((float(total_w) / total_wld)*100), result['details']['win_a'], result['details']['win_m'], result['details']['win_t'], result['details']['win_i'], result['details']['win_c']))
+        print('Losses [{0}%]: a={1} m={2} t={3} i={4} c={5}'.format("%.1f" % ((float(total_l) / total_wld)*100), result['details']['loss_a'], result['details']['loss_m'], result['details']['loss_t'], result['details']['loss_i'], result['details']['loss_c']))
+        print('Draws  [{0}%]: a={1} r={2} i={3} f={4} s={5}'.format("%.1f" % ((float(total_d) / total_wld)*100), result['details']['draw_a'], result['details']['draw_r'], result['details']['draw_i'], result['details']['draw_f'], result['details']['draw_s']))

--- a/worker/worker_stats.py
+++ b/worker/worker_stats.py
@@ -10,39 +10,39 @@ def worker_stats(result, line):
             if 'White' in line:
                 if 'adjudication' in line:
                     result['details']['win_a'] += 1
-                if 'mated' in line:
+                elif 'mated' in line:
                     result['details']['loss_m'] += 1
-                if 'time' in line:
+                elif 'time' in line:
                     result['details']['loss_t'] += 1
-                if 'illegal' in line:
+                elif 'illegal' in line:
                     result['details']['loss_i'] += 1
-            if 'Black' in line:
+            elif 'Black' in line:
                 if 'adjudication' in line:
                     result['details']['loss_a'] += 1
-                if 'mated' in line:
+                elif 'mated' in line:
                     result['details']['win_m'] += 1
-                if 'time' in line:
+                elif 'time' in line:
                     result['details']['win_t'] += 1
-                if 'illegal' in line:
+                elif 'illegal' in line:
                     result['details']['win_i'] += 1
-        if 'Base' in w_segm[0]:
+        elif 'Base' in w_segm[0]:
             if 'White' in line:
                 if 'adjudication' in line:
                     result['details']['loss_a'] += 1
-                if 'mated' in line:
+                elif 'mated' in line:
                     result['details']['win_m'] += 1
-                if 'time' in line:
+                elif 'time' in line:
                     result['details']['win_t'] += 1
-                if 'illegal' in line:
+                elif 'illegal' in line:
                     result['details']['win_i'] += 1
-            if 'Black' in line:
+            elif 'Black' in line:
                 if 'adjudication' in line:
                     result['details']['win_a'] += 1
-                if 'mated' in line:
+                elif 'mated' in line:
                     result['details']['loss_m'] += 1
-                if 'time' in line:
+                elif 'time' in line:
                     result['details']['loss_t'] += 1
-                if 'illegal' in line:
+                elif 'illegal' in line:
                     result['details']['loss_i'] += 1
 
     # Parse line like this (draws):
@@ -53,13 +53,13 @@ def worker_stats(result, line):
         segm = segm[:-1]
         if 'Draw by adjudication' in segm:
             result['details']['draw_a'] += 1
-        if 'Draw by 3-fold repetition' in segm:
+        elif 'Draw by 3-fold repetition' in segm:
             result['details']['draw_r'] += 1
-        if 'Draw by insufficient mating material' in segm:
+        elif 'Draw by insufficient mating material' in segm:
             result['details']['draw_i'] += 1
-        if 'Draw by fifty moves rule' in segm:
+        elif 'Draw by fifty moves rule' in segm:
             result['details']['draw_f'] += 1
-        if 'Draw by stalemate' in segm:
+        elif 'Draw by stalemate' in segm:
             result['details']['draw_s'] += 1
 
 def print_details(result):
@@ -74,9 +74,3 @@ def print_details(result):
         print('W[{0}%]: a={1} m={2} t={3} i={4}'.format("%.1f" % ((float(total_w) / total_wld)*100), result['details']['win_a'], result['details']['win_m'], result['details']['win_t'], result['details']['win_i']))
         print('L[{0}%]: a={1} m={2} t={3} i={4}'.format("%.1f" % ((float(total_l) / total_wld)*100), result['details']['loss_a'], result['details']['loss_m'], result['details']['loss_t'], result['details']['loss_i']))
         print('D[{0}%]: a={1} r={2} i={3} f={4} s={5}'.format("%.1f" % ((float(total_d) / total_wld)*100), result['details']['draw_a'], result['details']['draw_r'], result['details']['draw_i'], result['details']['draw_f'], result['details']['draw_s']))
-
-def check_time():
-    cur_time = str(datetime.datetime.now().time())
-    th = cur_time.split(':')
-    if 8 <= int(th[0]) <= 21:
-        sys.exit()


### PR DESCRIPTION
Upon request, I wanted to make this a PR, to see if we could use parts of my code (or modifications of it), to increase the amount of data that is generated by the worker. **Note** that the FishTest server does not handle these additional results yet. Also, at present, the new code has a little overlap with this part of the games.py code, but I can combine it in one module if this code proofs to be valuable.
https://github.com/glinscott/fishtest/blob/c328b74d41eb9c012cdc361e6b544ef5cc68db89/worker/games.py#L230-L257

I make use of a seperate function called [worker_stats.py](https://github.com/RensDeVries/fishtest/blob/a22578e295886fb93e2e037cf4e79e1597431424/worker/worker_stats.py) that calculates all the values. At present, all the values are saved in [result['details']](https://github.com/RensDeVries/fishtest/blob/a22578e295886fb93e2e037cf4e79e1597431424/worker/games.py#L346-L349)(which has overlap with result['stats'] at present):

**Changelog** ([code changes](https://github.com/glinscott/fishtest/compare/master...RensDeVries:master)):
+ Added reason for win/lose/draw:
_For win/loss: a=adjudication; m=mated; t=time; i=illegal move; c=crash
For draw:      a=adjudication; r=repetition; i=insufficient material; f=50 moves; s=stalemate_
+ Added wins/losses on color (white(w)/black(b))
+ Added comments to make the code better readable
+ Added the function _print_details_ to print all the values (and percentages) to the output.

Current (optional) output:
```
Finished game 250 (Base-3913726 vs New-ad59b3e): 1/2-1/2 {Draw by adjudication}
Score of New-ad59b3e vs Base-3913726: 56 - 52 - 142  [0.508] 250
Total: 250, W: 56 (w=37 b=19), L: 52 (w=21 b=31), D: 142
Wins   [22.4%]: a=56 m=0 t=0 i=0 c=0
Losses [20.8%]: a=51 m=0 t=1 i=0 c=0
Draws  [56.8%]: a=115 r=15 i=5 f=7 s=0
Task updated successfully in 0.092s
```

I would really appreciate your feedback. Even if it will not be implemented into the main branch, I will keep working on it. I hope to also add [engine statistics](https://github.com/glinscott/fishtest/issues/320) in the upcoming month.