### PR TITLE
Server-side check for whether master diff matches base branch

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -67,6 +67,7 @@ class RunDb:
               msg_new='',
               base_signature='',
               new_signature='',
+              base_same_as_master=None,
               start_time=None,
               sprt=None,
               spsa=None,
@@ -118,6 +119,7 @@ class RunDb:
       # Aggregated results
       'results': {'wins': 0, 'losses': 0, 'draws': 0},
       'results_stale': False,
+      'base_same_as_master': base_same_as_master,
       'finished': False,
       'approved': False,
       'approver': '',

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -60,7 +60,8 @@ var spsa_history_url = '${run_args[0][1]}/spsa_history';
   <span>
     <form action="/tests/approve" method="POST" style="display:inline">
       <input type="hidden" name="run-id" value="${run['_id']}">
-      <button type="submit" id="approve-btn" class="btn btn-success">
+      <button type="submit" id="approve-btn"
+              class="btn ${'btn-success' if run['base_same_as_master'] else 'btn-warning'}">
         Approve
       </button>
     </form>
@@ -78,11 +79,16 @@ var spsa_history_url = '${run_args[0][1]}/spsa_history';
     <button class="btn">Reschedule</button>
   </a>
 
-%if not run['finished'] and not run.get('approved', False):
+%if run.get('base_same_as_master') is not None:
   <br/>
   <br/>
-  <div id="master-diff" class="alert">
-    Comparing base branch with master...
+  <div id="master-diff"
+       class="alert ${'alert-success' if run['base_same_as_master'] else 'alert-error'}">
+    %if run['base_same_as_master']:
+      Base branch same as Stockfish master
+    %else:
+      Base branch not same as Stockfish master
+    %endif
   </div>
   <a href="https://github.com/official-stockfish/Stockfish/compare/master...${run['args']['resolved_base'][:7]}" target="_blank">Master diff</a>
 %endif
@@ -268,22 +274,6 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
 	hljs.highlightBlock($diffText[0]);
       }
     );
-
-  %if not run['finished'] and not run.get('approved', False):
-    var apiUrlBaseMaster = "https://api.github.com/repos/official-stockfish/Stockfish";
-    fetchDiff(
-      apiUrlBaseMaster + "/compare/master...${run['args']['resolved_base'][:7]}",
-      function(response) {
-        var $masterDiff = $("#master-diff");
-        if (response.length === 0) {
-          $masterDiff.text("Base branch same as Stockfish master").addClass("alert-success");
-        } else {
-          $masterDiff.text("Base branch not same as Stockfish master").addClass("alert-error");
-          $("#approve-btn").removeClass("btn-success").addClass("btn-warning");
-        }
-      }
-    );
-  %endif
   });
 </script>
 <link rel="stylesheet" href="/css/highlight.github.css">

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -476,6 +476,14 @@ def validate_form(request):
 
   stop_rule = request.POST['stop_rule']
 
+  # Check if the base branch of the test repo matches official master
+  api_url = 'https://api.github.com/repos/official-stockfish/Stockfish'
+  api_url += '/compare/master...' + data['resolved_base'][:7]
+  master_diff = requests.get(api_url, headers={
+    'Accept': 'application/vnd.github.v3.diff'
+  })
+  data['base_same_as_master'] = master_diff.text is ''
+
   # Integer parameters
   if stop_rule == 'sprt':
     data['sprt'] = fishtest.stats.stat_util.SPRT(alpha=0.05,


### PR DESCRIPTION
Since the client-side unauthenticated Github API limit is only 60 requests/hour, users will run into issues with the master diff check if they look at a bunch of tests.

This PR fixes that by moving this API request to the server, which has a limit of 5,000 API requests/hour (source: https://github.com/glinscott/fishtest/issues/385#issuecomment-528313637)