### PR TITLE
Change the stats package to use relative imports.

### DIFF
--- a/fishtest/fishtest/stats/LLRcalc.py
+++ b/fishtest/fishtest/stats/LLRcalc.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 import math,sys,copy
 
-from fishtest.stats.brentq import brentq
+from .brentq import brentq
 
 def MLE(pdf,s):
     """
@@ -164,5 +164,3 @@ elo0,elo1 are in logistic elo.
     # In practice it appears to work well in general.
     overshoot=0.583*(s1-s0)/math.sqrt(var)
     return N*LLR(pdf,s0,s1),overshoot
-
-

--- a/fishtest/fishtest/stats/brentq.py
+++ b/fishtest/fishtest/stats/brentq.py
@@ -155,11 +155,3 @@ def brentq(f, xa, xb, xtol=EPS, epsilon=1e-6, max_iter=500):
             return result(xcur, fcur, i, fcalls, True, "convergence")
 
     return result(xcur, fcur, i + 1, fcalls, False, "iterations")
-
-if __name__=='__main__':
-    import math
-    f=lambda x:math.cos(x)-x
-    print(brentq(f,0,math.pi/2))
-
-
-    

--- a/fishtest/fishtest/stats/brownian.py
+++ b/fishtest/fishtest/stats/brownian.py
@@ -116,7 +116,3 @@ robust we use the asymptotic development of Phi.
         else:
             t3=math.exp(2*gamma*b)*Phi(zb)
         return t1+t2-t3
-
-    
-
-

--- a/fishtest/fishtest/stats/sprt.py
+++ b/fishtest/fishtest/stats/sprt.py
@@ -3,9 +3,9 @@ from __future__ import division
 import math,copy
 import argparse
 
-from fishtest.stats.brownian import Brownian
-from fishtest.stats.brentq import brentq
-from fishtest.stats import LLRcalc
+from .brownian import Brownian
+from .brentq import brentq
+from . import LLRcalc
 
 class sprt:
     def __init__(self,alpha=0.05,beta=0.05,elo0=0,elo1=5):
@@ -84,38 +84,3 @@ less than p.
         ret['LOS']=self.outcome_prob(0)
         ret['LLR']=self.llr
         return ret
-
-if __name__=='__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--alpha",help="probability of a false positve",type=float,default=0.05)
-    parser.add_argument("--beta" ,help="probability of a false negative",type=float,default=0.05)
-    parser.add_argument("--elo0", help="H0 (expressed in LogisticElo)",type=float,default=0.0)
-    parser.add_argument("--elo1", help="H1 (expressed in LogisticElo)",type=float,default=5.0)
-    parser.add_argument("--level",help="confidence level",type=float,default=0.95)
-    parser.add_argument("--results", help="trinomial of pentanomial frequencies, low to high",nargs="*",type=int, required=True)
-    args=parser.parse_args()
-    results=args.results
-    if len(results)!=3 and len(results)!=5:
-        parser.error("argument --results: expected 3 or 5 arguments")
-    alpha=args.alpha
-    beta=args.beta
-    elo0=args.elo0
-    elo1=args.elo1
-    p=1-args.level
-    s=sprt(alpha=alpha,beta=beta,elo0=elo0,elo1=elo1)
-    s.set_state(results)
-    a=s.analytics(p)
-    print("Design parameters")
-    print("=================")
-    print("False positives             :  %4.2f%%" % (100*alpha,))
-    print("False negatives             :  %4.2f%%" % (100*beta,) )
-    print("[Elo0,Elo1]                 :  [%.2f,%.2f]"  % (elo0,elo1))
-    print("Confidence level            :  %4.2f%%" % (100*(1-p),))
-    print("Estimates")
-    print("=========")
-    print("Elo                         :  %.2f"    % a['elo'])
-    print("Confidence interval         :  [%.2f,%.2f] (%4.2f%%)"  % (a['ci'][0],a['ci'][1],100*(1-p)))
-    print("LOS                         :  %4.2f%%" % (100*a['LOS'],))
-    print("Context")
-    print("=======")
-    print("LLR [u,l]                   :  %.2f %s [%.2f,%.2f]"       % (a['LLR'], '(clamped)' if a['clamped'] else '',a['a'],a['b']))

--- a/fishtest/fishtest/stats/stat_util.py
+++ b/fishtest/fishtest/stats/stat_util.py
@@ -2,9 +2,9 @@ from __future__ import division
 
 import math,copy
 
-from fishtest.stats import LLRcalc
-from fishtest.stats import sprt
-from fishtest.stats import brownian
+from . import LLRcalc
+from . import sprt
+from . import brownian
 
 def phi(q):
   """
