### PR TITLE
Improve pending_hours estimate

### DIFF
--- a/fishtest/fishtest/templates/tests.mak
+++ b/fishtest/fishtest/templates/tests.mak
@@ -12,6 +12,7 @@
         cores ${'%.2fM' % (nps / (cores * 1000000.0 + 1))} nps
         (${'%.2fM' % (nps / (1000000.0 + 1))} total nps)
         ${games_per_minute} games/minute
+        ${pending_hours} hours remaining
       </span>
       <button id="machines-button" class="btn">
         ${'Hide' if machines_shown else 'Show'}
@@ -62,7 +63,7 @@
   %endif
 
   <h3>
-    Pending - ${len(runs['pending'])} tests ${pending_hours} hrs
+    Pending - ${len(runs['pending'])} tests
     <button id="pending-button" class="btn">
       ${'Hide' if pending_shown else 'Show'}
     </button>

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -1167,12 +1167,16 @@ def tests(request):
 
       def remaining_hours(run):
         r = run['results']
-        expected_games = run['args']['num_games']
         if 'sprt' in run['args']:
-          expected_games = 16000
-        remaining_games = max(0,
-                              expected_games
-                              - r['wins'] - r['losses'] - r['draws'])
+          # current average number of games. Regularly update / have server guess?
+          expected_games = 53000
+          # checking randomly, half the expected games needs still to be done
+          remaining_games = expected_games / 2
+        else:
+          expected_games = run['args']['num_games']
+          remaining_games = max(0,
+                                expected_games
+                                - r['wins'] - r['losses'] - r['draws'])
         game_secs = parse_tc(run['args']['tc'])
         return game_secs * remaining_games * int(
             run['args'].get('threads', 1)) / (60*60)


### PR DESCRIPTION
this should improve the pending hours estimate, by reflecting current average games / test, and not counting tests run so far for sprt tests.
More accurately estimating the remaining number of games for a running sprt test is not obvious.

move this estimate away from the pending tests line, to the top status line, since this is an estimate of all tests, related to the current estimated fishtest performance.

fixes https://github.com/glinscott/fishtest/issues/564