### PR TITLE
Don't show base branch comparison message for old finished tests

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -78,7 +78,7 @@ var spsa_history_url = '${run_args[0][1]}/spsa_history';
     <button class="btn">Reschedule</button>
   </a>
 
-%if not run.get('approved', False):
+%if not run['finished'] and not run.get('approved', False):
   <br/>
   <br/>
   <div id="master-diff" class="alert">
@@ -269,7 +269,7 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
       }
     );
 
-  %if not run.get('approved', False):
+  %if not run['finished'] and not run.get('approved', False):
     var apiUrlBaseMaster = "https://api.github.com/repos/official-stockfish/Stockfish";
     fetchDiff(
       apiUrlBaseMaster + "/compare/master...${run['args']['resolved_base'][:7]}",


### PR DESCRIPTION
@ppigazzini can you see if this fixes the issue you mentioned? i'm unable to test on my dev server
https://github.com/glinscott/fishtest/pull/559#issuecomment-610654540

these are the two test pages you mentioned:
https://tests.stockfishchess.org/tests/view/5214a8390ebc59160a0182f6
https://tests.stockfishchess.org/tests/view/5214ce9a0ebc59160a0182f8