### PR TITLE
Move "Test repo" field right under "Test branch"

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -21,6 +21,12 @@
     </div>
   </div>
   <div class="control-group">
+    <label class="control-label">Test repo:</label>
+    <div class="controls">
+      <input name="tests-repo" value="${args.get('tests_repo', tests_repo)}" ${'readonly' if re_run else ''}>
+    </div>
+  </div>
+  <div class="control-group">
     <label class="control-label">Test options:</label>
     <div class="controls">
     <input name="new-options" value="${args.get('new_options', 'Hash=16')}">
@@ -179,12 +185,6 @@ Cowardice,150,0,200,10,0.0020"""})['raw_params']}</textarea>
         <option selected="selected" value="100">100%</option>
         <option style="color:red" value="200">200%</option>
       </select>
-    </div>
-  </div>
-  <div class="control-group">
-    <label class="control-label">Test Repo:</label>
-    <div class="controls">
-      <input name="tests-repo" value="${args.get('tests_repo', tests_repo)}" ${'readonly' if re_run else ''}>
     </div>
   </div>
   <div class="control-group">


### PR DESCRIPTION
The test repo and test branch fields are closely related. As reported in a separate issue, I also think this is a UI problem for first-time test submitters. Fixes https://github.com/glinscott/fishtest/issues/340

---
This is how the top of the "Create new test" page will look:

![image](https://user-images.githubusercontent.com/208617/78503671-1dcaf100-7736-11ea-985f-1c03ba7d0a99.png)

