### PR TITLE
Show github diff above tasks section on test pages

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -138,6 +138,14 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
 <div id="div_spsa_history_plot"></div>
 %endif
 
+<section class="diff" style="display: none">
+  <h3>
+    Diff contents
+    <button id="diff-toggle" class="btn">Show</button>
+  </h3>
+  <pre class="diff-contents"></pre>
+</section>
+
 <h3>Tasks ${totals}</h3>
 <table class='table table-striped table-condensed'>
  <thead>
@@ -209,3 +217,38 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
   %endfor
  </tbody>
 </table>
+
+<script>
+  $(function() {
+    var apiUrlBase = "${base.repo(run)}".replace("//github.com/", "//api.github.com/repos/");
+    $.ajax({
+      url: apiUrlBase + "/compare/${run['args']['resolved_base'][:7]}...${run['args']['resolved_new'][:7]}",
+      headers: {
+        Accept: "application/vnd.github.v3.diff"
+      },
+      success: function(response) {
+        var numLines = response.split("\n").length;
+        var $toggleBtn = $("#diff-toggle");
+        var $diffContents = $(".diff-contents");
+        $diffContents.text(response);
+        $toggleBtn.on("click", function() {
+          $diffContents.toggle();
+          if ($toggleBtn.text() === "Hide") {
+            $toggleBtn.text("Show");
+          } else {
+            $toggleBtn.text("Hide");
+          }
+        });
+        // Hide large diffs by default
+        if (numLines < 50) {
+          $diffContents.show();
+          $toggleBtn.text("Hide");
+        } else {
+          $diffContents.hide();
+          $toggleBtn.text("Show");
+        }
+        $(".diff").show();
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
This shows the Github diff on the test page so you don't have to open the diff in a separate tab or window. The browser fetches the diff from Github through their API. If for some reason the request fails, then the diff section just won't show up. Fixes https://github.com/glinscott/fishtest/issues/332

---
For example, this is how this test page would look with the diff rendered:
https://tests.stockfishchess.org/tests/view/5e8a751164ea67c1c449bb7e

![image](https://user-images.githubusercontent.com/208617/78587144-884d6100-780a-11ea-8854-4d21fba2e83e.png)

---
Github API docs for commit ranges:
https://developer.github.com/v3/repos/commits/#compare-two-commits