### PR TITLE
Fix Time Control Format.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -182,10 +182,10 @@ def adjust_tc(tc, base_nps, concurrency):
     time_tc = float(chunks[0])
 
   # Rebuild scaled_tc now
-  scaled_tc = '%.2f' % (time_tc * factor)
+  scaled_tc = '%.3f' % (time_tc * factor)
   tc_limit = time_tc * factor * 3
   if increment > 0.0:
-    scaled_tc += '+%.2f' % (increment * factor)
+    scaled_tc += '+%.3f' % (increment * factor)
     tc_limit += increment * factor * 200
   if num_moves > 0:
     scaled_tc = '%d/%s' % (num_moves, scaled_tc)


### PR DESCRIPTION
Looking into a number of timeouts in fishtest run using TC 0.5+0.005,
the workers with problems had an effective TC without increment, while others had one of 0.01:

5e0654a4c13ac2425c4a9e14-74.pgn:[TimeControl "0.55+0.01"]
5e0654a4c13ac2425c4a9e14-76.pgn:[TimeControl "0.36"]

This is due to rounding, with the given format string.

Cutechess allows for 3 digits, use that internally as well.