### PR TITLE
Change STC bounds to [-1.5 , 4.5]

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -64,7 +64,7 @@
     <label class="control-label">SPRT bounds:</label>
     <div class="controls">
       <select name="bounds">
-        <option value="standard STC">Standard STC [0.5,4.5]</option>
+        <option value="standard STC">Standard STC [-1.5,4.5]</option>
         <option value="standard LTC">Standard LTC [0,3.5]</option>
         <option value="tweak">Parameter Tweak [0,4]</option>
         <option value="regression">Non-regression [-3,1]</option>
@@ -205,7 +205,7 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
 $(function() {
   var update_bounds = function() {
     var bounds = $('select[name=bounds]').val();
-    if (bounds == 'standard STC') { $('input[name=sprt_elo0]').val('0.5'); $('input[name=sprt_elo1]').val('4.5'); }
+    if (bounds == 'standard STC') { $('input[name=sprt_elo0]').val('-1.5'); $('input[name=sprt_elo1]').val('4.5'); }
     if (bounds == 'standard LTC') { $('input[name=sprt_elo0]').val('0.0'); $('input[name=sprt_elo1]').val('3.5'); }
     if (bounds == 'tweak') { $('input[name=sprt_elo0]').val('0'); $('input[name=sprt_elo1]').val('4'); }
     if (bounds == 'regression') { $('input[name=sprt_elo0]').val('-3'); $('input[name=sprt_elo1]').val('1'); }
@@ -240,7 +240,7 @@ $(function() {
     $('input[name=tc]').val('60+0.6');
     $('input[name=new-options]').val('Hash=64');
     $('input[name=base-options]').val('Hash=64');
-    if ($('input[name=sprt_elo0]').val() == '0.5' && $('input[name=sprt_elo1]').val() == '4.5')
+    if ($('input[name=sprt_elo0]').val() == '-1.5' && $('input[name=sprt_elo1]').val() == '4.5')
       { $('select[name=bounds]').val('standard LTC'); update_bounds(); }
   });
 });


### PR DESCRIPTION
This pull request proposes to change the STC bounds to [-1.5 , 4.5]

At the date of october 19th, the pourcentage for speculative LTC
of the last 100 LTC Elo-gaining tests was 70%, from all active 
Stockfish developers.

This gives some feedback after a few months of intensive use with
the changes introduced in #342, and shows that the new STC bounds
were too strict for our community since even the most motivated
members bypass them.

Related discussions:
glinscott/fishtest#342
https://github.com/official-stockfish/Stockfish/issues/2283
https://github.com/official-stockfish/Stockfish/pull/1804#issuecomment-445429885
https://github.com/official-stockfish/Stockfish/issues/1859