### PR TITLE
Better overshoot correction.

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -498,11 +498,7 @@ class RunDb:
       sprt = run['args']['sprt']
       sprt_stats = fishtest.stats.stat_util.SPRT(
             self.get_results(run, False),
-            elo0=sprt['elo0'],
-            alpha=sprt['alpha'],
-            elo1=sprt['elo1'],
-            beta=sprt['beta'],
-            elo_model=sprt.get('elo_model', 'BayesElo')
+            sprt
             )
       if sprt_stats['finished']:
         run['args']['sprt']['state'] = sprt_stats['state']

--- a/fishtest/fishtest/stats/LLRcalc.py
+++ b/fishtest/fishtest/stats/LLRcalc.py
@@ -164,10 +164,6 @@ elo0,elo1 are in logistic elo.
 """
     s0,s1=[L_(elo) for elo in (elo0,elo1)]
     N,pdf=results_to_pdf(results)
-    s,var=stats(pdf)
-    # The well-known universal constant 0.583 is for normal increments.
-    # In practice it appears to work well in general.
-    overshoot=0.583*(s1-s0)/math.sqrt(var)
-    return N*LLR(pdf,s0,s1),overshoot
+    return N*LLR(pdf,s0,s1)
 
 

--- a/fishtest/fishtest/templates/tests_stats.mak
+++ b/fishtest/fishtest/templates/tests_stats.mak
@@ -56,6 +56,7 @@
       elo0=run['args']['sprt']['elo0']
       elo1=run['args']['sprt']['elo1']
       elo_model=run['args']['sprt'].get('elo_model','BayesElo')
+      o=run['args']['sprt'].get('overshoot',None)
       %>
       <table class="table table-condensed">
 	<tr><td>Alpha</td><td>${alpha}</td></tr>
@@ -122,7 +123,12 @@
 	    a5=sp.analytics()
 	    LLR5_l=a5['a']
 	    LLR5_u=a5['b']
-	    LLR5,overshoot5=fishtest.stats.LLRcalc.LLR_logistic(lelo0,lelo1,results5_)
+	    LLR5=fishtest.stats.LLRcalc.LLR_logistic(lelo0,lelo1,results5_)
+	    o0=0
+	    o1=0
+	    if o!=None:
+	       o0=-o['sq0']/o['m0']/2 if o['m0']!=0 else 0
+	       o1=o['sq1']/o['m1']/2 if o['m1']!=0 else 0
 	    elo5_l=a5['ci'][0]
 	    elo5_u=a5['ci'][1]
 	    elo5=a5['elo']
@@ -183,7 +189,7 @@
 	<tr><td>Sensitivity ((score-0.5)/stdev)/game</td><td>${"%.5f [%.5f, %.5f]"%(sens5_per_game,sens5_per_game_l,sens5_per_game_u)}</td></tr>
 % endif  ## has_sprt
 % if has_sprt:
-	<tr><td>Expected overshoot</td><td>${"%.5f"%overshoot5}</td></tr>
+	<tr><td>Expected overshoot [H0,H1]</td><td>${"[%.5f, %.5f]"%(o0,o1)}</td></tr>
 % endif  ## has_sprt
       </table>
 % endif  ## has_pentanomial
@@ -222,13 +228,12 @@
 		 RMS_bias=var_diff**.5 if var_diff>=0 else 0
 		 RMS_bias_elo=fishtest.stats.stat_util.elo(0.5+RMS_bias)
 	 if has_sprt:
-	 	 sp_=fishtest.stats.stat_util.SPRT(R3_,elo0,alpha,elo1,beta,elo_model=elo_model)
-	 	 LLR3=sp_['llr']
-	 	 LLR3_l=sp_['lower_bound']
-		 LLR3_u=sp_['upper_bound']
-	 	 sp=fishtest.stats.sprt.sprt(alpha=alpha,beta=beta,elo0=lelo0,elo1=lelo1)
-	 	 sp.set_state(results3_)
-	 	 a3=sp.analytics()
+		 sp=fishtest.stats.sprt.sprt(alpha=alpha,beta=beta,elo0=lelo0,elo1=lelo1)
+		 sp.set_state(results3_)
+		 a3=sp.analytics()
+		 LLR3_l=a3['a']
+		 LLR3_u=a3['b']
+		 LLR3=fishtest.stats.LLRcalc.LLR_logistic(lelo0,lelo1,results3_)
 	 	 elo3_l=a3['ci'][0]
 	 	 elo3_u=a3['ci'][1]
 	 	 elo3=a3['elo']

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -474,7 +474,15 @@ def validate_form(request):
       'alpha': 0.05,
       'elo1': float(request.POST['sprt_elo1']),
       'beta': 0.05,
-      'elo_model': 'logistic'
+      'elo_model': 'logistic',
+      'overshoot': {'last_update'    :0,
+                    'skipped_updates':0,
+                    'ref0'           :0,
+                    'm0'             :0,
+                    'sq0'            :0,
+                    'ref1'           :0,
+                    'm1'             :0,
+                    'sq1'            :0}
     }
     # Limit on number of games played.
     # Shouldn't be hit in practice as long as it is larger than > ~200000
@@ -742,13 +750,7 @@ def format_results(run_results, run):
     sprt = run['args']['sprt']
     state = sprt.get('state', '')
     elo_model = sprt.get('elo_model', 'BayesElo')
-    stats = fishtest.stats.stat_util.SPRT(run_results,
-                                          elo0=sprt['elo0'],
-                                          alpha=sprt['alpha'],
-                                          elo1=sprt['elo1'],
-                                          beta=sprt['beta'],
-                                          elo_model=elo_model
-                                          )
+    stats = fishtest.stats.stat_util.SPRT(run_results,sprt)
     result['llr'] = stats['llr']
     if elo_model == 'BayesElo':
       result['info'].append('LLR: %.2f (%.2lf,%.2lf) [%.2f,%.2f]'


### PR DESCRIPTION
    The theoretical properties of an SPRT are established under the
    assumption that updates are continuous.
    
    To have accurate agreement with the predictions, when the updates are
    discrete, one has to estimate the expected "overshoot" and terminate
    the SPRT a bit early, accordingly.  Unfortunately, to the best of our
    knowledge, overshoot estimation is (surprisingly) computationally expensive.
    
    Moreover in the case of a GSPRT there is the added complication of
    unknown parameters and these have to be continuously estimated from
    the sample. This more or less means that the expected overshoot
    estimation has to be performed after every update, which is
    prohibitively expensive (IMHO, doing it only when we are "close" to
    one of the boundaries would lead to messy and possibly fragile code).
    
    A theoretical formula for the expected overshoot is: Siegmund -
    Sequential Analysis - Corollary 8.33. Like other such formulas, it is
    difficult to evaluate theoretically, but the result can be very easily
    estimated, with only a few lines of code, from the ongoing test itself.
    This "dynamic overshoot estimation" is implemented in this commit.
    
    That this works very well can be verified by simulation. A multi-threaded
    simulator written in C can be found here.
    
    https://github.com/vdbergh/simul
    
    Example:
    
    $ ./simul --elo0 0 --elo1 10 --elo 0
    
    yields
    
    ...
    sims=20001904 pass=0.050322[0.050175,0.050469] ...
    ...
    
    whereas
    
    $ ./simul --elo0 0 --elo1 10 --elo 0 --noovcor
    
    yields
    
    ...
    sims=20000943 pass=0.048530[0.048385,0.048674] ...
    ...
    
    (the confidence interval is 3 sigma).
    
    Obviously the version with overshoot correction is much more accurate.
    
    Currently Fishtest uses an approximate formula for overshoot
    correction which is actually not even asymptotically correct, although
    it works well for small Elo differences. However for larger Elo
    differences it starts to break down. This is undesirable as people may
    copy the Fishtest code and apply it in a different context.
    
    In the implementation the SPRT() function in stat_util.py now takes an
    sprt dictionary as argument. This dictionary may optionally contain a
    subdictionary with dynamic overshoot data which is updated in-place.
    It is assumed that SPRT() is called after each finished game (trinomial)
    or game pair (pentanomial). But calling SPRT() multiple times with
    the same parameters is safe and skipped updates are also handled sensibly.
    After a purge the overshoot data is deleted. Deleting the overshoot data
    is always safe as it simply means that the test is carried out with error
    probabilities that are slightly smaller than the assigned ones.
    
    The actual overshoot estimates can be found on the raw statistics
    page. Note that the estimate corresponding to the test outcome (H0 or H1)
    is typically the most accurate.
