### PR TITLE
Reduce default throughput from 10000 to 3000

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -61,7 +61,7 @@ class RunDb:
               username=None,
               tests_repo=None,
               auto_purge=True,
-              throughput=1000,
+              throughput=3000,
               priority=0):
     if start_time == None:
       start_time = datetime.utcnow()
@@ -270,7 +270,8 @@ class RunDb:
           break
     # Recalculate internal priority based on task start date and throughput
     # Formula: - second_since_epoch - played_and_allocated_tasks * 3600 * chunk_size / games_throughput
-    # With default value 'throughput = 1000', this means that the priority is unchanged as long as we play at rate '1000 games / hour'.
+    # With default value 'throughput = 3000', this means that the priority is unchanged as long as
+    # we play at rate '3000 games / hour'.
     if (run['args']['throughput'] != None and run['args']['throughput'] != 0):
       run['args']['internal_priority'] = - time.mktime(run['start_time'].timetuple()) - \
         task_id * 3600 * self.chunk_size * run['args']['threads'] / run['args']['throughput']

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -171,7 +171,7 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
   <div class="control-group">
     <label class="control-label">Throughput:</label>
     <div class="controls">
-      <input name="throughput" value="${args.get('throughput', 10000)}">
+      <input name="throughput" value="${args.get('throughput', 3000)}">
     </div>
   </div>
   <div class="control-group">


### PR DESCRIPTION
See also the discussion #362 

The recent change to the default throughput seems to have been overdone, and older jobs are now preventing new ones from starting for extended periods.
This change reduces the default throughput so that is higher than the original 1000, but lower than the current 10000.