### PR TITLE
Handle test stop, restart in statistics update

### DIFF
--- a/fishtest/utils/delta_update_users.py
+++ b/fishtest/utils/delta_update_users.py
@@ -122,6 +122,7 @@ def update_users():
     current += step_size
 
   if new_deltas:
+    new_deltas.update(deltas)
     rundb.deltas.remove()
     rundb.deltas.save(new_deltas)
 


### PR DESCRIPTION
When a test is stopped and restarted (by a modify) this
can cause many runs (30 days period) to be counted twice.
This happens only when the restarted test was the only new
finished test at the last execution of this script.
When the test is restarted before the script is executed
then there is also no error condition.

This can be fixed by storing also all older run-ids,
with a small performance impact (bigger MongoDb table).

Note that tasks in the restarted test are counted twice
when the error condition happens. This should be very rare.

@ppigazzini This has low priority. The performance impact should be minimal. Note that linenumbers have changed so you should adapt your upgrade procedure patch.