### PR TITLE
Enable CSRF protection for POST requests on website

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -18,6 +18,7 @@ def main(global_config, **settings):
                         session_factory=session_factory,
                         root_factory='fishtest.models.RootFactory')
   config.include('pyramid_mako')
+  config.set_default_csrf_options(require_csrf=False)
 
   rundb = RunDb()
 

--- a/fishtest/fishtest/static/js/application.js
+++ b/fishtest/fishtest/static/js/application.js
@@ -30,4 +30,26 @@ $(() => {
         $("#machines").toggle();
         $.cookie('machines_state', $(this).text().trim());
     });
+
+    // CSRF protection for links and forms
+    const csrfToken = $("meta[name='csrf-token']").attr('content');
+    $("#logout").on("click", (event) => {
+        event.preventDefault();
+        $.ajax({
+            url: "/logout",
+            method: "POST",
+            headers: {
+                'X-CSRF-Token': csrfToken
+            },
+            success: () => {
+                window.location = "/";
+            }
+        });
+    });
+    $("form[method='POST']").each((i, $form) => {
+        $("<input>")
+            .attr("type", "hidden")
+            .attr("name", "csrf_token").val(csrfToken)
+            .appendTo($form);
+    });
 });

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Stockfish Testing Framework</title>
+  <meta name="csrf-token" content="${request.session.get_csrf_token()}" />
 
   <link href="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css"
         integrity="sha384-4FeI0trTH/PCsLWrGCD1mScoFu9Jf2NdknFdFoJhXZFwsvzZ3Bo5sAh7+zL8Xgnd"
@@ -17,7 +18,7 @@
           crossorigin="anonymous"></script>
 
   <script src="/js/jquery.cookie.js" defer></script>
-  <script src="/js/application.js" defer></script>
+  <script src="/js/application.js?v=1" defer></script>
 
   <%block name="head"/>
 </head>
@@ -54,7 +55,7 @@
       <li class="nav-header">Admin</li>
       %if request.authenticated_userid:
         <li><a href="/user">Profile</a></li>
-        <li><a href="/logout">Logout</a></li>
+        <li><a href="/logout" id="logout">Logout</a></li>
       %else:
         <li><a href="/signup">Register</a></li>
         <li><a href="/login">Login</a></li>

--- a/fishtest/fishtest/templates/mainpage.mak
+++ b/fishtest/fishtest/templates/mainpage.mak
@@ -1,30 +1,35 @@
 <%inherit file="base.mak"/>
 
 <h3>Stockfish testing</h3>
+
 <div class="alert alert-info alert-block">
-<h4>Permission Required</h4>
-Creating or modifying tests requires you to be logged in.  If you don't have an account, please <a href="/signup">Register</a>.
+  <h4>Permission Required</h4>
+  Creating or modifying tests requires you to be logged in.
+  If you don't have an account, please
+  <a href="/signup">Register</a>.
 </div>
 
 <div>
-<form class="form-horizontal" action="" method="POST">
-  <legend>Login</legend>
-  <div class="control-group">
-    <label class="control-label">Login:</label>
-    <div class="controls">
-      <input name="username"/>
+  <form class="form-horizontal" action="" method="POST">
+    <input type="hidden" name="csrf_token"
+           value="${request.session.get_csrf_token()}" />
+    <legend>Login</legend>
+    <div class="control-group">
+      <label class="control-label">Login:</label>
+      <div class="controls">
+        <input name="username"/>
+      </div>
     </div>
-  </div>
-  <div class="control-group">
-    <label class="control-label">Password:</label>
-    <div class="controls">
-      <input name="password" type="password" />
+    <div class="control-group">
+      <label class="control-label">Password:</label>
+      <div class="controls">
+        <input name="password" type="password" />
+      </div>
     </div>
-  </div>
-  <div class="control-group">
-    <div class="controls">
-      <button type="submit" name="form.submitted" class="btn btn-primary">Login</button>
+    <div class="control-group">
+      <div class="controls">
+        <button type="submit" class="btn btn-primary">Login</button>
+      </div>
     </div>
-  </div>
-</form>
+  </form>
 </div>

--- a/fishtest/fishtest/templates/mainpage.mak
+++ b/fishtest/fishtest/templates/mainpage.mak
@@ -11,8 +11,6 @@
 
 <div>
   <form class="form-horizontal" action="" method="POST">
-    <input type="hidden" name="csrf_token"
-           value="${request.session.get_csrf_token()}" />
     <legend>Login</legend>
     <div class="control-group">
       <label class="control-label">Login:</label>

