### PR TITLE
Fix failing tests, use different db for tests

### DIFF
--- a/fishtest/tests/test_run.py
+++ b/fishtest/tests/test_run.py
@@ -5,11 +5,9 @@ from fishtest.views import get_master_bench
 
 class CreateRunTest(unittest.TestCase):
 
-  def tearDown(self):
-    pass
-
   def test_10_get_bench(self):
     self.assertTrue(re.match('[0-9]{7}|None', str(get_master_bench())))
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/fishtest/tests/test_rundb.py
+++ b/fishtest/tests/test_rundb.py
@@ -1,39 +1,37 @@
 import unittest
 import datetime
 
-from fishtest.rundb import RunDb
-
 import util
 
-rundb = None
-run_id_stc = None
 run_id = None
 
 class CreateRunDBTest(unittest.TestCase):
 
+  def setUp(self):
+    self.rundb = util.get_rundb()
+
   def tearDown(self):
-    rundb.runs.delete_many({'args.username': 'travis'})
+    self.rundb.runs.delete_many({ 'args.username': 'travis' })
     # Shutdown flush thread:
-    rundb.stop()
+    self.rundb.stop()
 
   def test_10_create_run(self):
-    global rundb, run_id, run_id_stc
-    rundb = RunDb()
+    global run_id
     # STC
-    run_id_stc = rundb.new_run('master', 'master', 100000, '10+0.01', 'book', 10, 1, '', '',
-                               username='travis', tests_repo='travis',
-                               start_time=datetime.datetime.utcnow())
-    run = rundb.get_run(run_id_stc)
+    run_id_stc = self.rundb.new_run('master', 'master', 100000, '10+0.01', 'book', 10, 1, '', '',
+                                    username='travis', tests_repo='travis',
+                                    start_time=datetime.datetime.utcnow())
+    run = self.rundb.get_run(run_id_stc)
     run['finished'] = True
-    rundb.buffer(run, True)
+    self.rundb.buffer(run, True)
 
     # LTC
-    run_id = rundb.new_run('master', 'master', 100000, '150+0.01', 'book', 10, 1, '', '',
-                           username='travis', tests_repo='travis',
-                           start_time=datetime.datetime.utcnow())
+    run_id = self.rundb.new_run('master', 'master', 100000, '150+0.01', 'book', 10, 1, '', '',
+                                username='travis', tests_repo='travis',
+                                start_time=datetime.datetime.utcnow())
     print(' ')
     print(run_id)
-    run = rundb.get_run(run_id)
+    run = self.rundb.get_run(run_id)
     print(run['tasks'][0])
     self.assertFalse(run['tasks'][0][u'active'])
     run['tasks'][0][u'active'] = True
@@ -41,38 +39,41 @@ class CreateRunDBTest(unittest.TestCase):
       'username': 'worker1', 'unique_key': 'travis', 'concurrency': 1}
     run['cores'] = 1
 
-    print(util.find_run()['args'])
+    for run in self.rundb.get_unfinished_runs():
+      if run['args']['username'] == 'travis':
+        print(run['args'])
 
   def test_20_update_task(self):
-    run = rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-3,
-                                      'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker2')
+    run = self.rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': self.rundb.chunk_size-3,
+                                             'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker2')
     self.assertEqual(run, {'task_alive': False})
-    run = rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-3,
-                                      'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
+    run = self.rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': self.rundb.chunk_size-3,
+                                             'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
     self.assertEqual(run, {'task_alive': True})
-    run = rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': rundb.chunk_size-2,
-                                      'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
+    run = self.rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': self.rundb.chunk_size-2,
+                                             'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
     self.assertEqual(run, {'task_alive': False})
 
   def test_30_finish(self):
-    run = rundb.get_run(run_id)
+    print('run_id: {}'.format(run_id))
+    run = self.rundb.get_run(run_id)
     run['finished'] = True
-    rundb.buffer(run, True)
+    self.rundb.buffer(run, True)
 
   def test_40_list_LTC(self):
-    finished_runs= rundb.get_finished_runs(limit=3, ltc_only=True)[0]
+    finished_runs = self.rundb.get_finished_runs(limit=3, ltc_only=True)[0]
     for run in finished_runs:
       print(run['args']['tc'])
 
   def test_90_delete_runs(self):
-    for run in rundb.get_runs():
+    for run in self.rundb.get_runs():
       if run['args']['username'] == 'travis' and not 'deleted' in run:
         print('del ')
         run['deleted'] = True
         run['finished'] = True
         for w in run['tasks']:
           w['pending'] = False
-        rundb.buffer(run, True)
+        self.rundb.buffer(run, True)
 
 
 if __name__ == "__main__":

--- a/fishtest/tests/util.py
+++ b/fishtest/tests/util.py
@@ -1,7 +1,10 @@
 from fishtest.rundb import RunDb
 
+def get_rundb():
+  return RunDb(db_name='fishtest_tests')
+
 def find_run(arg='username', value='travis'):
-  rundb = RunDb()
+  rundb = RunDb(db_name='fishtest_tests')
   for run in rundb.get_unfinished_runs():
     if run['args'][arg] == value:
       return run


### PR DESCRIPTION
this fixes the failing travis tests as @tomtor pointed out in https://github.com/glinscott/fishtest/pull/577.

it also uses a `fishtest_tests` db so running tests in dev/prod will use a different db.