### PR TITLE
Stop using old_runs collection for runs queries

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -1092,6 +1092,7 @@ def get_paginated_finished_runs(request):
     results = request.rundb.get_results(run)
     if 'results_info' not in run:
       run['results_info'] = format_results(results, run)
+
     # Look for failed runs
     if results['wins'] + results['losses'] + results['draws'] == 0:
       failed_runs.append(run)
@@ -1152,7 +1153,13 @@ def aggregate_and_update_unfinished_runs(unfinished_runs, rundb):
           run['results_info'] = format_results(results, run)
           rundb.buffer(run, True)
       if purged == 0:
+        # The run is finished and will no longer be updated after this
         run['finished'] = True
+        # Decouple the styling of the run from its finished status
+        if run['results_info']['style'] == '#44EB44':
+          run['is_green'] = True
+        elif run['results_info']['style'] == 'yellow':
+          run['is_yellow'] = True
         rundb.buffer(run, True)
         post_result(run)
     else:

--- a/fishtest/tests/test_rundb.py
+++ b/fishtest/tests/test_rundb.py
@@ -1,6 +1,8 @@
 import unittest
 import datetime
 
+from pymongo import DESCENDING
+
 import util
 
 run_id = None
@@ -9,6 +11,11 @@ class CreateRunDBTest(unittest.TestCase):
 
   def setUp(self):
     self.rundb = util.get_rundb()
+    self.rundb.runs.ensure_index(
+      [('last_updated', DESCENDING), ('tc_base', DESCENDING)],
+      name='finished_ltc_runs',
+      partialFilterExpression={ 'finished': True, 'tc_base': { '$gte': 40 } }
+    )
 
   def tearDown(self):
     self.rundb.runs.delete_many({ 'args.username': 'travis' })
@@ -66,7 +73,7 @@ class CreateRunDBTest(unittest.TestCase):
       print(run['args']['tc'])
 
   def test_90_delete_runs(self):
-    for run in self.rundb.get_runs():
+    for run in self.rundb.runs.find():
       if run['args']['username'] == 'travis' and not 'deleted' in run:
         print('del ')
         run['deleted'] = True


### PR DESCRIPTION
@ppigazzini this PR only uses the `runs` collection for queries, so you can use it to see how the site is when everything is moved from `old_runs` to `runs`.

Fixes https://github.com/glinscott/fishtest/issues/569
Fixes https://github.com/glinscott/fishtest/issues/563