### PR TITLE
Various internal/external cleanups for the SPRT calculator.

### DIFF
--- a/fishtest/fishtest/static/html/SPRTcalculator.html
+++ b/fishtest/fishtest/static/html/SPRTcalculator.html
@@ -10,6 +10,11 @@
               text-align: right;
               margin-right: 0.5em;
             }
+            .chart-div {
+              display:inline-block;
+              width:560px;
+              height:500px;
+            }
         </style>
     </head>
     <body>
@@ -18,27 +23,29 @@
             <form id=parameters class=form-inline>
                 <div class=form-group>
                     <label for=elo-0>Elo0</label>
-                    <input id=elo-0 name=elo-0 class='form-control number'>
+                    <input id=elo-0 class='form-control number'>
                 </div>
                 <div class=form-group>
                     <label for=elo-1>Elo1</label>
-                    <input id=elo-1 name=elo-1 class='form-control number'>
+                    <input id=elo-1 class='form-control number'>
                 </div>
                 <div class=form-group>
                     <label for=draw-ratio>Draw ratio</label>
-                    <input id=draw-ratio name=draw-ratio class='form-control number'>
+                    <input id=draw-ratio class='form-control number'>
                 </div>
                 <div class=form-group>
                     <label for=rms-bias>RMS bias</label>
-                    <input id=rms-bias name=rms-bias class='form-control number'>
+                    <input id=rms-bias class='form-control number'>
                 </div>
                 <div class=form-group style="width:3em;"></div>
-                <input class='btn btn-success' type=button name=calculate value=Calculate onclick="draw_charts();")>
+                <input class='btn btn-success' type=button value=Calculate onclick="draw_charts();")>
             </form>
             <hr>
-            <div id="pass_prob_chart_div" style="float:left;display:inline-block;width:560px;height:500px" onmousemove="show_tooltips_pass(event);" onmouseout="hide_tooltips_pass(event);"></div>
-            <div style="width:1em;"></div>
-            <div id="expected_chart_div" style="display:inline-block;width:560px;height:500px;" onmousemove="show_tooltips_expected(event);" onmouseout="hide_tooltips_expected(event);"></div>
+	    <div id="mouse_screen">
+              <div id="pass_prob_chart_div" class="chart-div" style="float:left;"></div>
+              <div style="width:1em;"></div>
+              <div id="expected_chart_div" class="chart-div"></div>
+	    </div>
             <ul>
               <li> The fields <b>Elo0</b> and <b>Elo1</b> represent the bounds
                 for an
@@ -92,6 +99,5 @@
         <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
         <script src=/js/sprt.js></script>
         <script src=/js/calc.js></script>
-        </div>
     </body>
 </html>

--- a/fishtest/fishtest/static/js/calc.js
+++ b/fishtest/fishtest/static/js/calc.js
@@ -4,15 +4,25 @@ google.charts.load('current', {'packages':['corechart']});
 
 var pass_chart=null;
 var expected_chart=null;
-var N=10;
 
 google.charts.setOnLoadCallback(function(){
     var pass_prob_chart_div=document.getElementById('pass_prob_chart_div');
     pass_chart = new google.visualization.LineChart(pass_prob_chart_div);
     pass_chart.div=pass_prob_chart_div;
+    pass_chart.loaded=false;
+    google.visualization.events.addListener(pass_chart, 'ready', function(){pass_chart.loaded=true;});
+
     var expected_chart_div=document.getElementById('expected_chart_div');
     expected_chart = new google.visualization.LineChart(expected_chart_div);
     expected_chart.div=expected_chart_div;
+    expected_chart.loaded=false;
+    google.visualization.events.addListener(expected_chart, 'ready', function(){expected_chart.loaded=true;});
+
+    var mouse_screen=document.getElementById('mouse_screen')
+    mouse_screen.addEventListener("click",function(e){e.stopPropagation();},true);
+    mouse_screen.addEventListener("mouseover",function(e){e.stopPropagation();},true);
+    mouse_screen.addEventListener('mousemove',handle_tooltips,true);
+    mouse_screen.addEventListener('mouseleave',handle_tooltips,true);
     set_fields();
     draw_charts();
 });
@@ -41,37 +51,35 @@ function draw_charts(){
     }else if(elo1<elo0+0.5){
 	val="The difference between Elo1 and Elo0 must be at least 0.5.";
     }else if((Math.abs(elo0)>10)||Math.abs(elo1)>10){
-	val="Elo values cannot be larger than 10.";
+	val="Elo values must be between -10 and 10.";
     }else if((draw_ratio<=0.0)||(draw_ratio>=1.0)){
 	val="The draw ratio must be strictly between 0.0 and 1.0.";
     }else if(rms_bias<0){
 	val="The RMS bias must be positive.";
-    }
-    var sprt=new Sprt(0.05,0.05,elo0,elo1,draw_ratio,rms_bias);
-    if(sprt.variance<=0){
-	val="The draw ratio and the RMS bias are not compatible.";
+    }else{
+	var sprt=new Sprt(0.05,0.05,elo0,elo1,draw_ratio,rms_bias);
+	if(sprt.variance<=0){
+	    val="The draw ratio and the RMS bias are not compatible.";
+	}
     }
     if(val!=""){
 	alert(val);
 	return;
     }
+    pass_chart.loaded=false;
+    expected_chart.loaded=false;
     var data_pass=[['Elo','Pass Probability']];
     var data_expected=[['Elo','Expected Number of Games']];
