### PR TITLE
Empty pgns collection and keep indexes during backup

### DIFF
--- a/fishtest/utils/backup.sh
+++ b/fishtest/utils/backup.sh
@@ -8,7 +8,7 @@
 cd ${HOME}/backup
 mongodump && \
 rm -f dump.tar.gz && \
-rm -f dump/fishtest_new/pgns.* && \
+: > dump/fishtest_new/pgns.bson && \
 tar -czvf dump.tar.gz dump && \
 rm -rf dump
 


### PR DESCRIPTION
Empty the pgns collection (pgns.bson) to reduce the backup size but keep the indexes (pgns.metadata.json).