### PR TITLE
Keep some of the gain when a test gets ahead of expected throughput.

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -286,7 +286,7 @@ class RunDb:
     # A copy of the test start date is used. This is adjusted if the test gets ahead of its expected schedule
     # so that it can keep some of those gains.
     if (run['args']['throughput'] != None and run['args']['throughput'] != 0):
-      if (run['args']['ip_start_time'] == None):
+      if ('ip_start_time' not in run['args']):
         run['args']['ip_start_time'] = run['start_time']
       new_internal_prio = - time.mktime(run['args']['ip_start_time'].timetuple()) - \
         task_id * 3600 * self.chunk_size * run['args']['threads'] / run['args']['throughput']

--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -89,8 +89,8 @@ class RunDb:
       'auto_purge': auto_purge,
       'throughput': throughput,
       'priority': priority,
-      'ip_start_time': - time.mktime(start_time.timetuple())
-      'internal_priority': - time.mktime(start_time.timetuple()),
+      'ip_start_time': - time.mktime(start_time.timetuple()),
+      'internal_priority': - time.mktime(start_time.timetuple())
     }
 
     if sprt != None:

--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -286,7 +286,8 @@ class RunDb:
     # A copy of the test start date is used. This is adjusted if the test gets ahead of its expected schedule
     # so that it can keep some of those gains.
     if (run['args']['throughput'] != None and run['args']['throughput'] != 0):
-      run['args']['ip_start_time'] = run['start_time'] if (run['args']['ip_start_time'] == None)
+      if (run['args']['ip_start_time'] == None):
+        run['args']['ip_start_time'] = run['start_time']
       new_internal_prio = - time.mktime(run['args']['ip_start_time'].timetuple()) - \
         task_id * 3600 * self.chunk_size * run['args']['threads'] / run['args']['throughput']
       time_gain = -time.time() - new_internal_prio


### PR DESCRIPTION
If fishtest is quiet, the tests that are running can get well ahead of where the throughput calculation expects them to be. If a new test is then submitted the new test gets most/all of the available cores because it is neutral and the older tests are ahead of expected throughput. e.g. a few days ago I noticed one of my STC tests get more than half of the available cores when it started. In some cases, repeated creation of new tests seems to starve older tests of resources.

This patch attempts to reduce/remove this effect by adjusting the start time used in the throughput calculation. A copy of the actual start time of the job is made, and if the job gets ahead of its expected throughput this copy is adjusted to an earlier time so that the job can keep some of its "extra" gains. The calculation used only keeps half of the gain, but in practice I expect repeated application of this adjustment to allocate most of the gain to the job. This should mean that new tests only get a modest allocation of cores instead of the current situation where they sometimes get a large proportion of the available cores. It's possible this will also help when many extra cores are added to fishtest.