### PR TITLE
Remove yellow for STC tests

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -672,8 +672,10 @@ def format_results(run_results, run):
 
   result['info'].append('Total: %d W: %d L: %d D: %d' % (sum(WLD), WLD[0], WLD[1], WLD[2]))
 
+  tc = run['args']['tc']
+
   if state == 'rejected':
-    if WLD[0] > WLD[1]:
+    if WLD[0] > WLD[1] and tc == '60+0.05':
       result['style'] = 'yellow'
     else:
       result['style'] = '#FF6A6A'


### PR DESCRIPTION
The yellow test results at STC are often abused as a pretext to make speculative LTC.

If the STC bounds change of pull request https://github.com/glinscott/fishtest/pull/417 is merged, then STC tests will get a green passed status more easily, and we can restrict the yellow color to LTC test results.