### PR TITLE
Change default throughput to 10000

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -170,7 +170,7 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
   <div class="control-group">
     <label class="control-label">Throughput:</label>
     <div class="controls">
-      <input name="throughput" value="${args.get('throughput', 1000)}">
+      <input name="throughput" value="${args.get('throughput', 10000)}">
     </div>
   </div>
   <div class="control-group">


### PR DESCRIPTION
[This](https://groups.google.com/d/msg/fishcooking/BxWmrJ9yK64/ltnoKx0rFQAJ) discussion on fishcooking  suggested changing the default throughput for tests.

Possible values of 5000 or 10000 were mentioned. This patch currently changes the default to 10000, but if people want a different value, it could obviously be changed before being merged.