### PR TITLE
Validate book is in official books repo when submitting tests

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -424,6 +424,15 @@ def validate_form(request):
         data['info'] = ('' if re.match('^[012]?[0-9][^0-9].*', data['tc'])
                         else 'LTC: ') + strip_message(c['commit']['message'])
 
+  # Check that the book exists in the official books repo
+  if len(data['book']) > 0:
+    api_url = 'https://api.github.com/repos/official-stockfish/books/contents'
+    c = requests.get(api_url).json()
+    matcher = re.compile(r'\.(epd|pgn)\.zip$')
+    valid_book_filenames = [file['name'] for file in c if matcher.search(file['name'])]
+    if data['book'] + '.zip' not in valid_book_filenames:
+      raise Exception('Invalid book - ' + data['book'])
+
   if len([v for v in list(data.values()) if len(v) == 0]) > 0:
     raise Exception('Missing required option')
 


### PR DESCRIPTION
As reported in a separate issue, submitting a test with an invalid book name will cause workers to hang until the test is manually stopped. This PR prevents that from happening by making sure the book exists in https://github.com/official-stockfish/books. If the supplied book name is invalid, the page will display an error.

Fixes https://github.com/glinscott/fishtest/issues/531

---
Example of the error message when using an invalid book name:


<img src="https://user-images.githubusercontent.com/208617/78713940-06803500-78e9-11ea-8032-78de6707d922.png" width="500"/>
