### PR TITLE
Speedup backup using mongodump options

### DIFF
--- a/fishtest/utils/backup.sh
+++ b/fishtest/utils/backup.sh
@@ -6,10 +6,10 @@
 . ${HOME}/.profile
 
 cd ${HOME}/backup
-mongodump && \
-rm -f dump.tar.gz && \
-: > dump/fishtest_new/pgns.bson && \
-tar -czvf dump.tar.gz dump && \
+for db_name in "fishtest_new" "admin" "fishtest" "fishtest_testing"; do
+  mongodump --db=${db_name} --excludeCollection="pgns" --gzip
+done
+tar -cv dump | gzip -1 > dump.tar.gz
 rm -rf dump
 
 date_utc=$(date +%Y%m%d --utc)


### PR DESCRIPTION
Speedup the back process using collection skipping and compression options of new mongodump.
Respect to the previous version this saves:
 - 9/10 hard disk space
 - 1/2 time
 - 1/6 size backup file