### PR TITLE
Adjust bounds

### DIFF
--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -62,7 +62,7 @@
           <li><a href="/users/monthly">Top Month</a></li>
           <li><a href="/actions">Actions</a></li>
           <li><a href="https://github.com/glinscott/fishtest/wiki" target="_blank">Wiki</a></li>
-          <li><a href="/html/SPRTcalculator.html?elo-0=-1&elo-1=3&draw-ratio=0.61&rms-bias=0" target="_blank">SPRT Calc</a></li>
+          <li><a href="/html/SPRTcalculator.html?elo-0=-0.5&elo-1=1.5&draw-ratio=0.61&rms-bias=0" target="_blank">SPRT Calc</a></li>
           <li class="nav-header">Links</li>
           <li><a href="https://github.com/glinscott/fishtest" target="_blank">Github</a></li>
           <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/fishcooking" target="_blank">Forum</a></li>

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -64,8 +64,8 @@
     <label class="control-label">SPRT bounds:</label>
     <div class="controls">
       <select name="bounds">
-        <option value="standard STC">Standard STC {-1,3}</option>
-        <option value="standard LTC">Standard LTC {0,2}</option>
+        <option value="standard STC">Standard STC {-0.5,1.5}</option>
+        <option value="standard LTC">Standard LTC {0.25,1.75}</option>
         <option value="regression">Non-regression {-1.5,0.5}</option>
         <option value="simplification">Simplification {-1.5,0.5}</option>
         <option value="custom">Custom bounds...</option>
@@ -210,8 +210,8 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
 $(function() {
   var update_bounds = function() {
     var bounds = $('select[name=bounds]').val();
-    if (bounds == 'standard STC') { $('input[name=sprt_elo0]').val('-1.0'); $('input[name=sprt_elo1]').val('3.0'); }
-    if (bounds == 'standard LTC') { $('input[name=sprt_elo0]').val('0.0'); $('input[name=sprt_elo1]').val('2.0'); }
+    if (bounds == 'standard STC') { $('input[name=sprt_elo0]').val('-0.5'); $('input[name=sprt_elo1]').val('1.5'); }
+    if (bounds == 'standard LTC') { $('input[name=sprt_elo0]').val('0.25'); $('input[name=sprt_elo1]').val('1.75'); }
     if (bounds == 'regression') { $('input[name=sprt_elo0]').val('-1.5'); $('input[name=sprt_elo1]').val('0.5'); }
     if (bounds == 'simplification') { $('input[name=sprt_elo0]').val('-1.5'); $('input[name=sprt_elo1]').val('0.5'); }
     if (bounds == 'custom')
@@ -236,7 +236,7 @@ $(function() {
     $('input[name=tc]').val('10+0.1');
     $('input[name=new-options]').val('Hash=16');
     $('input[name=base-options]').val('Hash=16');
-    if ($('input[name=sprt_elo0]').val() == '0.0' && $('input[name=sprt_elo1]').val() == '2.0')
+    if ($('input[name=sprt_elo0]').val() == '0.25' && $('input[name=sprt_elo1]').val() == '1.75')
       { $('select[name=bounds]').val('standard STC'); update_bounds(); }
   });
 
@@ -244,7 +244,7 @@ $(function() {
     $('input[name=tc]').val('60+0.6');
     $('input[name=new-options]').val('Hash=64');
     $('input[name=base-options]').val('Hash=64');
-    if ($('input[name=sprt_elo0]').val() == '-1.0' && $('input[name=sprt_elo1]').val() == '3.0')
+    if ($('input[name=sprt_elo0]').val() == '-0.5' && $('input[name=sprt_elo1]').val() == '1.5')
       { $('select[name=bounds]').val('standard LTC'); update_bounds(); }
   });
 });


### PR DESCRIPTION
as per discussion in https://github.com/official-stockfish/Stockfish/issues/2531

introduce new bounds:

standard STC {-0.5, 1.5} -> 50% pass rate at 0.5 Elo (100k games), 1% pass rate at -1.0 Elo
standard LTC {0.25, 1.75} -> 50% pass rate at 1.0 Elo (137k games), 0.3% pass rate at -0.5 Elo
simplification STC/LTC {-1.5, 0.5} unmodified.