### PR TITLE
Show number of github comments on the diff when viewing tests

### DIFF
--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -124,5 +124,5 @@
 </%def>
 
 <%def name="diff_url(run)">
-  <a href="${repo(run)}/compare/${run['args']['resolved_base'][:7]}...${run['args']['resolved_new'][:7]}" target="_blank">diff</a>
+  ${repo(run)}/compare/${run['args']['resolved_base'][:7]}...${run['args']['resolved_new'][:7]}
 </%def>

--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -67,7 +67,7 @@
     <td style="width:6%">${run['start_time'].strftime("%y-%m-%d")}</td>
     <td style="width:2%"><a href="/tests/user/${run['args'].get('username','')}" title="${run['args'].get('username','')}">${run['args'].get('username','')[:3]}</td>
     <td style="width:16%"><a href="/tests/view/${run['_id']}">${run['args']['new_tag'][:23]}</a></td>
-    <td style="width:2%">${base.diff_url(run)}</td>
+    <td style="width:2%"><a href="${base.diff_url(run)}" target="_blank">diff</a></td>
     <td style="width:1%"><%include file="elo_results.mak" args="run=run, show_gauge=active" /></td>
     <td style="width:11%">
     %if 'sprt' in run['args']:

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -11,7 +11,10 @@ var spsa_history_url = '${run_args[0][1]}/spsa_history';
 <script type="text/javascript" src="/js/spsa.js"></script>
 %endif
 
-<h3>${run['args']['new_tag']} vs ${run['args']['base_tag']} ${base.diff_url(run)}</h3>
+<h3>
+  ${run['args']['new_tag']} vs ${run['args']['base_tag']}
+  <a href="${base.diff_url(run)}" target="_blank">diff</a>
+</h3>
 
 <div class="row-fluid">
 <div style="display:inline-block;">
@@ -148,7 +151,9 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
 
 <section id="diff-section" style="display: none">
   <h3>
-    Diff contents
+    Diff
+    <span id="diff-num-comments" style="display: none"></span>
+    <a href="${base.diff_url(run)}" class="btn btn-link" target="_blank">view on Github</a>
     <button id="diff-toggle" class="btn">Show</button>
   </h3>
   <pre id="diff-contents"><code class="diff"></code></pre>
@@ -240,14 +245,15 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
     }
 
     var apiUrlBase = "${base.repo(run)}".replace("//github.com/", "//api.github.com/repos/");
+    var diffApiUrl = apiUrlBase + "/compare/${run['args']['resolved_base'][:7]}...${run['args']['resolved_new'][:7]}";
     fetchDiff(
-      apiUrlBase + "/compare/${run['args']['resolved_base'][:7]}...${run['args']['resolved_new'][:7]}",
+      diffApiUrl,
       function(response) {
         var numLines = response.split("\n").length;
         var $toggleBtn = $("#diff-toggle");
         var $diffContents = $("#diff-contents");
-	var $diffText = $diffContents.find("code");
-	$diffText.text(response);
+        var $diffText = $diffContents.find("code");
+        $diffText.text(response);
         $toggleBtn.on("click", function() {
           $diffContents.toggle();
           if ($toggleBtn.text() === "Hide") {
@@ -265,7 +271,19 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
           $toggleBtn.text("Show");
         }
         $("#diff-section").show();
-	hljs.highlightBlock($diffText[0]);
+        hljs.highlightBlock($diffText[0]);
+
+        // Show # of comments for this diff on Github
+        $.ajax({
+          url: diffApiUrl,
+          success: function(response) {
+            var numComments = 0;
+            response.commits.forEach(function(row) {
+              numComments += row.commit.comment_count;
+            });
+            $("#diff-num-comments").text("(" + numComments + " comments)").show();
+          }
+        });
       }
     );
 


### PR DESCRIPTION
@vondele this adds the # of comments to the diff section as you suggested here https://github.com/glinscott/fishtest/pull/558#issuecomment-610596557

---
Example of how this page would look:
https://tests.stockfishchess.org/tests/view/5e8cab330ffd2be7f15e560f

![image](https://user-images.githubusercontent.com/208617/78724322-30425780-78fb-11ea-9d7e-dcb60192f7f3.png)
