### PR TITLE
Update default hash size for STC

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -17,7 +17,7 @@
   <div class="control-group">
     <label class="control-label">Test options:</label>
     <div class="controls">
-    <input name="new-options" value="${args.get('new_options', 'Hash=4')}">
+    <input name="new-options" value="${args.get('new_options', 'Hash=8')}">
     </div>
   </div>
   <div class="control-group">
@@ -35,7 +35,7 @@
   <div class="control-group">
     <label class="control-label">Base options:</label>
     <div class="controls">
-    <input name="base-options" value="${args.get('base_options', 'Hash=4')}">
+    <input name="base-options" value="${args.get('base_options', 'Hash=8')}">
     </div>
   </div>
   <div class="control-group">
@@ -228,8 +228,8 @@ $(function() {
 
   $('#fast_test').click(function() {
     $('input[name=tc]').val('10+0.1');
-    $('input[name=new-options]').val('Hash=4');
-    $('input[name=base-options]').val('Hash=4');
+    $('input[name=new-options]').val('Hash=8');
+    $('input[name=base-options]').val('Hash=8');
   });
 
   $('#slow_test').click(function() {


### PR DESCRIPTION
This makes the default hash size 8 for STC.
I have not tested this as my local fishtest is not working currently but the change is minimal and hopefully easy enough for others to check.
Let me know if I need to do anything else.