### PR TITLE
Write a more efficient script to update the user statistics

### DIFF
--- a/fishtest/fishtest/actiondb.py
+++ b/fishtest/fishtest/actiondb.py
@@ -15,6 +15,9 @@ class ActionDb:
       q['username'] = username
     return self.actions.find(q, sort=[('_id', DESCENDING)], limit=max_num)
 
+  def update_stats(self):
+    self._new_action('fishtest.system', 'update_stats', '')
+
   def new_run(self, username, run):
     self._new_action(username, 'new_run', run)
 

--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -27,6 +27,7 @@ class RunDb:
     self.pgndb = self.db['pgns']
     self.runs = self.db['runs']
     self.old_runs = self.db['old_runs']
+    self.deltas = self.db['deltas']
 
     self.chunk_size = 250
 
@@ -124,7 +125,7 @@ class RunDb:
           machine['nps'] = task.get('nps', 0)
           machines.append(machine)
     return machines
-  
+
   def get_pgn(self, id):
     id = id.split('.')[0] # strip .pgn
     pgn = self.pgndb.find_one({'run_id': id})
@@ -234,7 +235,7 @@ class RunDb:
       result[1] += c.count()
     else:
       result[1] += self.old_runs.find(q).count()
-      
+
     return result
 
   def get_results(self, run, save_run=True):
@@ -403,7 +404,7 @@ class RunDb:
     if task['worker_info']['username'] != username:
       print('Update_task: Non matching username: ' + username)
       return {'task_alive': False}
-    
+
     # Guard against incorrect results
     count_games = lambda d: d['wins'] + d['losses'] + d['draws']
     num_games = count_games(stats)
@@ -452,9 +453,9 @@ class RunDb:
   def upload_pgn(self, run_id, pgn_zip):
 
     self.pgndb.insert({'run_id': run_id, 'pgn_zip': Binary(pgn_zip)})
-    
+
     return {}
-  
+
   def failed_task(self, run_id, task_id):
     run = self.get_run(run_id)
     if task_id >= len(run['tasks']):
@@ -530,10 +531,10 @@ class RunDb:
             value = fl
 
     return value
-  
+
   # Store SPSA parameters for each worker
   spsa_params = {}
-  
+
   def store_params(self, run_id, worker, params):
     run_id = str(run_id)
     if not run_id in self.spsa_params:
@@ -617,7 +618,7 @@ class RunDb:
       freq = 100
     maxlen = 250000 / freq
     grow_summary = len(spsa['param_history']) < min(maxlen, spsa['iter'] / freq)
-    
+
     # Update the current theta based on the results from the worker
     # Worker wins/losses are always in terms of w_params
     result = spsa_results['wins'] - spsa_results['losses']

--- a/fishtest/fishtest/templates/actions.mak
+++ b/fishtest/fishtest/templates/actions.mak
@@ -32,7 +32,7 @@ Show only:
  %for action in actions:
   <tr>
    <td>${action['time'].strftime("%y-%m-%d %H:%M:%S")}</td>
-   %if approver:
+   %if approver and 'fishtest.' not in action['username']:
    <td><a href="/user/${action['username']}">${action['username']}</a></td>
    %else:
    <td>${action['username']}</td>

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -176,7 +176,10 @@ def actions(request):
       'time': action['time'],
       'username': action['username'],
     }
-    if action['action'] == 'block_user':
+    if action['action'] == 'update_stats':
+      item['user'] = ''
+      item['description'] = 'Update user statistics'
+    elif action['action'] == 'block_user':
       item['description'] = ('blocked' if action['data']['blocked'] else 'unblocked')
       item['user'] = action['data']['user']
     elif action['action'] == 'modify_run':

