### PR TITLE
Set book default to noob_3moves.pgn

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -146,7 +146,7 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
   <div class="control-group">
     <label class="control-label">Book:</label>
     <div class="controls">
-      <input name="book" value="${args.get('book', 'noob_3moves.epd')}">
+      <input name="book" value="${args.get('book', 'noob_3moves.pgn')}">
     </div>
   </div>
   <div class="control-group">


### PR DESCRIPTION
Old versions of cutechess-cli have problems with opening books in EPD format, so switch to book in PGN format as default in fishtest.

See: https://groups.google.com/forum/?fromgroups=#!topic/fishcooking/hcGWL4mXFGw