### PR TITLE
Update the list of authors and contributors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# List of authors for fishtest, as of January 11, 2020
+# List of authors for fishtest, as of April 07, 2020
 
 Gary Linscott (glinscott)
 
@@ -14,6 +14,7 @@ Joona Kiiski (joona)
 Joost VandeVondele (vondele)
 Jörg Oster (joergoster)
 Kamyar Kaviani
+Linmiao Xu (linrock)
 Lucas Braesch (lucasart)
 Malcolm Campbell (xoto10)
 Marco Costalba (mcostalba)


### PR DESCRIPTION
Data from `git shortlog -s | cut -c8-`
Moved Gary Linscott in first position.