### PR TITLE
Fix the worker update process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ worker/custom_make.txt
 worker/env
 worker/fish.exit
 worker/fishtest.cfg
+worker/_testing_*
 worker/testing

--- a/worker/test_worker.py
+++ b/worker/test_worker.py
@@ -48,7 +48,7 @@ class workerTest(unittest.TestCase):
   def test_updater(self):
     file_list = updater.update(restart=False, test=True)
     print(file_list)
-    self.assertTrue('worker' in file_list)
+    self.assertTrue('worker.py' in file_list)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Update only the worker files so that the update process will work
also with a custom worker folder name.
Enforce the download of the lastest version of cutechess-cli, books etc.
renaming the "testing" folder with a timestamp. Keep the lastest 3 backups
of the "testing" folder to save eventual custom user files.
Thanks to @vondele for some ideas and code.