### PR TITLE
Calculate priority with number of active cores

### DIFF
--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -1,4 +1,4 @@
-<%page args="runs, show_delete=False, active=False, id_cores={}"/>
+<%page args="runs, show_delete=False, active=False"/>
 
 <%namespace name="base" file="base.mak"/>
 
@@ -75,7 +75,7 @@
     %else:
     ${run['args']['num_games']}
     %endif
-    @ ${run['args']['tc']} th ${str(run['args'].get('threads',1))}<br>${('cores: '+str(id_cores[run['_id']])) if run['_id'] in id_cores else ''}</td>
+    @ ${run['args']['tc']} th ${str(run['args'].get('threads',1))}<br>${('cores: '+str(run['cores'])) if not run['finished'] and 'cores' in run else ''}</td>
     <td style="word-break:break-word">${run['args'].get('info', '')}</td>
    </tr>
   %endfor

--- a/fishtest/fishtest/templates/tests.mak
+++ b/fishtest/fishtest/templates/tests.mak
@@ -20,9 +20,6 @@
 <%include file="run_table.mak" args="runs=runs['failed'], show_delete=True"/>
 %endif
 
-<%
-id_cores = {}
-%>
 %if show_machines:
  <h3>Active - ${len(machines)} machines ${cores}
      cores ${'%.2fM' % (nps / (cores * 1000000.0 + 1))} nps
@@ -45,13 +42,6 @@ id_cores = {}
    </thead>
    <tbody>
   %for machine in machines:
-<%
-    id = machine['run']['_id']
-    if id not in id_cores:
-      id_cores[id] = machine['concurrency']
-    else:
-      id_cores[id] += machine['concurrency']
-%>
     <tr>
      <td>${machine['username']}</td>
      <td>
@@ -75,7 +65,7 @@ id_cores = {}
 %else:
  <h3>Active - ${len(runs['active'])} tests</h3>
 %endif
-<%include file="run_table.mak" args="runs=runs['active'],id_cores=id_cores"/>
+<%include file="run_table.mak" args="runs=runs['active']"/>
 
 %endif
 

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -168,9 +168,15 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
     </div>
   </div>
   <div class="control-group">
-    <label class="control-label">Throughput:</label>
+    <label class="control-label">Throughput%:</label>
     <div class="controls">
-      <input name="throughput" value="${args.get('throughput', 3000)}">
+      <select name="throughput">
+        <option value="10">10%</option>
+        <option value="25">25%</option>
+        <option value="50">50%</option>
+        <option selected="selected" value="100">100%</option>
+        <option style="color:red" value="200">200%</option>
+      </select>
     </div>
   </div>
   <div class="control-group">

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -85,7 +85,7 @@ var spsa_history_url = '${run_args[0][1]}/spsa_history';
     <label class="control-label">Adjust priority (higher is more urgent):</label>
     <input name="priority" value="${run['args']['priority']}">
 
-    <label class="control-label">Adjust throughput:</label>
+    <label class="control-label">Adjust throughput%:</label>
     <input name="throughput" value="${run['args'].get('throughput', 1000)}">
 
     <input type="hidden" name="run" value="${run['_id']}" />

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -528,7 +528,7 @@ def tests_modify(request):
     run['args']['num_games'] = num_games
     run['args']['priority'] = int(request.POST['priority'])
     run['args']['throughput'] = int(request.POST['throughput'])
-    request.rundb.recalc_prio(run)
+    request.rundb.calc_itp(run)
     request.rundb.buffer(run, True)
     request.rundb.task_time = 0
 
@@ -850,7 +850,7 @@ def tests_view(request):
   for name in ['new_tag', 'new_signature', 'new_options', 'resolved_new',
                'base_tag', 'base_signature', 'base_options', 'resolved_base',
                'sprt', 'num_games', 'spsa', 'tc', 'threads', 'book', 'book_depth',
-               'auto_purge', 'priority', 'internal_priority', 'username', 'tests_repo',
+               'auto_purge', 'priority', 'itp', 'username', 'tests_repo',
                'info']:
 
     if not name in run['args']:
@@ -1007,7 +1007,8 @@ def tests(request):
         else:
           runs[state].append(run)
 
-      runs['pending'].sort(key=lambda run: (run['args']['priority'], run['args']['internal_priority']))
+      runs['pending'].sort(key=lambda run: (run['args']['priority'],
+                                            run['args']['itp'] if 'itp' in run['args'] else 100))
       runs['active'].sort(reverse=True, key=lambda run: ('sprt' in run['args'], run['results_info']['llr'] if 'llr' in run['results_info'] else 0,
                                                        'spsa' not in run['args'], run['results']['wins'] + run['results']['draws'] + run['results']['losses']))
 

--- a/fishtest/tests/test_rundb.py
+++ b/fishtest/tests/test_rundb.py
@@ -8,7 +8,7 @@ import util
 rundb = None
 run_id_stc = None
 run_id = None
-  
+
 class CreateRunDBTest(unittest.TestCase):
 
   def tearDown(self):
@@ -16,7 +16,7 @@ class CreateRunDBTest(unittest.TestCase):
     # Shutdown flush thread:
     rundb.stop()
 
-  def test_10_create_run(self): 
+  def test_10_create_run(self):
     global rundb, run_id, run_id_stc
     rundb= RunDb()
     # STC
@@ -34,10 +34,11 @@ class CreateRunDBTest(unittest.TestCase):
     print(run['tasks'][0])
     self.assertFalse(run['tasks'][0][u'active'])
     run['tasks'][0][u'active'] = True
-    run['tasks'][0][u'worker_info'] = {'username': 'worker1', 'unique_key': 'travis'}
-    
+    run['tasks'][0][u'worker_info'] = {'username': 'worker1', 'unique_key': 'travis', 'concurrency': 1}
+    run['cores'] = 1
+
     print(util.find_run()['args'])
-    
+
   def test_20_update_task(self):
     r= rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-3, 'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker2')
     self.assertEqual(r, {'task_alive': False})


### PR DESCRIPTION
See https://github.com/glinscott/fishtest/pull/458

@ppigazzini @vdv @xoto10 I have tested this locally and it is ready for some more testing and feedback.

This change allocates cores round-robin. It is not completely fair now, because all cores are treated equally, so some workers might get faster cores than others. This is easy to change to Mnps calculation, but because we show allocated cores on the main page this is both simple to code and least confusing for users.

Note that old existing tests will have 3000 as throughput, so until they are finished they will get a large amount of the cores. When merging we should change prio to 100 for old tests