### PR TITLE
Count games updated instead of estimating.

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -25,6 +25,7 @@ def main(global_config, **settings):
     event.request.rundb = rundb
     event.request.userdb = rundb.userdb
     event.request.actiondb = rundb.actiondb
+    event.request.gendb = rundb.gendb
 
   def add_renderer_globals(event):
     event['h'] = helpers

--- a/fishtest/fishtest/gendb.py
+++ b/fishtest/fishtest/gendb.py
@@ -1,0 +1,21 @@
+# GenDb is used to store general name/value pairs
+
+class GenDb:
+  def __init__(self, db):
+    self.db = db
+    self.general = self.db['general']
+
+  def get(self, name):
+    q['name'] = name
+    return self.general.find(q, limit=1)
+
+  def delete(self, name):
+    self.general.delete_one({'name', name})
+
+  def update(self, name, value):
+    result = self.general.update_one(
+        {"name" : name},
+        {"$set": {'value' : value}},
+        upsert=True)
+    return result
+

--- a/fishtest/fishtest/gendb.py
+++ b/fishtest/fishtest/gendb.py
@@ -6,11 +6,16 @@ class GenDb:
     self.general = self.db['general']
 
   def get(self, name):
+    q = {}
     q['name'] = name
-    return self.general.find(q, limit=1)
+    d = self.general.find_one(q, limit=1)
+    if d:
+        return d['value']
+    else:
+        return ''
 
   def delete(self, name):
-    self.general.delete_one({'name', name})
+    self.general.delete_one({'name': name})
 
   def update(self, name, value):
     result = self.general.update_one(

--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -199,7 +199,14 @@ class RunDb:
       if flush:
         self.run_cache[r_id] = {'dirty': False, 'rtime': time.time(),
                               'ftime': time.time(), 'run': run}
-        games = sum(self.game_count)
+
+        minute = (int(time.time()) % 3600) / 60
+        game_count[(minute + 1) % 60] = 0
+        games = 0
+        for x in range(1, 6):
+          games = games + game_count[(60 + minute - x) % 60]
+        games = games / 5
+
         with self.run_cache_write_lock:
           self.runs.save(run)
           self.general.update('gamesperminute', games)
@@ -537,8 +544,8 @@ class RunDb:
         self.stop_run(run_id, run)
         flush = True
 
-    seconds = int(time.time()) % 60
-    game_count[seconds] = game_count[seconds] + 1
+    minute = (int(time.time()) % 3600) / 60
+    game_count[minute] = game_count[minute] + 1
 
     self.buffer(run, flush)
 

--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -37,7 +37,7 @@ class RunDb:
     self.deltas = self.db['deltas']
 
     self.chunk_size = 250
-    self.game_count = [0] * 64;
+    self.game_count = [0] * 60;
 
     global last_rundb
     last_rundb = self
@@ -202,7 +202,7 @@ class RunDb:
         games = sum(self.game_count)
         with self.run_cache_write_lock:
           self.runs.save(run)
-          self.general.update('gamesper64s', games)
+          self.general.update('gamesperminute', games)
       else:
         if r_id in self.run_cache:
           ftime = self.run_cache[r_id]['ftime']
@@ -537,7 +537,7 @@ class RunDb:
         self.stop_run(run_id, run)
         flush = True
 
-    seconds = int(time.time()) & 63
+    seconds = int(time.time()) % 60
     game_count[seconds] = game_count[seconds] + 1
 
     self.buffer(run, flush)

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -1154,9 +1154,11 @@ def tests(request):
           run['results']['wins'] + run['results']['draws']
           + run['results']['losses']))
 
+      games_per_minute = request.gendb.get('gamesperminute')
+      if !games_per_minute:
+          games_per_minute = 0
+
       machines = request.rundb.get_machines()
-      games = request.gendb.get('gamesper64s')
-      games_per_minute = games * 60.0 / 64.0
       for machine in machines:
         machine['last_updated'] = delta_date(machine['last_updated'])
       machines.reverse()

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -1155,7 +1155,7 @@ def tests(request):
           + run['results']['losses']))
 
       games_per_minute = request.gendb.get('gamesperminute')
-      if !games_per_minute:
+      if not games_per_minute:
           games_per_minute = 0
 
       machines = request.rundb.get_machines()

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -1154,15 +1154,11 @@ def tests(request):
           run['results']['wins'] + run['results']['draws']
           + run['results']['losses']))
 
-      games_per_minute = 0.0
       machines = request.rundb.get_machines()
+      games = request.gendb.get('gamesper64s')
+      games_per_minute = games * 60.0 / 64.0
       for machine in machines:
         machine['last_updated'] = delta_date(machine['last_updated'])
-        if machine['nps'] != 0:
-          games_per_minute += (
-              (machine['nps'] / 1200000.0)
-              * (60.0 / parse_tc(machine['run']['args']['tc']))
-              * int(machine['concurrency']))
       machines.reverse()
 
       def remaining_hours(run):


### PR DESCRIPTION
Count the games updated instead of estimating them from the number of machines connected. This also creates a key/value store which is likely to be useful for other things.

We could perhaps keep the existing machines based estimation and then use the difference as a guide to whether fishtest is overloaded?

UNTESTED

Solves #554 