### PR TITLE
Fix slow queries due to missing MongoDB indexes

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -16,7 +16,6 @@ from pymongo import MongoClient, ASCENDING, DESCENDING
 
 from fishtest.userdb import UserDb
 from fishtest.actiondb import ActionDb
-from fishtest.views import format_results
 
 import fishtest.stats.stat_util
 


### PR DESCRIPTION
Some MongoDB queries are really slow because they don't use indexes, so they have to scan an entire collection (runs, old_runs, actions). Slow queries also degrade performance for other people using the site at the same time.

@tomtor this adds indexes to `old_runs` as you suggest here https://github.com/glinscott/fishtest/issues/563#issuecomment-610868360. It looks like there were no indexes on that collection at all, so queries being sent to `old_runs` would be slow.

@ppigazzini if you check out this branch in DEV, you'll have to use `fishtest/utils/create_indexes.py` to set up the indexes. My dev server has almost no data on it, so I don't have a good way of verifying the performance improvement.

Examples of really slow pages that should be fixed:
- https://tests.stockfishchess.org/actions?action=modify_run&user=Vizvezdenec
- https://tests.stockfishchess.org/tests?page=50&success_only=1
- https://tests.stockfishchess.org/tests?page=50&ltc_only=1