### PR TITLE
changed geo provider for country lookups

### DIFF
--- a/fishtest/fishtest/api.py
+++ b/fishtest/fishtest/api.py
@@ -13,11 +13,11 @@ def get_flag(request):
 
   # Get country flag ip
   try:
-    FLAG_HOST = 'http://geoip.nekudo.com/api/'
+    FLAG_HOST = 'https://freegeoip.app/json/'
 
     r = requests.get(FLAG_HOST + request.remote_addr, timeout=1.0)
     if r.status_code == 200:
-      country_code = r.json()['country']['code']
+      country_code = r.json()['country_code']
 
       request.userdb.flag_cache.insert({
         'ip': ip,


### PR DESCRIPTION
As stated in #498 the old API endpoint has been declared as outdated and thus been shut down about 2 years ago.
We can use a similar, free provider (it only limits at around 15'000 requests/hour, which we never exceed because of caching) to circumvent that problem.
Please share your thouights about using a third-party service instead of shipping the fishtest server with a prebuilt IP database file. We don't have control of what they want to do with the data we sent them (same goes for the old provider). Both of them have their source-codes publicly available but you never know how they implemented it on their side...

Feel free to change/adjust code if I misinterpreted your contribution guidelines :)