### PR TITLE
Lazy-load machines table on homepage if hidden by user

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -60,6 +60,7 @@ def main(global_config, **settings):
   config.add_route('actions', '/actions')
 
   config.add_route('tests', '/tests')
+  config.add_route('tests_machines', '/tests/machines')
   config.add_route('tests_run', '/tests/run')
   config.add_route('tests_modify', '/tests/modify')
   config.add_route('tests_view', '/tests/view/{id}')

--- a/fishtest/fishtest/static/js/application.js
+++ b/fishtest/fishtest/static/js/application.js
@@ -24,9 +24,14 @@ $(() => {
         $.cookie('pending_state', $(this).text().trim());
     });
 
+    let fetchingMachines = false;
     $("#machines-button").click(function () {
-        var active = $(this).text().trim() === 'Hide';
+        const active = $(this).text().trim() === 'Hide';
         $(this).text(active ? 'Show' : 'Hide');
+        if (!active && !$("#machines table")[0] && !fetchingMachines) {
+            fetchingMachines = true;
+            $.get("/tests/machines", (html) => $("#machines").append(html));
+        }
         $("#machines").toggle();
         $.cookie('machines_state', $(this).text().trim());
     });

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -18,7 +18,7 @@
           crossorigin="anonymous"></script>
 
   <script src="/js/jquery.cookie.js" defer></script>
-  <script src="/js/application.js?v=1" defer></script>
+  <script src="/js/application.js?v=2" defer></script>
 
   <%block name="head"/>
 </head>

--- a/fishtest/fishtest/templates/machines_table.mak
+++ b/fishtest/fishtest/templates/machines_table.mak
@@ -1,0 +1,38 @@
+<table class="table table-striped table-condensed"
+       style="max-width: 960px;">
+  <thead>
+    <tr>
+      <th>Machine</th>
+      <th>Cores</th>
+      <th>MNps</th>
+      <th>System</th>
+      <th>Version</th>
+      <th>Running on</th>
+      <th>Last updated</th>
+    </tr>
+  </thead>
+  <tbody>
+    %for machine in machines:
+      <tr>
+        <td>${machine['username']}</td>
+        <td>
+          %if 'country_code' in machine:
+            <div class="flag flag-${machine['country_code'].lower()}"
+                 style="display: inline-block"></div>
+          %endif
+          ${machine['concurrency']}
+        </td>
+        <td>${'%.2f' % (machine['nps'] / 1000000.0)}</td>
+        <td>${machine['uname']}</td>
+        <td>${machine['version']}</td>
+        <td>
+          <a href="/tests/view/${machine['run']['_id']}">${machine['run']['args']['new_tag']}</a>
+        </td>
+        <td>${machine['last_updated']}</td>
+      </tr>
+    %endfor
+    %if len(machines) == 0:
+      <td>No machines running</td>
+    %endif
+  </tbody>
+</table>

--- a/fishtest/fishtest/templates/tests.mak
+++ b/fishtest/fishtest/templates/tests.mak
@@ -21,44 +21,9 @@
 
     <div id="machines"
          style="${'' if machines_shown else 'display: none;'}">
-      <table class="table table-striped table-condensed"
-             style="max-width: 960px;">
-        <thead>
-          <tr>
-          <th>Machine</th>
-          <th>Cores</th>
-          <th>MNps</th>
-          <th>System</th>
-          <th>Version</th>
-          <th>Running on</th>
-          <th>Last updated</th>
-          </tr>
-        </thead>
-        <tbody>
-          %for machine in machines:
-            <tr>
-              <td>${machine['username']}</td>
-              <td>
-                %if 'country_code' in machine:
-                  <div class="flag flag-${machine['country_code'].lower()}"
-                      style="display: inline-block"></div>
-                %endif
-                ${machine['concurrency']}
-              </td>
-              <td>${'%.2f' % (machine['nps'] / 1000000.0)}</td>
-              <td>${machine['uname']}</td>
-              <td>${machine['version']}</td>
-              <td>
-                <a href="/tests/view/${machine['run']['_id']}">${machine['run']['args']['new_tag']}</a>
-              </td>
-              <td>${machine['last_updated']}</td>
-            </tr>
-          %endfor
-          %if len(machines) == 0:
-            <td>No machines running</td>
-          %endif
-        </tbody>
-      </table>
+      %if machines_shown:
+        <%include file="machines_table.mak" args="machines=machines"/>
+      %endif
     </div>
   %endif
 

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -953,6 +953,16 @@ def tests_stats(request):
   return {'run': run}
 
 
+@view_config(route_name='tests_machines', renderer='machines_table.mak')
+def tests_machines(request):
+  machines = request.rundb.get_machines()
+  for machine in machines:
+    machine['last_updated'] = delta_date(machine['last_updated'])
+  return {
+    'machines': machines
+  }
+
+
 @view_config(route_name='tests_view_spsa_history', renderer='json')
 def tests_view_spsa_history(request):
   run = request.rundb.get_run(request.matchdict['id'])
@@ -1205,7 +1215,6 @@ def tests(request):
             else:
               info['info'].append(('{%.2f,%.2f}')
                                   % (sprt['elo0'], sprt['elo1']))
-
     else:  # not full_info
       cores = 0
       nps = 0


### PR DESCRIPTION
@tomtor as we discussed in https://github.com/glinscott/fishtest/pull/581, this is what i was thinking:
- if the user has the machines table hidden by default, it won't be rendered upon pageload
- if the user clicks "Show" while the table doesn't exist, the table is fetched and then rendered

the idea is to speed up the homepage by doing less work on both client and server when not needed, but there are still a lot of calculations done for the homepage on each request.