### PR TITLE
Speed up finished runs MongoDb query

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -216,7 +216,7 @@ class RunDb:
                           sort=[('last_updated', DESCENDING), ('start_time', DESCENDING)])
 
   def get_finished_runs(self, skip=0, limit=0, username='', success_only=False, ltc_only=False):
-    q = {'finished': True, 'deleted': {'$exists': False}}
+    q = {'finished': True}
     if len(username) > 0:
       q['args.username'] = username
     if ltc_only:

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -933,6 +933,8 @@ def tests(request):
   try:
     unfinished_runs = request.rundb.get_unfinished_runs()
     for run in unfinished_runs:
+      if 'deleted' in run:
+        continue
       # Is username filtering on?  If so, match just runs from that user
       if len(username) > 0 and run['args'].get('username', '') != username:
         continue


### PR DESCRIPTION
edit: Filtering 'deleted' in python speeds up to 0.2s