### PR TITLE
Cache pending for 1s instead of 60s

### DIFF
--- a/fishtest/fishtest/userdb.py
+++ b/fishtest/fishtest/userdb.py
@@ -51,14 +51,14 @@ class UserDb:
   def get_users(self):
     return self.users.find(sort=[('_id', ASCENDING)])
 
-  # Cache pending for 60s
+  # Cache pending for 1s
   last_pending_time = 0
   last_pending = None
   pending_lock = threading.Lock()
 
   def get_pending(self):
     with self.pending_lock:
-      if time.time() > self.last_pending_time + 60:
+      if time.time() > self.last_pending_time + 1:
         self.last_pending = list(self.users.find({'blocked': True},
                                                  sort=[('_id', ASCENDING)]))
         self.last_pending_time = time.time()


### PR DESCRIPTION
Fix (makes rare) #578 

Edit: Alternatives are:
* completely remove caching of pending user query
* disable separate main page pserve instance