-    var hticks=[];
     var d=elo1-elo0;
     var elo_start=Math.floor(elo0-d/3);
     var elo_end=Math.ceil(elo1+d/3);
+    var N=(elo_end-elo_start)<=5?20:10;
+    // pseudo globals
     pass_chart.elo_start=elo_start;
     pass_chart.elo_end=elo_end;
     pass_chart.N=N;
-    expected_chart.elo_start=elo_start;
-    expected_chart.elo_end=elo_end;
-    expected_chart.N=N;
     for (var i=elo_start*N; i<=elo_end*N; i+=1) {
         var elo=i/N;
-	if(i%N==0){
-	    hticks.push(elo);
-	}
 	var c=sprt.characteristics(elo);
 	data_pass.push([elo,{v:c[0],f:(c[0]*100).toFixed(1)+'%'}]);
 	data_expected.push([elo,{v:c[1],f:(c[1]/1000).toFixed(1)+'K'}]);
@@ -79,7 +87,7 @@ function draw_charts(){
     var options={
 	legend: {position: 'none'},
 	curveType: 'function',
-	hAxis: {title: 'Elo',ticks:hticks},
+	hAxis: {title: 'Elo', gridlines: {count:elo_end-elo_start}},
 	vAxis: {title: 'Pass Probability', format:'percent'},
 	tooltip: {trigger: 'selection'},
 	chartArea: {backgroundColor: '#F0F0F0', left:'15%',top:'5%',width:'80%',height:'80%'} 
@@ -91,15 +99,44 @@ function draw_charts(){
     expected_chart.draw(data_table,options);
 }
 
-function show_tooltips(e,chart){
-    var rect=chart.div.getBoundingClientRect();
-    var x = e.clientX - rect.left; //x position within the element.
-    var y = e.clientY - rect.top;
-    var elo=chart.getChartLayoutInterface().getHAxisValue(x);
-    var row=Math.round(chart.N*(elo-chart.elo_start));
-    var max_rows=Math.round(chart.N*(chart.elo_end-chart.elo_start));
-    var d=(chart.elo_end-chart.elo_start)/20;
-    if((elo>=chart.elo_start-d) && (elo<=chart.elo_end+d)){
+function ready(){
+    return pass_chart!=null && pass_chart.loaded && expected_chart!=null && expected_chart.loaded;
+}
+
+function contains(rect,x,y){
+    return x>=rect.left && x<=rect.right && y<=rect.bottom && y>=rect.top;
+}
+
+function handle_tooltips(e){
+    // generic mouse events handler
+    if(!ready()){
+	return;
+    }
+    var x = e.clientX;
+    var y = e.clientY;
+    var rect;
+    var rect_pass=pass_chart.div.getBoundingClientRect();
+    var rect_expected=expected_chart.div.getBoundingClientRect();
+    var chart;
+    if(contains(rect_pass,x,y)){
+	chart=pass_chart;
+	rect=rect_pass;
+    }else if(contains(rect_expected,x,y)){
+	chart=expected_chart;
+	rect=rect_expected;
+    }else{
+	pass_chart.setSelection([]);
+	expected_chart.setSelection([]);
+	return;
+    }
+    var elo=chart.getChartLayoutInterface().getHAxisValue(x-rect.left);
+    var N=pass_chart.N;
+    var elo_start=pass_chart.elo_start;
+    var elo_end=pass_chart.elo_end;
+    var row=Math.round(N*(elo-elo_start));
+    var max_rows=Math.round(N*(elo_end-elo_start));
+    var d=(elo_end-elo_start)/20;
+    if((elo>=elo_start-d) && (elo<=elo_end+d)){
 	row=Math.max(row,0);
 	row=Math.min(row,max_rows);
 	pass_chart.setSelection([{'row':row, 'column':1}]);
@@ -108,30 +145,5 @@ function show_tooltips(e,chart){
 	pass_chart.setSelection([]);
 	expected_chart.setSelection([]);
     }
-}
-
-function show_tooltips_pass(e){
-    show_tooltips(e,pass_chart);
-}
-
-function show_tooltips_expected(e){
-    show_tooltips(e,expected_chart);
-}
-
-function hide_tooltips(e,chart){
-    var rect=chart.div.getBoundingClientRect();
-    var x=e.clientX;
-    var y=e.clientY;
-    if(x<rect.left || x>rect.right || y>rect.bottom || y<rect.top){
-	pass_chart.setSelection([]);
-	expected_chart.setSelection([]);
-    }
-}
-
-function hide_tooltips_pass(e){
-    hide_tooltips(e,pass_chart);
-}
-
-function hide_tooltips_expected(e){
-    hide_tooltips(e,expected_chart);
+    e.stopPropagation();
 }


### PR DESCRIPTION
As usual the new version is here.

http://hardy.uhasselt.be/Toga/SPRTcalculator.html

**Changes**

There are now minor and major vertical grid lines.

The Elo increment used for graph drawing is now a bit adaptive. This gives smoother tooltip behaviour for small elo differences.

All mouse events are now captured by a div specially created for that purpose. The GC default event handlers are thus completely disabled. This removes some prior artifacts, e.g. when the user clicked on the graphs.

Events are now disabled until the charts are fully drawn.

In general event handling is greatly simplified internally.

Some html cleanup. In particular the name attribute of the input fields is not used and thus was removed. Most inline styling was removed. A spurious ```</div>``` was removed.