### PR TITLE
Remove parameter tweak option for test bounds

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -66,7 +66,6 @@
       <select name="bounds">
         <option value="standard STC">Standard STC [-1.5,4.5]</option>
         <option value="standard LTC">Standard LTC [0,3.5]</option>
-        <option value="tweak">Parameter Tweak [0,4]</option>
         <option value="regression">Non-regression [-3,1]</option>
         <option value="simplification">Simplification [-3,1]</option>
         <option value="custom">Custom bounds...</option>
@@ -207,7 +206,6 @@ $(function() {
     var bounds = $('select[name=bounds]').val();
     if (bounds == 'standard STC') { $('input[name=sprt_elo0]').val('-1.5'); $('input[name=sprt_elo1]').val('4.5'); }
     if (bounds == 'standard LTC') { $('input[name=sprt_elo0]').val('0.0'); $('input[name=sprt_elo1]').val('3.5'); }
-    if (bounds == 'tweak') { $('input[name=sprt_elo0]').val('0'); $('input[name=sprt_elo1]').val('4'); }
     if (bounds == 'regression') { $('input[name=sprt_elo0]').val('-3'); $('input[name=sprt_elo1]').val('1'); }
     if (bounds == 'simplification') { $('input[name=sprt_elo0]').val('-3'); $('input[name=sprt_elo1]').val('1'); }
     if (bounds == 'custom')


### PR DESCRIPTION
In the past, parameter tweak tests were allowed to use easier bounds than normal tests. Now that normal test bounds have been changed they are easier to pass than the old parameter tweak bounds so the [0,4] bounds are redundant.

This patch removes the ` Parameter Tweak [0,4] ` option from the SPRT bounds drop-down in the New Test web page.