### PR TITLE
"get_results" now returns the aggregated pentanomial frequencies.

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -253,6 +253,9 @@ class RunDb:
       return run['results']
 
     results = { 'wins': 0, 'losses': 0, 'draws': 0, 'crashes': 0, 'time_losses':0 }
+    
+    has_pentanomial=True
+    pentanomial=5*[0]
     for task in run['tasks']:
       if 'stats' in task:
         stats = task['stats']
@@ -261,6 +264,12 @@ class RunDb:
         results['draws'] += stats['draws']
         results['crashes'] += stats['crashes']
         results['time_losses'] += stats.get('time_losses', 0)
+        if 'pentanomial' in stats.keys() and has_pentanomial:
+          pentanomial=[pentanomial[i]+stats['pentanomial'][i] for i in range(0,5)]
+        else:
+          has_pentanomial=False
+    if has_pentanomial:
+      results['pentanomial']=pentanomial
 
     if 'sprt' in run['args'] and 'state' in run['args']['sprt']:
       results['sprt'] = run['args']['sprt']['state']


### PR DESCRIPTION
This small compagnon PR to PR #351 makes the server aggregate the pentanomial frequencies, whenever they are present in its database. The effect can be verified with the `get_run` api call (see the next to last line in the output below).
```
$ curl http://localhost:6543/api/get_run/5c40f4d75c6d4e34f00d7269

{"results_info": {"info": ["ELO: -3.13 +-18.7 (95%) LOS: 37.1%", "Total: 1000 W: 371 L: 380 D: 249",
 "style": ""}, "last_updated": "2019-01-17 21:43:25.249000", "results_stale": false, 
"start_time": "2019-01-17 21:34:15.163000", "args": {"book_depth": "8", "internal_priority": -1547759955.0, 
"new_signature": "3739723", "auto_purge": true, "tests_repo": "https://github.com/official-
stockfish/Stockfish", "new_tag": "master", "priority": 0, "base_signature": "3739723", "book": 
"2moves_v1.pgn", "tc": "0.3+0.01", "username": "user01", "base_tag": "master", "msg_base": "Remove 
AdjacentFiles", "new_options": "Hash=8", "resolved_new": 
"3300517ecb75df265489d2a9841e4fce2414fd09", "threads": 1, "resolved_base": 
"3300517ecb75df265489d2a9841e4fce2414fd09", "base_options": "Hash=8", "info": "Dummy 4", 
"num_games": 1000, "msg_new": "Remove AdjacentFiles", "throughput": 1000}, "results": {"draws": 249, 
"crashes": 0, "wins": 371, "losses": 380, "pentanomial": [71, 100, 168, 89, 72], "time_losses": 1}, 
"approver": "user00", "_id": "5c40f4d75c6d4e34f00d7269", "finished": true, "approved": true}
```


