### PR TITLE
Queue worker updates if the server is down (worker update)

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -272,8 +272,6 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
   global old_stats
   rounds={}
 
-  failed_updates = 0
-
   q = Queue()
   t = threading.Thread(target=enqueue_output, args=(p.stdout, q))
   t.daemon = True
@@ -325,27 +323,29 @@ def run_game(p, remote, result, spsa, spsa_tuning, tc_limit):
         spsa['losses'] = wld[1]
         spsa['draws'] = wld[2]
 
-      try:
-        t0 = datetime.datetime.utcnow()
-        req = requests.post(remote + '/api/update_task', data=json.dumps(result), headers={'Content-type': 'application/json'}, timeout=HTTP_TIMEOUT).json()
-        failed_updates = 0
-        print("Task updated successfully in %ss" % ((datetime.datetime.utcnow() - t0).total_seconds()))
-
-        if not req['task_alive']:
-          # This task is no longer neccesary
-          print('Server told us task is no longer needed')
-          kill_process(p)
-          return req
-
-      except:
-        sys.stderr.write('Exception from calling update_task:\n')
-        traceback.print_exc(file=sys.stderr)
-        failed_updates += 1
-        if failed_updates > 5:
-          print('Too many failed update attempts')
-          kill_process(p)
+      update_succeeded=False
+      for _ in range(0,5):
+        try:
+          t0 = datetime.datetime.utcnow()
+          req = requests.post(remote + '/api/update_task', data=json.dumps(result), headers={'Content-type': 'application/json'}, timeout=HTTP_TIMEOUT).json()
+          print("Task updated successfully in %ss" % ((datetime.datetime.utcnow() - t0).total_seconds()))
+          if not req['task_alive']:
+            # This task is no longer neccesary
+            print('Server told us task is no longer needed')
+            kill_process(p)
+            return req
+          update_succeeded=True
           break
+        except Exception as e:
+          sys.stderr.write('Exception from calling update_task:\n')
+          print(e)
+#          traceback.print_exc(file=sys.stderr)
         time.sleep(HTTP_TIMEOUT)
+
+      if not update_succeeded:
+        print('Too many failed update attempts')
+        kill_process(p)
+        break
 
     pentanomial=update_pentanomial(line,rounds)
     result['stats']['pentanomial']=pentanomial
@@ -390,7 +390,7 @@ def launch_cutechess(cmd, remote, result, spsa_tuning, games_to_play, tc_limit):
 
   try:
     return run_game(p, remote, result, spsa, spsa_tuning, tc_limit)
-  except:
+  except Exception as e:
     traceback.print_exc(file=sys.stderr)
     try:
       print('Exception running games')

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -107,9 +107,10 @@ def worker(worker_info, password, remote):
     t0 = datetime.utcnow()
     req = requests.post(remote + '/api/request_task', data=json.dumps(payload), headers={'Content-type': 'application/json'}, timeout=HTTP_TIMEOUT)
     req = json.loads(req.text)
-  except:
+  except Exception as e:
     sys.stderr.write('Exception accessing host:\n')
-    traceback.print_exc()
+    print(e)
+#    traceback.print_exc()
     time.sleep(random.randint(10,60))
     return
 
@@ -155,9 +156,10 @@ def worker(worker_info, password, remote):
           payload['pgn'] = base64.b64encode(zlib.compress(data.encode('utf-8'))).decode()
           print('Uploading compressed PGN of %d bytes' % (len(payload['pgn'])))
           requests.post(remote + '/api/upload_pgn', data=json.dumps(payload), headers={'Content-type': 'application/json'}, timeout=HTTP_TIMEOUT)
-        except:
+        except Exception as e:
           sys.stderr.write('\nException PGN upload:\n')
-          traceback.print_exc()
+          print(e)
+#          traceback.print_exc()
     try:
       os.remove(pgn_file)
     except:


### PR DESCRIPTION
Dropping worker updates violates the SPRT contract which says
that updates should occur after every game pair.

Also: for connection related exceptions print the exception instead
of the full backtrace.

This issue came up while testing. The backtraces are too verbose
as they refer to the inner workings of things like urllib etc... The
exceptions themselves seem to contain exactly the right amount
of information.

The effect of this PR can be seen using #536. With this PR the
overshoot data should no longer be deleted after a server restart.
This was verified with some local testing.