### PR TITLE
Limit max number of worker cores for a SPSA tuning job

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -420,7 +420,16 @@ class RunDb:
          and run['args']['threads'] >= min_threads \
          and need_tt <= max_memory:
         task_id = -1
+        cores = 0
+        if 'spsa' in run['args']:
+          limit = 40000 / math.sqrt(len(run['args']['spsa']['params']))
+        else:
+          limit = 1000000  # No limit for SPRT
         for task in run['tasks']:
+          if task['active']:
+            cores += task['worker_info']['concurrency']
+            if cores > limit:
+              break
           task_id = task_id + 1
           if not task['active'] and task['pending']:
             task['worker_info'] = worker_info


### PR DESCRIPTION
EDIT: SPSA tuning jobs with many parameters require additional server resources compared to SPRT tests, due to the recalculation of the parameters after each mini batch of (2 * concurrency) games.

This PR limits the number of cores that are allocated to these jobs to (10000 / sqrt(nr-of-tuning-parameters)).