### PR TITLE
Fix old_runs delete and speedup grand total

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -228,20 +228,22 @@ class RunDb:
 
     c = self.runs.find(q, skip=skip, limit=limit, sort=[('last_updated', DESCENDING)])
     no_del = []
+    del_count = 0
     for run in c:
       if 'deleted' in run:
+        del_count += 1
         continue
       no_del.append(run)
-    result = [no_del, len(no_del)]
+    result = [no_del, c.count()]
 
-    if limit != 0 and len(result[0]) != limit:
+    if limit != 0 and len(result[0]) != limit - del_count:
       c = self.old_runs.find(q, skip=max(0, skip-c.count()),
                              limit=limit-len(result[0]),
                              sort=[('_id',DESCENDING)])
       result[0] += list(c)
       result[1] += c.count()
     else:
-      result[1] += self.old_runs.find(q).count()
+      result[1] += self.old_runs.find().count()
 
     return result
 

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -746,9 +746,6 @@ def get_chi2(tasks, bad_users):
   expected = numpy.outer(row_sums, column_sums) / grand_total
   diff = observed - expected
   adj = numpy.outer((1 - row_sums / grand_total), (1 - column_sums / grand_total))
-  if expected * adj <= 0:
-    return results
-
   residual = diff / numpy.sqrt(expected * adj)
   for idx in range(len(users)):
     users[users.keys()[idx]] = numpy.max(numpy.abs(residual[idx]))


### PR DESCRIPTION
I make a short cut here, I do not filter deleted runs from old_runs, but that should not be an issue.

@xoto10 I also noted that the grand total of runs is computed by counting 'finished' runs in old_runs, but old_runs does NOT have an index on 'finished'! We may consider all runs in old_runs to be finished, so I changed it to just count all in old_runs. That should give a significant speedup (EDIT: because old_runs does not change very often, MongoDb might cache the count result between invocations).

@ppigazzini This really needs testing on the dev server before it can be merged. 

Edit: Also fix count of runs