### PR TITLE
Make the worker calculate the pentanomial frequencies.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -25,7 +25,7 @@ except ImportError:
   from queue import Queue, Empty  # python 3.x
 
 # Global because is shared across threads
-old_stats = {'wins':0, 'losses':0, 'draws':0, 'crashes':0, 'time_losses':0}
+old_stats = {'wins':0, 'losses':0, 'draws':0, 'crashes':0, 'time_losses':0, 'pentanomial':5*[0]}
 
 IS_WINDOWS = 'windows' in platform.system().lower()
 
@@ -205,8 +205,73 @@ def enqueue_output(out, queue):
 w_params = None
 b_params = None
 
+
+def update_pentanomial(line,rounds):
+  def result_to_score(_result):
+    if _result=="1-0":
+      return 2
+    elif _result=="0-1":
+      return 0
+    elif _result=="1/2-1/2":
+      return 1
+    else:
+      return -1
+  if not 'pentanomial' in rounds.keys():
+    rounds['pentanomial']=5*[0]
+  if not 'trinomial' in rounds.keys():
+    rounds['trinomial']=3*[0]
+  # Parse line like this:
+  # Finished game 4 (Base-5446e6f vs New-1a68b26): 1/2-1/2 {Draw by adjudication}
+  line=line.split()
+  if line[0]=='Finished' and line[1]=='game' and len(line)>=7:
+    round_=int(line[2])
+    current={}
+    rounds[round_]=current
+    current['white']=line[3][1:]
+    current['black']=line[5][:-2]
+    i=current['result']=result_to_score(line[6])
+    if round_%2==0:
+      if i!=-1:
+        rounds['trinomial'][2-i]+=1   #reversed colors
+      odd=round_-1
+      even=round_
+    else:
+      if i!=-1:
+        rounds['trinomial'][i]+=1
+      odd=round_
+      even=round_+1
+    if odd in rounds.keys() and even in rounds.keys():
+      assert(rounds[odd]['white'][0:3]=='New')
+      assert(rounds[odd]['white']==rounds[even]['black'])
+      assert(rounds[odd]['black']==rounds[even]['white'])
+      i=rounds[odd]['result']
+      j=rounds[even]['result']  # even is reversed colors
+      if i!=-1 and j!=-1:
+        rounds['pentanomial'][i+2-j]+=1
+        del rounds[odd]
+        del rounds[even]
+        rounds['trinomial'][i]-=1
+        rounds['trinomial'][2-j]-=1
+        assert(rounds['trinomial'][i]>=0)
+        assert(rounds['trinomial'][2-j]>=0)
+  pentanomial=[rounds['pentanomial'][i]+old_stats['pentanomial'][i] for i in range(0,5)]
+  return pentanomial
+
+def validate_pentanomial(wld,rounds):
+  def results_to_score(results):
+    return sum([results[i]*(i/2.0) for i in range(0,len(results))])
+  LDW=[wld[1],wld[2],wld[0]]
+  s3=results_to_score(LDW)
+  s5=results_to_score(rounds['pentanomial'])+results_to_score(rounds['trinomial'])
+  assert(sum(LDW)==2*sum(rounds['pentanomial'])+sum(rounds['trinomial']))
+  epsilon=1e-4
+  assert(abs(s5-s3)<epsilon)
+
+
 def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
   global old_stats
+  rounds={}
+
   failed_updates = 0
 
   q = Queue()
@@ -248,6 +313,9 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
       chunks = line.split(':')
       chunks = chunks[1].split()
       wld = [int(chunks[0]), int(chunks[2]), int(chunks[4])]
+
+      validate_pentanomial(wld,rounds)
+
       result['stats']['wins']   = wld[0] + old_stats['wins']
       result['stats']['losses'] = wld[1] + old_stats['losses']
       result['stats']['draws']  = wld[2] + old_stats['draws']
@@ -278,6 +346,9 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
           kill_process(p)
           break
         time.sleep(HTTP_TIMEOUT)
+
+    pentanomial=update_pentanomial(line,rounds)
+    result['stats']['pentanomial']=pentanomial
 
   if datetime.datetime.now() >= end_time:
     print(str(datetime.datetime.now()) + ' is past end time ' + str(end_time))
@@ -336,12 +407,14 @@ def run_games(worker_info, password, remote, run, task_id):
     'password': password,
     'run_id': str(run['_id']),
     'task_id': task_id,
-    'stats': {'wins':0, 'losses':0, 'draws':0, 'crashes':0, 'time_losses':0},
+    'stats': {'wins':0, 'losses':0, 'draws':0, 'crashes':0, 'time_losses':0, 'pentanomial':5*[0]},
   }
 
   # Have we run any games on this task yet?
   global old_stats
-  old_stats = task.get('stats', {'wins':0, 'losses':0, 'draws':0, 'crashes':0, 'time_losses':0})
+  old_stats = task.get('stats', {'wins':0, 'losses':0, 'draws':0, 'crashes':0, 'time_losses':0, 'pentanomial':5*[0]})
+  if not 'pentanomial' in old_stats.keys():
+    old_stats['pentanomial']=5*[0]
   result['stats']['crashes'] = old_stats.get('crashes', 0)
   result['stats']['time_losses'] = old_stats.get('time_losses', 0)
   games_remaining = task['num_games'] - (old_stats['wins'] + old_stats['losses'] + old_stats['draws'])

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -27,7 +27,7 @@ from updater import update
 from datetime import datetime
 from os import path
 
-WORKER_VERSION = 70
+WORKER_VERSION = 71
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 


### PR DESCRIPTION
This PR contains the worker changes. There are no server changes in this patch.

The updated worker will send the pentanomial frequencies
to the server and the server will faithfully store them in
its database as it does with all information received from
the client.

The actual logic added to the worker is quite minor.
A dictionary "rounds" keeps track of the finished games. For every
finished game pair (which consists of an odd numbered game
and the next even numbered game) the pentanomial frequencies
are updated.

Since sending incorrect frequencies to the server would
be quite disastrous, a lot of sanity checking is done to
make sure that the pentanomial frequencies are consistent
with the trinomial frequencies provided by cutechess itself.

