### PR TITLE
Fix games per hour statistic for grand total

### DIFF
--- a/fishtest/utils/delta_update_users.py
+++ b/fishtest/utils/delta_update_users.py
@@ -99,6 +99,8 @@ def update_users():
       info[username] = rundb.userdb.user_cache.find_one({'username': username})
       if not info[username]:
         info[username] = top_month[username].copy()
+      else:
+        info[username]['games_per_hour'] = 0.0
 
   for run in rundb.get_unfinished_runs():
     process_run(run, top_month)


### PR DESCRIPTION
@ppigazzini This one sneaked through. The games/hour grand total should be cleared but it was not, so in the users report the games/hour continuously grows. The first incremental run should fix the grand total, no need to run a full scan.