### PR TITLE
Use the pentanomial frequencies for fixed length tests.

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -675,7 +675,10 @@ def format_results(run_results, run):
     result['llr'] = stats['llr']
     result['info'].append('LLR: %.2f (%.2lf,%.2lf) [%.2f,%.2f]' % (stats['llr'], stats['lower_bound'], stats['upper_bound'], sprt['elo0'], sprt['elo1']))
   else:
-    elo, elo95, los = stat_util.get_elo(WLD)
+    if 'pentanomial' in run_results.keys():
+      elo, elo95, los = stat_util.get_elo(run_results['pentanomial'])
+    else:
+      elo, elo95, los = stat_util.get_elo([WLD[1],WLD[2],WLD[0]])
 
     # Display the results
     eloInfo = 'ELO: %.2f +-%.1f (95%%)' % (elo, elo95)


### PR DESCRIPTION
Use the pentanomial frequencies for fixed length tests.
    
The pentanomial error bars are a bit smaller for the type of tests that are run on fishtest.
    
To correctly appreciate this one should use the observation that the amount of effort needed to reach certain error bars is _inversely quadratic_ in the size of the error bars.