--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -3,81 +3,111 @@
 <%namespace name="base" file="base.mak"/>
 
 %if active:
-<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-<script type="text/javascript">
-      google.charts.load('current', {'packages':['gauge']});
-      google.charts.setOnLoadCallback(drawCharts);
+  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+  <script type="text/javascript">
+    google.charts.load('current', {'packages':['gauge']});
+    google.charts.setOnLoadCallback(drawCharts);
 
-      function drawCharts() {
-
-        var a= -2.94, b= 2.94;
-        var options = {
-          redFrom: a, redTo: 0,
-          greenFrom: 0, greenTo: b,
-          min: a, max: b,
-          minorTicks: 5
-        };
-        
-        %for run in runs:
-          %if 'sprt' in run['args']:
-            var data = google.visualization.arrayToDataTable([
-              ['Label', 'Value'],
-              ['LLR', ${run['results_info']['info'][0].split(' ')[1]}]
-            ]);
-
-            var chart = new google.visualization.Gauge(document.getElementById('chart_div_${str(run['_id'])}'));
-
-            chart.draw(data, options);
-          %endif
-        %endfor
-      }
-</script>
+    function drawCharts() {
+      var a = -2.94, b = 2.94;
+      var options = {
+        redFrom: a,
+        redTo: 0,
+        greenFrom: 0,
+        greenTo: b,
+        min: a,
+        max: b,
+        minorTicks: 5
+      };
+      
+      %for run in runs:
+        %if 'sprt' in run['args']:
+          var data = google.visualization.arrayToDataTable([
+            ['Label', 'Value'],
+            ['LLR', ${run['results_info']['info'][0].split(' ')[1]}]
+          ]);
+          var chart = new google.visualization.Gauge(
+            document.getElementById('chart_div_${str(run['_id'])}')
+          );
+          chart.draw(data, options);
+        %endif
+      %endfor
+    }
+  </script>
 %endif
 
-<table class='table table-striped table-condensed'>
+<table class="table table-striped table-condensed">
   <tbody>
-  %for run in runs:
-   <tr>
-   %if show_delete:
-    <td style="width:1%">
-      <div class="dropdown">
-        <button type="submit" class="btn btn-danger btn-mini" data-toggle="dropdown">
-          <i class="icon-trash icon-white"></i>
-        </button>
-        <div class="dropdown-menu" role="menu">
-          <form action="/tests/delete" method="POST" style="display:inline">
-            <input type="hidden" name="run-id" value="${run['_id']}">
-            <button type="submit" class="btn btn-danger btn-mini">Confirm</button>
-          </form>
-        </div>
-      </div>
-    </td>
-    <td style="width:1%">
-      %if run.get('approved', False):
-      <button class="btn btn-success btn-mini">
-        <i class="icon-thumbs-up"></i>
-      </button>
-      %else:
-      <button class="btn btn-warning btn-mini">
-        <i class="icon-question-sign"></i>
-      </button>
-      %endif
-    </td>
-    %endif
-    <td style="width:6%">${run['start_time'].strftime("%y-%m-%d")}</td>
-    <td style="width:2%"><a href="/tests/user/${run['args'].get('username','')}" title="${run['args'].get('username','')}">${run['args'].get('username','')[:3]}</td>
-    <td style="width:16%"><a href="/tests/view/${run['_id']}">${run['args']['new_tag'][:23]}</a></td>
-    <td style="width:2%"><a href="${h.diff_url(run)}" target="_blank" rel="noopener">diff</a></td>
-    <td style="width:1%"><%include file="elo_results.mak" args="run=run, show_gauge=active" /></td>
-    <td style="width:11%">
-    %if 'sprt' in run['args']:
-    <a href="/html/live_elo.html?${str(run['_id'])}" target="_blank">sprt</a>
-    %else:
-    ${run['args']['num_games']}
-    %endif
-    @ ${run['args']['tc']} th ${str(run['args'].get('threads',1))}<br>${('cores: '+str(run['cores'])) if not run['finished'] and 'cores' in run else ''}</td>
-    <td style="word-break:break-word">${run['args'].get('info', '')}</td>
-   </tr>
-  %endfor
+    %for run in runs:
+      <tr>
+        %if show_delete:
+          <td style="width: 1%;">
+            <div class="dropdown">
+              <button type="submit" class="btn btn-danger btn-mini" data-toggle="dropdown">
+                <i class="icon-trash icon-white"></i>
+              </button>
+              <div class="dropdown-menu" role="menu">
+                <form action="/tests/delete" method="POST" style="display: inline;">
+                  <input type="hidden" name="csrf_token"
+                         value="${request.session.get_csrf_token()}" />
+                  <input type="hidden" name="run-id" value="${run['_id']}">
+                  <button type="submit" class="btn btn-danger btn-mini">Confirm</button>
+                </form>
+              </div>
+            </div>
+          </td>
+
+          <td style="width: 1%;">
+            %if run.get('approved', False):
+              <button class="btn btn-success btn-mini">
+                <i class="icon-thumbs-up"></i>
+              </button>
+            %else:
+              <button class="btn btn-warning btn-mini">
+                <i class="icon-question-sign"></i>
+              </button>
+            %endif
+          </td>
+        %endif
+
+        <td style="width: 6%;">
+          ${run['start_time'].strftime("%y-%m-%d")}
+        </td>
+
+        <td style="width: 2%;">
+          <a href="/tests/user/${run['args'].get('username', '')}"
+             title="${run['args'].get('username', '')}">
+            ${run['args'].get('username', '')[:3]}
+          </a>
+        </td>
+
+        <td style="width: 16%;">
+          <a href="/tests/view/${run['_id']}">${run['args']['new_tag'][:23]}</a>
+        </td>
+
+        <td style="width: 2%;">
+          <a href="${h.diff_url(run)}" target="_blank" rel="noopener">diff</a>
+        </td>
+
+        <td style="width: 1%;">
+          <%include file="elo_results.mak" args="run=run, show_gauge=active" />
+        </td>
+
+        <td style="width: 11%;">
+          %if 'sprt' in run['args']:
+            <a href="/html/live_elo.html?${str(run['_id'])}" target="_blank">sprt</a>
+          %else:
+            ${run['args']['num_games']}
+          %endif
+          @ ${run['args']['tc']} th ${str(run['args'].get('threads',1))}
+          <br>
+          ${('cores: '+str(run['cores'])) if not run['finished'] and 'cores' in run else ''}
+        </td>
+
+        <td style="word-break: break-word;">
+          ${run['args'].get('info', '')}
+        </td>
+      </tr>
+    %endfor
   </tbody>
 </table>

