### PR TITLE
Fix sorting of lazy-loaded tables

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -481,7 +481,6 @@ class RunDb:
       return self.sync_update_task(run_id, task_id, stats, nps, spsa, username)
 
   def sync_update_task(self, run_id, task_id, stats, nps, spsa, username):
-
     run = self.get_run(run_id)
     if task_id >= len(run['tasks']):
       return {'task_alive': False}

--- a/fishtest/fishtest/static/js/application.js
+++ b/fishtest/fishtest/static/js/application.js
@@ -6,14 +6,13 @@ const comparer = (idx, asc) => (a, b) => ((v1, v2) =>
 
 $(() => {
     // clicking on table headers sorts the rows
-    document.querySelectorAll('th').forEach(th => {
-        th.addEventListener('click', (() => {
-            const table = th.closest('table');
-            const body = table.querySelector('tbody');
-            Array.from(body.querySelectorAll('tr'))
-                .sort(comparer(Array.from(th.parentNode.children).indexOf(th), this.asc = !this.asc))
-                .forEach(tr => body.appendChild(tr));
-        }));
+    $(document).on('click', 'th', (event) => {
+        const th = $(event.currentTarget)[0];
+        const table = th.closest('table');
+        const body = table.querySelector('tbody');
+        Array.from(body.querySelectorAll('tr'))
+            .sort(comparer(Array.from(th.parentNode.children).indexOf(th), this.asc = !this.asc))
+            .forEach(tr => body.appendChild(tr));
     });
 
     // clicking Show/Hide on Pending tests and Machines sections toggles them

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -18,7 +18,7 @@
           crossorigin="anonymous"></script>
 
   <script src="/js/jquery.cookie.js" defer></script>
-  <script src="/js/application.js?v=2" defer></script>
+  <script src="/js/application.js?v=3" defer></script>
 
   <%block name="head"/>
 </head>


### PR DESCRIPTION
Fixes https://github.com/glinscott/fishtest/issues/585

General fix so that all lazy-loaded tables will be sortable. Does not yet track the default sort key