### PR TITLE
Protect links to cross-origin destinations

### DIFF
--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -38,17 +38,17 @@
           <li><a href="/users">Users</a></li>
           <li><a href="/users/monthly">Top Month</a></li>
           <li><a href="/actions">Actions</a></li>
-          <li><a href="https://github.com/glinscott/fishtest/wiki" target="_blank">Wiki</a></li>
+          <li><a href="https://github.com/glinscott/fishtest/wiki" target="_blank" rel="noopener">Wiki</a></li>
           <li><a href="/html/SPRTcalculator.html?elo-0=-0.5&elo-1=1.5&draw-ratio=0.61&rms-bias=0" target="_blank">SPRT Calc</a></li>
 
           <li class="nav-header">Links</li>
-          <li><a href="https://github.com/glinscott/fishtest" target="_blank">Github</a></li>
-          <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/fishcooking" target="_blank">Forum</a></li>
-          <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/fishcooking_results" target="_blank">History</a></li>
-          <li><a href="https://hxim.github.io/Stockfish-Evaluation-Guide/" target="_blank">Eval&shy;Guide</a></li>
-          <li><a href="https://github.com/glinscott/fishtest/wiki/Regression-Tests" target="_blank">Regres&shy;sion</a></li>
-          <li><a href="http://abrok.eu/stockfish/" target="_blank">Compiles</a></li>
-          <li><a href="https://github.com/official-stockfish/Stockfish" target="_blank">SF-github</a></li>
+          <li><a href="https://github.com/glinscott/fishtest" target="_blank" rel="noopener">Github</a></li>
+          <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/fishcooking" target="_blank" rel="noopener">Forum</a></li>
+          <li><a href="https://groups.google.com/forum/?fromgroups=#!forum/fishcooking_results" target="_blank" rel="noopener">History</a></li>
+          <li><a href="https://hxim.github.io/Stockfish-Evaluation-Guide/" target="_blank" rel="noopener">Eval&shy;Guide</a></li>
+          <li><a href="https://github.com/glinscott/fishtest/wiki/Regression-Tests" target="_blank" rel="noopener">Regres&shy;sion</a></li>
+          <li><a href="http://abrok.eu/stockfish/" target="_blank" rel="noopener">Compiles</a></li>
+          <li><a href="https://github.com/official-stockfish/Stockfish" target="_blank" rel="noopener">SF-github</a></li>
 
           <li class="nav-header">Admin</li>
           <li><a href="/signup">Register</a></li>

--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -67,7 +67,7 @@
     <td style="width:6%">${run['start_time'].strftime("%y-%m-%d")}</td>
     <td style="width:2%"><a href="/tests/user/${run['args'].get('username','')}" title="${run['args'].get('username','')}">${run['args'].get('username','')[:3]}</td>
     <td style="width:16%"><a href="/tests/view/${run['_id']}">${run['args']['new_tag'][:23]}</a></td>
-    <td style="width:2%"><a href="${h.diff_url(run)}" target="_blank">diff</a></td>
+    <td style="width:2%"><a href="${h.diff_url(run)}" target="_blank" rel="noopener">diff</a></td>
     <td style="width:1%"><%include file="elo_results.mak" args="run=run, show_gauge=active" /></td>
     <td style="width:11%">
     %if 'sprt' in run['args']:

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -13,7 +13,7 @@
 
 <h3>
   <span>${run['args']['new_tag']} vs ${run['args']['base_tag']}</span>
-  <a href="${h.diff_url(run)}" target="_blank">diff</a>
+  <a href="${h.diff_url(run)}" target="_blank" rel="noopener">diff</a>
 </h3>
 
 <div class="row-fluid">
@@ -41,7 +41,7 @@
         <tr><td>${arg[0]}</td><td>${str(markupsafe.Markup(arg[1])).replace('\n', '<br>') | n}</td></tr>
       %endif
     %else:
-    <tr><td>${arg[0]}</td><td><a href="${arg[2]}" target="_blank">${arg[1]}</a></td></tr>
+    <tr><td>${arg[0]}</td><td><a href="${arg[2]}" target="_blank" rel="noopener">${arg[1]}</a></td></tr>
     %endif
   %endfor
   <tr><td>raw statistics</td><td>
@@ -95,7 +95,7 @@
     </div>
   %endif
   <a href="https://github.com/official-stockfish/Stockfish/compare/master...${run['args']['resolved_base'][:7]}"
-     target="_blank">Master diff</a>
+     target="_blank" rel="noopener">Master diff</a>
 
   <hr>
 
@@ -160,7 +160,7 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
   <h3>
     Diff
     <span id="diff-num-comments" style="display: none"></span>
-    <a href="${h.diff_url(run)}" class="btn btn-link" target="_blank">view on Github</a>
+    <a href="${h.diff_url(run)}" class="btn btn-link" target="_blank" rel="noopener">view on Github</a>
     <button id="diff-toggle" class="btn">Show</button>
   </h3>
   <pre id="diff-contents"><code class="diff"></code></pre>

--- a/fishtest/fishtest/templates/users.mak
+++ b/fishtest/fishtest/templates/users.mak
@@ -42,7 +42,7 @@
    <td style="text-align:right">${int(user['cpu_hours'])}</td>
    <td style="text-align:right">${int(user['games'])}</td>
    <td style="text-align:right"><a href="/tests/user/${user['username']}">${user['tests']}</td>
-   <td><a href="${user['tests_repo']}" target="_blank">${user['tests_repo']}</a></td>
+   <td><a href="${user['tests_repo']}" target="_blank" rel="noopener">${user['tests_repo']}</a></td>
   </tr>
  %endfor
  </tbody>


### PR DESCRIPTION
Linking another site using `target="_blank"` attribute exposes the site
to performance and security issues:
 - the linked page may run on the same process as the start page
 - the linked page can access the `window` object of the start page

Adding `rel="noopener"` to `target="_blank"` link avoids these issues.

https://web.dev/external-anchors-use-rel-noopener/