@@ -219,34 +219,3 @@ lower_bound/upper_bound - SPRT bounds
     result['state'] = 'accepted'
 
   return result
-
-if __name__ == "__main__":
-  # unit tests
-  print('SPRT tests')
-  print(SPRT({'wins': 0, 'losses': 0, 'draws': 0}, 0, 0.05, 5, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 10, 'losses': 0, 'draws': 0}, 0, 0.05, 5, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 100, 'losses': 0, 'draws': 0}, 0, 0.05, 5, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 10, 'losses': 0, 'draws': 20}, 0, 0.05, 5, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 10, 'losses': 1, 'draws': 20}, 0, 0.05, 5, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 5019, 'losses': 5026, 'draws': 15699}, 0, 0.05, 5, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 1450, 'losses': 1500, 'draws': 4000}, 0, 0.05, 6, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 716, 'losses': 591, 'draws': 2163}, 0, 0.05, 6, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 13543,'losses': 13624, 'draws': 34333}, -3, 0.05, 1, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 13543,'losses': 13624, 'draws': 34333, 'pentanomial':[1187, 7410, 13475, 7378, 1164]}, -3, 0.05, 1, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 65388,'losses': 65804, 'draws': 56553}, -3, 0.05, 1, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 65388,'losses': 65804, 'draws': 56553, 'pentanomial':[10789, 19328, 33806, 19402, 10543]}, -3, 0.05, 1, 0.05, elo_model='BayesElo'))
-  print(SPRT({'wins': 65388,'losses': 65804, 'draws': 56553, 'pentanomial':[10789, 19328, 33806, 19402, 10543]}, -3, 0.05, 1, 0.05, elo_model='logistic'))
-  print('elo tests')
-  print(SPRT_elo({'wins': 0, 'losses': 0, 'draws': 0}, elo0=0,  elo1=5, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 10, 'losses': 0, 'draws': 0}, elo0=0,  elo1=5, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 100, 'losses': 0, 'draws': 0}, elo0=0,  elo1=5, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 10, 'losses': 0, 'draws': 20}, elo0=0,  elo1=5, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 10, 'losses': 1, 'draws': 20}, elo0=0,  elo1=5, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 5019, 'losses': 5026, 'draws': 15699}, elo0=0,  elo1=5, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 1450, 'losses': 1500, 'draws': 4000}, elo0=0,  elo1=6, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 716, 'losses': 591, 'draws': 2163}, elo0=0,  elo1=6, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 13543,'losses': 13624, 'draws': 34333}, elo0=-3,  elo1=1, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 13543,'losses': 13624, 'draws': 34333, 'pentanomial':[1187, 7410, 13475, 7378, 1164]}, elo0=-3,  elo1=1, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 65388,'losses': 65804, 'draws': 56553}, elo0=-3,  elo1=1, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 65388,'losses': 65804, 'draws': 56553, 'pentanomial':[10789, 19328, 33806, 19402, 10543]}, elo0=-3,  elo1=1, elo_model='BayesElo'))
-  print(SPRT_elo({'wins': 65388,'losses': 65804, 'draws': 56553, 'pentanomial':[10789, 19328, 33806, 19402, 10543]}, elo0=-3,  elo1=1, elo_model='logistic'))


### PR DESCRIPTION
Adresses #521.

Currently when doing ```import stats```  the whole fishtest framework is imported (causing a noticeable delay) even though ```stats``` does not depend on this. I feel this is not right. I feel that ```stats``` should be a self contained relocatable package (except for using system libraries). 


