### PR TITLE
Fix #537: cutechess warning for opening repetitions

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -550,7 +550,7 @@ def run_games(worker_info, password, remote, run, task_id):
 
   while games_remaining > 0:
     # Run cutechess-cli binary
-    cmd = [ cutechess, '-repeat', '-rounds', str(int(games_to_play)), '-tournament', 'gauntlet'] + pgnout + \
+    cmd = [ cutechess, '-repeat', '-rounds', str(int(games_to_play/2)), '-games', ' 2', '-tournament', 'gauntlet'] + pgnout + \
           ['-site', 'https://tests.stockfishchess.org/tests/view/' + run['_id']] + \
           ['-event', 'Batch %d: %s vs %s' % (task_id, make_player('new_tag'), make_player('base_tag'))] + \
           ['-srand', "%d" % struct.unpack("<L", os.urandom(struct.calcsize("<L")))] + \

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -27,7 +27,7 @@ from updater import update
 from datetime import datetime
 from os import path
 
-WORKER_VERSION = 71
+WORKER_VERSION = 72
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 


### PR DESCRIPTION
Fix the "Warning: 2 opening repetitions vs 1 games per encounter"
Also raise the worker version to 72 (worker side).