--- a/fishtest/fishtest/templates/signup.mak
+++ b/fishtest/fishtest/templates/signup.mak
@@ -5,48 +5,49 @@
 </%block>
 
 <div>
-<p></p>
-<p>
-Note that many modern browsers can generate/remember a strong password for you.
-</p>
-<p>
-If it is not suggested by default you can try right-clicking on the password entry field.
-</p>
-<form class="form-horizontal" action="" method="POST">
-  <legend>Create new user</legend>
-  <div class="control-group">
-    <label class="control-label">Username:</label>
-    <div class="controls">
-      <input name="username" pattern="[A-Za-z0-9]{2,}" title="Only letters and digits and at least 2 long" required="required"/>
+  <p></p>
+  <p>Note that many modern browsers can generate/remember a strong password for you.</p>
+  <p>If it is not suggested by default you can try right-clicking on the password entry field.</p>
+
+  <form class="form-horizontal" action="" method="POST">
+    <input type="hidden" name="csrf_token"
+           value="${request.session.get_csrf_token()}" />
+    <legend>Create new user</legend>
+    <div class="control-group">
+      <label class="control-label">Username:</label>
+      <div class="controls">
+        <input name="username" pattern="[A-Za-z0-9]{2,}"
+               title="Only letters and digits and at least 2 long" required="required"/>
+      </div>
     </div>
-  </div>
-  <div class="control-group">
-    <label class="control-label">Password:</label>
-    <div class="controls">
-      <input name="password" type="password" pattern=".{8,}" title="Eight or more characters" required="required"/>
+    <div class="control-group">
+      <label class="control-label">Password:</label>
+      <div class="controls">
+        <input name="password" type="password" pattern=".{8,}"
+               title="Eight or more characters" required="required"/>
+      </div>
     </div>
-  </div>
-  <div class="control-group">
-    <label class="control-label">Repeat password:</label>
-    <div class="controls">
-      <input name="password2" type="password" required="required"/>
+    <div class="control-group">
+      <label class="control-label">Repeat password:</label>
+      <div class="controls">
+        <input name="password2" type="password" required="required"/>
+      </div>
     </div>