--- a/fishtest/utils/delta_update_users.py
+++ b/fishtest/utils/delta_update_users.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+import os
+import sys
+
+from datetime import datetime, timedelta
+
+# For tasks
+sys.path.append(os.path.expanduser('~/fishtest/fishtest'))
+from fishtest.rundb import RunDb
+from fishtest.views import parse_tc, delta_date
+
+new_deltas = {}
+skip = False
+
+def process_run(run, info, deltas=None):
+  global skip
+  if 'deleted' in run:
+    return
+  if deltas and (skip or str(run['_id']) in deltas):
+    skip = True
+    return
+  if deltas != None and str(run['_id']) in new_deltas:
+    print('Warning: skipping repeated run!')
+    return
+  if 'username' in run['args']:
+    username = run['args']['username']
+    info[username]['tests'] += 1
+
+  tc = parse_tc(run['args']['tc'])
+  for task in run['tasks']:
+    if 'worker_info' not in task:
+      continue
+    username = task['worker_info'].get('username', None)
+    if username == None:
+      continue
+
+    if 'stats' in task:
+      stats = task['stats']
+      num_games = stats['wins'] + stats['losses'] + stats['draws']
+    else:
+      num_games = task['num_games']
+
+    try:
+      info[username]['last_updated'] = max(task['last_updated'], info[username]['last_updated'])
+    except:
+      info[username]['last_updated'] = task['last_updated']
+
+    info[username]['cpu_hours'] += float(num_games * int(run['args'].get('threads', 1)) * tc / (60 * 60))
+    info[username]['games'] += num_games
+  if deltas != None:
+    new_deltas.update({ str(run['_id']) : None})
+
+def build_users(machines, info):
+  for machine in machines:
+    games_per_hour = (machine['nps'] / 1200000.0) * (3600.0 / parse_tc(machine['run']['args']['tc'])) * int(machine['concurrency'])
+    info[machine['username']]['games_per_hour'] += games_per_hour
+
+  users = []
+  for u in info.keys():
+    user = info[u]
+    try:
+      user['last_updated'] = delta_date(user['last_updated'])
+    except:
+      pass
+    users.append(user)
+
+  users = [u for u in users if u['games'] > 0 or u['tests'] > 0]
+  return users
+
+def update_users():
+  rundb = RunDb()
+
+  deltas = {}
+  info = {}
+  top_month = {}
+
+  clear_stats = True
+  if len(sys.argv) > 1:
+    print('scan all')
+  else:
+    deltas = rundb.deltas.find_one()
+    if deltas:
+      clear_stats = False
+    else:
+      deltas = {}
+
+  for u in rundb.userdb.get_users():
+    username = u['username']
+    top_month[username] = {'username': username,
+                      'cpu_hours': 0,
+                      'games': 0,
+                      'tests': 0,
+                      'tests_repo': u.get('tests_repo', ''),
+                      'last_updated': datetime.min,
+                      'games_per_hour': 0.0,}
+    if clear_stats:
+      info[username] = top_month[username].copy()
+    else:
+      info[username] = rundb.userdb.user_cache.find_one({'username': username})
+      if not info[username]:
+        info[username] = top_month[username].copy()
+
+  for run in rundb.get_unfinished_runs():
+    process_run(run, top_month)
+
+  # Step through these in small batches (step size 100) to save RAM
+  current = 0
+  step_size = 100
+
+  now = datetime.utcnow()
+  more_days = True
+  while more_days:
+    runs = rundb.get_finished_runs(skip=current, limit=step_size)[0]
+    if len(runs) == 0:
+      break
+    for run in runs:
+      process_run(run, info, deltas)
+      if (now - run['start_time']).days < 30:
+        process_run(run, top_month)
+      elif not clear_stats:
+        more_days = False
+    current += step_size
+
+  if new_deltas:
+    rundb.deltas.remove()
+    rundb.deltas.save(new_deltas)
+
+  machines = rundb.get_machines()
+
+  users = build_users(machines, info)
+  rundb.userdb.user_cache.remove()
+  rundb.userdb.user_cache.insert(users)
+
+  rundb.userdb.top_month.remove()
+  rundb.userdb.top_month.insert(build_users(machines, top_month))
+
+  # Delete users that have never been active and old admins group
+  idle = {}
+  for u in rundb.userdb.get_users():
+      update = False
+      while 'group:admins' in u['groups']:
+          u['groups'].remove('group:admins')
+          update = True
+      if update:
+        rundb.userdb.users.save(u)
+      if not 'registration_time' in u \
+         or u['registration_time'] < datetime.utcnow() - timedelta(days=28):
+        idle[u['username']] = u
+  for u in rundb.userdb.user_cache.find():
+    if u['username'] in idle:
+      del idle[u['username']]
+  for u in idle.values():
+    # A safe guard against deleting long time users
+    if not 'registration_time' in u \
+      or u['registration_time'] < datetime.utcnow() - timedelta(days=38):
+        print('Warning: Found old user to delete: ' + str(u['_id']))
+    else:
+      print('Delete: ' + str(u['_id']))
+      rundb.userdb.users.remove({'_id': u['_id']})
+
+  print('Successfully updated %d users' % (len(users)))
+
+  # record this update run
+  rundb.actiondb.update_stats()
+
+
+def main():
+  update_users()
+
+if __name__ == '__main__':
+  main()

--- a/fishtest/utils/scavenge.py
+++ b/fishtest/utils/scavenge.py
@@ -20,28 +20,8 @@ def scavenge_tasks(scavenge=True, minutes=60):
     if changed and scavenge:
       rundb.runs.save(run)
 
-def get_idle_users(days):
-  """Check for users that have never been active"""
-  idle = {}
-  for u in rundb.userdb.get_users():
-      if not 'registration_time' in u \
-         or u['registration_time'] < datetime.utcnow() - timedelta(days=days):
-        idle[u['username']] = u
-  for u in rundb.userdb.user_cache.find():
-    if u['username'] in idle:
-      del idle[u['username']]
-  idle= idle.values()
-  return idle
-
-def scavenge_users(scavenge=True, days=28):
-  for u in get_idle_users(days):
-    if scavenge:
-      rundb.userdb.users.remove({'_id': u['_id']})
-
 def main():
   scavenge_tasks(scavenge=True)
-  # scavenge_users(scavenge=True) # Fix this, see
-  # https://github.com/glinscott/fishtest/issues/323#issuecomment-526127748
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
See #391 

`update_users.py` reads the whole MongoDb database to build user statistics from scratch.

This PR creates a new script `delta_update_users.py` which incrementally updates the statistics and only reads runs from the last 31 days.

Edit: Note that the first run will be as slow as `update_users.py`