### PR TITLE
Use different titles for finished test pages

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -61,16 +61,19 @@ def main(global_config, **settings):
 
   config.add_route('tests', '/tests')
   config.add_route('tests_machines', '/tests/machines')
+  config.add_route('tests_finished', '/tests/finished')
   config.add_route('tests_run', '/tests/run')
-  config.add_route('tests_modify', '/tests/modify')
   config.add_route('tests_view', '/tests/view/{id}')
   config.add_route('tests_view_spsa_history', '/tests/view/{id}/spsa_history')
+  config.add_route('tests_user', '/tests/user/{username}')
+  config.add_route('tests_stats', '/tests/stats/{id}')
+
+  # Tests - actions
+  config.add_route('tests_modify', '/tests/modify')
   config.add_route('tests_delete', '/tests/delete')
   config.add_route('tests_stop', '/tests/stop')
   config.add_route('tests_approve', '/tests/approve')
   config.add_route('tests_purge', '/tests/purge')
-  config.add_route('tests_user', '/tests/user/{username}')
-  config.add_route('tests_stats', '/tests/stats/{id}')
 
   # API
   config.add_route('api_request_task', '/api/request_task')

--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -270,7 +270,7 @@ class RunDb:
   def get_finished_runs(self, skip=0, limit=0, username='',
                         success_only=False, ltc_only=False):
     q = {'finished': True}
-    if len(username) > 0:
+    if username:
       q['args.username'] = username
     if ltc_only:
       q['args.tc'] = {'$regex': '^([4-9][0-9])|([1-9][0-9][0-9])'}

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -30,8 +30,8 @@
 
       <li class="nav-header">Tests</li>
       <li><a href="/tests">Overview</a></li>
-      <li><a href="/tests?success_only=1">Greens</a></li>
-      <li><a href="/tests?ltc_only=1">Slow (LTC)</a></li>
+      <li><a href="/tests/finished?success_only=1">Greens</a></li>
+      <li><a href="/tests/finished?ltc_only=1">LTC</a></li>
       <li><a href="/tests/run">New</a></li>
 
       <li class="nav-header">Misc</li>

--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -1,4 +1,4 @@
-<%page args="runs, show_delete=False, active=False"/>
+<%page args="runs, pages=None, show_delete=False, active=False"/>
 
 <%namespace name="base" file="base.mak"/>
 
@@ -35,6 +35,22 @@
     }
   </script>
 %endif
+
+<%def name="pagination()">
+  %if pages and len(pages) > 3:
+    <h3>
+      <span class="pagination pagination-small">
+        <ul>
+          %for page in pages:
+            <li class="${page['state']}"><a href="${page['url']}">${page['idx']}</a></li>
+          %endfor
+        </ul>
+      </span>
+    </h3>
+  %endif
+</%def>
+
+${pagination()}
 
 <table class="table table-striped table-condensed">
   <tbody>
@@ -111,3 +127,5 @@
     %endfor
   </tbody>
 </table>
+
+${pagination()}

--- a/fishtest/fishtest/templates/tests.mak
+++ b/fishtest/fishtest/templates/tests.mak
@@ -51,18 +51,5 @@
   <%include file="run_table.mak" args="runs=runs['active']"/>
 %endif
 
-<%def name="pagination()">
-  %if len(pages) > 3:
-    <span class="pagination pagination-small">
-      <ul>
-        %for page in pages:
-          <li class="${page['state']}"><a href="${page['url']}">${page['idx']}</a></li>
-        %endfor
-      </ul>
-    </span>
-  %endif
-</%def>
-
-<h3>Finished - ${finished_runs} tests ${pagination()}</h3>
-<%include file="run_table.mak" args="runs=runs['finished']"/>
-<h3>${pagination()}</h3>
+<h3>Finished - ${num_finished_runs} tests</h3>
+<%include file="run_table.mak" args="runs=runs['finished'], pages=finished_runs_pages"/>

--- a/fishtest/fishtest/templates/tests_finished.mak
+++ b/fishtest/fishtest/templates/tests_finished.mak
@@ -1,0 +1,13 @@
+<%inherit file="base.mak"/>
+
+<h2>
+  Finished Tests
+  %if 'success_only' in request.url:
+    - Greens
+  %elif 'ltc_only' in request.url:
+    - LTC
+  %endif
+</h2>
+
+<h3>Finished - ${num_finished_runs} tests</h3>
+<%include file="run_table.mak" args="runs=finished_runs, pages=finished_runs_pages"/>


### PR DESCRIPTION
So the title of the page tells you which page you're on:

![image](https://user-images.githubusercontent.com/208617/79167389-52355180-7db5-11ea-9654-c92c6c89f4d1.png)

---
- Use a separate view for finished test pages
- Simplify tests view function for better readability
- Show Greens and LTC (Slow) titles on finished test pages
- Handle table pagination in one place