### PR TITLE
Include the pentanomial frequencies in the "elo results" widget.

### DIFF
--- a/fishtest/fishtest/templates/elo_results.mak
+++ b/fishtest/fishtest/templates/elo_results.mak
@@ -6,6 +6,18 @@
       return 'background-color:' + run['results_info']['style']
     return ''
 %>
+<%def name="list_info(run)">
+<%
+      info=run['results_info']['info']
+      l=len(info)
+%>
+      % for i in range(0,l):
+      	${info[i]}
+        % if i<l-1:
+	   <br/>
+	% endif   
+      % endfor
+</%def>
 
 %if 'sprt' in run['args'] and not 'Pending' in run['results_info']['info'][0]:
 <a href="${'/html/live_elo.html?' + str(run['_id'])}" style="text-decoration:none">
@@ -19,8 +31,7 @@
 %endif
 %endif
 <pre style="${get_run_style(run)};white-space:nowrap;" class="elo-results">
-${run['results_info']['info'][0]}<br/>
-${run['results_info']['info'][1] if len(run['results_info']['info']) > 1 else ''}
+${list_info(run)}
 </pre>
 %if show_gauge:
 </div>

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -689,6 +689,8 @@ def format_results(run_results, run):
       state = 'accepted'
 
   result['info'].append('Total: %d W: %d L: %d D: %d' % (sum(WLD), WLD[0], WLD[1], WLD[2]))
+  if 'pentanomial' in run_results.keys():
+    result['info'].append("Ptnml(0-2): "+", ".join(str(run_results['pentanomial'][i]) for i in range(0,5)))
 
   if state == 'rejected':
     if WLD[0] > WLD[1]:


### PR DESCRIPTION
The pentanomial frequencies cannot be used solely behind the scenes
since that would make it difficult to verify independently the
statistical quantities derived from them.

So here we include them in the elo widget. As yet no statistical
quantities are computed.
```
ELO: -4.86 +-20.6 (95%) LOS: 32.2% 
Total: 500 W: 111 L: 118 D: 271 
Ptnml(0-2): 10, 60, 114, 59, 7
```
