### PR TITLE
Include the pentanomial frequencies in the "elo results" widget.

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -654,6 +654,8 @@ def format_results(run_results, run):
       state = 'accepted'
 
   result['info'].append('Total: %d W: %d L: %d D: %d' % (sum(WLD), WLD[0], WLD[1], WLD[2]))
+  if 'pentanomial' in run_results.keys():
+    result['info'].append("Ptnml(0-2): "+", ".join(str(run_results['pentanomial'][i]) for i in range(0,5)))
 
   if state == 'rejected':
     if WLD[0] > WLD[1]:
@@ -995,6 +997,7 @@ def tests(request):
 
     for run in finished:
       results = request.rundb.get_results(run)
+      run['results_info'] = format_results(results, run)  # MAKE SURE TO DELETE THIS
       if results['wins'] + results['losses'] + results['draws'] == 0:
         runs['failed'].append(run)
 


### PR DESCRIPTION
The pentanomial frequencies cannot be used solely behind the scenes
since that would make it difficult to verify independently the
statistical quantities derived from them.

So here we include them in the elo widget. As yet no statistical
quantities are computed.
```
ELO: -4.86 +-20.6 (95%) LOS: 32.2% 
Total: 500 W: 111 L: 118 D: 271 
Ptnml(0-2): 10, 60, 114, 59, 7
```
My next plan is to apply the pentanomial frequencies to fixed length
tests. That would be the first statistical application.