### PR TITLE
A few minor cleanups in the SPRT calculator.

### DIFF
--- a/fishtest/fishtest/static/html/SPRTcalculator.html
+++ b/fishtest/fishtest/static/html/SPRTcalculator.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <title>Chess SPRT Calculator</title>
@@ -11,7 +11,7 @@
               margin-right: 0.5em;
             }
             .chart-div {
-              display:inline-block;
+	      display:inline-block;
               width:560px;
               height:500px;
             }
@@ -38,12 +38,11 @@
                     <input id=rms-bias class='form-control number'>
                 </div>
                 <div class=form-group style="width:3em;"></div>
-                <input class='btn btn-success' type=button value=Calculate onclick="draw_charts();")>
+                <input class='btn btn-success' type=button value=Calculate onclick="draw_charts();">
             </form>
             <hr>
 	    <div id="mouse_screen">
-              <div id="pass_prob_chart_div" class="chart-div" style="float:left;"></div>
-              <div style="width:1em;"></div>
+              <div id="pass_prob_chart_div" class="chart-div"></div>
               <div id="expected_chart_div" class="chart-div"></div>
 	    </div>
             <ul>
@@ -96,7 +95,7 @@
             </ul>
         </div>
         <script src=https://cdnjs.cloudflare.com/ajax/libs/js-url/1.8.4/url.min.js></script>
-        <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+        <script src=https://www.gstatic.com/charts/loader.js></script>
         <script src=/js/sprt.js></script>
         <script src=/js/calc.js></script>
     </body>

--- a/fishtest/fishtest/static/js/calc.js
+++ b/fishtest/fishtest/static/js/calc.js
@@ -109,6 +109,7 @@ function contains(rect,x,y){
 
 function handle_tooltips(e){
     // generic mouse events handler
+    e.stopPropagation();
     if(!ready()){
 	return;
     }
@@ -145,5 +146,4 @@ function handle_tooltips(e){
 	pass_chart.setSelection([]);
 	expected_chart.setSelection([]);
     }
-    e.stopPropagation();
 }


### PR DESCRIPTION
Fixes an html error (apparently inconsequential) and some warnings found by https://validator.w3.org/ .

Fixes an inconsistency. I was using both float:left and display:inline-block for the char divs. They serve the same purpose. So now I only use display:inline-block which is the more modern solution.

Fixes a small, probably untriggerable, race condition in event handling. 

As usual the latest version is here 

http://hardy.uhasselt.be/Toga/SPRTcalculator.html

Externally it is indistinguishable from the previous version (or should be).

Future plans: when I find the time I will add a curve with the 95% quantile...