### PR TITLE
Remove some remnants of the old sprt handling.

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -325,9 +325,6 @@ class RunDb:
     if has_pentanomial:
       results['pentanomial'] = pentanomial
 
-    if 'sprt' in run['args'] and 'state' in run['args']['sprt']:
-      results['sprt'] = run['args']['sprt']['state']
-
     run['results_stale'] = False
     run['results'] = results
     if save_run:
@@ -346,11 +343,8 @@ class RunDb:
     if 'sprt' not in run['args']:
       itp *= 0.5
     else:
-      results = self.get_results(run)
-      run['results_info'] = format_results(results, run)
-      if 'llr' in run['results_info']:
-        llr = run['results_info']['llr']
-        itp *= (5 + llr) / 5
+      llr = run['args']['sprt'].get('llr',0)
+      itp *= (5 + llr) / 5
     run['args']['itp'] = itp
 
   def sum_cores(self, run):

--- a/fishtest/fishtest/stats/stat_util.py
+++ b/fishtest/fishtest/stats/stat_util.py
@@ -162,7 +162,7 @@ drawelo is estimated "out of sample".
 
 
 def SPRT(alpha=0.05,beta=0.05,elo0=None,elo1=None,elo_model='logistic'):
-  """ Constructuctor for the "sprt object" """
+  """ Constructor for the "sprt object" """
   return {'alpha'       : alpha,
           'beta'        : beta,
           'elo0'        : elo0,
@@ -217,7 +217,7 @@ R['pentanomial'] contains the pentanomial frequencies
 elo_model can be either 'BayesElo' or 'logistic'
 """
 
-  # the next two lines are for backward compatibility
+  # the next two lines are superfluous, but necessary for backward compatibility
   sprt['lower_bound']=math.log(sprt['beta']/(1-sprt['alpha']))
   sprt['upper_bound']=math.log((1-sprt['beta'])/sprt['alpha'])
   

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -660,7 +660,8 @@ def purge_run(rundb, run):
 
     run['finished'] = False
     if 'sprt' in run['args'] and 'state' in run['args']['sprt']:
-      del run['args']['sprt']['state']
+      fishtest.stats.stat_util.update_SPRT(results,run['args']['sprt'])
+      run['args']['sprt']['state']=''
 
     rundb.buffer(run, True)
 
@@ -742,7 +743,6 @@ def format_results(run_results, run):
     elo_model = sprt.get('elo_model', 'BayesElo')
     if not 'llr' in sprt:  # legacy
       fishtest.stats.stat_util.update_SPRT(run_results,sprt)
-    result['llr'] = sprt['llr']
     if elo_model == 'BayesElo':
       result['info'].append('LLR: %.2f (%.2lf,%.2lf) [%.2f,%.2f]'
                             % (sprt['llr'],
@@ -1132,7 +1132,7 @@ def tests(request):
                                             if 'itp' in run['args'] else 100))
       runs['active'].sort(reverse=True, key=lambda run: (
           'sprt' in run['args'],
-          run['results_info']['llr'] if 'llr' in run['results_info'] else 0,
+          run['args'].get('sprt',{}).get('llr',0),
           'spsa' not in run['args'],
           run['results']['wins'] + run['results']['draws']
           + run['results']['losses']))


### PR DESCRIPTION
The commit 926b8853c0a8c1fc7 appears to have cured the problem of disappearing overshoot data. So it seems to be the right approach to keeping state across updates. In fact I now realize it is similar to how spsa works (Instead of an sprt object there is an spsa object, both represented by dictionaries of course, for easy conversion to json). It could be the model for new types of tests.

This commit removes some remnants of the old sprt handling. In particular it fixes a small bug. Currently a ghost (empty) sprt item is left in the results dictionary after the test is finished. This is innocent of course, but not nice.  