-  </div>
-  <div class="control-group">
-    <label class="control-label">E-mail:</label>
-    <div class="controls">
-      <input name="email" type="email" required="required"/>
+    <div class="control-group">
+      <label class="control-label">E-mail:</label>
+      <div class="controls">
+        <input name="email" type="email" required="required"/>
+      </div>
     </div>
-  </div>
-  <div class="control-group">
-    <div class="controls">
-      <div class="g-recaptcha" data-sitekey="6LePs8YUAAAAABMmqHZVyVjxat95Z1c_uHrkugZM"></div>
+    <div class="control-group">
+      <div class="controls">
+        <div class="g-recaptcha" data-sitekey="6LePs8YUAAAAABMmqHZVyVjxat95Z1c_uHrkugZM"></div>
+      </div>
     </div>
-  </div>
-  <div class="control-group">
-    <div class="controls">
-      <button type="submit" name="form.submitted" class="btn btn-primary">Create User</button>
+    <div class="control-group">
+      <div class="controls">
+        <button type="submit" class="btn btn-primary">Create User</button>
+      </div>
     </div>
-  </div>
-</form>
+  </form>
 </div>

--- a/fishtest/fishtest/templates/signup.mak
+++ b/fishtest/fishtest/templates/signup.mak
@@ -41,7 +41,8 @@
     </div>
     <div class="control-group">
       <div class="controls">
-        <div class="g-recaptcha" data-sitekey="6LePs8YUAAAAABMmqHZVyVjxat95Z1c_uHrkugZM"></div>
+        <div class="g-recaptcha"
+             data-sitekey="6LePs8YUAAAAABMmqHZVyVjxat95Z1c_uHrkugZM"></div>
       </div>
     </div>
     <div class="control-group">

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -2,12 +2,15 @@
 
 <% re_run = len(args) > 0 %>
 
-<form class="form-horizontal" action="${request.url}" method="POST">
-  <legend>Create New Test</legend>
-  Please read the <a href="https://github.com/glinscott/fishtest/wiki/Creating-my-first-test">Testing Guidelines</a> before
-  creating your test.
+<legend>Create New Test</legend>
+<div>
+  Please read the
+  <a href="https://github.com/glinscott/fishtest/wiki/Creating-my-first-test">Testing Guidelines</a>
+  before creating your test.
+</div>
+<br><br>
 
-  <br><br>
+<form class="form-horizontal" action="${request.url}" method="POST">
   <div class="control-group">
     <label class="control-label">Test branch:</label>
     <div class="controls">

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -53,7 +53,7 @@
 <div class="span4">
   <h4>Actions</h4>
   %if not run['finished']:
-    <form action="/tests/stop" method="POST" style="display:inline">
+    <form action="/tests/stop" method="POST" style="display: inline;">
       <input type="hidden" name="run-id" value="${run['_id']}">
       <button type="submit" class="btn btn-danger">
         Stop
@@ -61,7 +61,7 @@
     </form>
     %if not run.get('approved', False):
       <span>
-        <form action="/tests/approve" method="POST" style="display:inline">
+        <form action="/tests/approve" method="POST" style="display: inline;">
           <input type="hidden" name="run-id" value="${run['_id']}">
           <button type="submit" id="approve-btn"
                   class="btn ${'btn-success' if run['base_same_as_master'] else 'btn-warning'}">
@@ -71,7 +71,7 @@
       </span>
     %endif
   %else:
-    <form action="/tests/purge" method="POST" style="display:inline">
+    <form action="/tests/purge" method="POST" style="display: inline;">
       <input type="hidden" name="run-id" value="${run['_id']}">
       <button type="submit" class="btn btn-danger">
         Purge


### PR DESCRIPTION
Auto-attaches CSRF token fields to POST forms and adds CSRF protection for logout link.

These routes are now protected. Normal users should see no difference.

- /login
- /signup [erratum corrige: /register]
- /logout
- /tests/run
- /tests/modify
- /tests/delete
- /tests/stop
- /tests/approve
- /tests/purge

For a simple example of a CSRF attack in master, put this in an html file locally (`csrf.html`):

```html
<form action="https://tests.stockfishchess.org/logout"></form>
<script>document.querySelector("form").submit()</script>
```

While logged-in to https://tests.stockfishchess.org/ open `csrf.html`. You will be taken to the fishtest website and you'll be logged out. When CSRF protection is enabled, you'll see an error message instead.

Fixes https://github.com/glinscott/fishtest/issues/386