### PR TITLE
Add numba for SPSA inner loop calculation

### DIFF
--- a/fishtest/setup.py
+++ b/fishtest/setup.py
@@ -14,7 +14,8 @@ requires = [
     'numpy<1.16',
     'scipy<1.2',
     'requests',
-    'boto'
+    'boto',
+    'numba',
     ]
 
 setup(name='fishtest-server',


### PR DESCRIPTION
The SPSA calculation is the most CPU intensive part in fishtest.

Rewrite inner loop for Numba JIT compilation.

Note that this PR requires Python 3 Numba version, so it will be merged at a later date.

EDIT: default clipping is `old`, so gain is somewhat limited.