### PR TITLE
Fix unnecessary expensive work on tests pages past page 1

### DIFF
--- a/fishtest/fishtest/templates/run_tables.mak
+++ b/fishtest/fishtest/templates/run_tables.mak
@@ -1,0 +1,28 @@
+%if page_idx == 0:
+  <h3>
+    Pending - ${len(runs['pending'])} tests
+    <button id="pending-button" class="btn">
+      ${'Hide' if pending_shown else 'Show'}
+    </button>
+  </h3>
+
+  <div id="pending"
+       style="${'' if pending_shown else 'display: none;'}">
+    %if len(runs['pending']) == 0:
+      No pending runs
+    %else:
+      <%include file="run_table.mak" args="runs=runs['pending'], show_delete=True"/>
+    %endif
+  </div>
+
+  %if len(runs['failed']) > 0:
+    <h3>Failed</h3>
+    <%include file="run_table.mak" args="runs=runs['failed'], show_delete=True"/>
+  %endif
+
+  <h3>Active - ${len(runs['active'])} tests</h3>
+  <%include file="run_table.mak" args="runs=runs['active']"/>
+%endif
+
+<h3>Finished - ${num_finished_runs} tests</h3>
+<%include file="run_table.mak" args="runs=finished_runs, pages=finished_runs_pages"/>

--- a/fishtest/fishtest/templates/tests.mak
+++ b/fishtest/fishtest/templates/tests.mak
@@ -5,51 +5,25 @@
 <h2>Stockfish Testing Queue</h2>
 
 %if page_idx == 0:
-  %if show_machines:
-    <h3>
-      <span>
-        ${len(machines)} machines ${cores}
-        cores ${'%.2fM' % (nps / (cores * 1000000.0 + 1))} nps
-        (${'%.2fM' % (nps / (1000000.0 + 1))} total nps)
-        ${games_per_minute} games/minute
-        ${pending_hours} hours remaining
-      </span>
-      <button id="machines-button" class="btn">
-        ${'Hide' if machines_shown else 'Show'}
-      </button>
-    </h3>
-
-    <div id="machines"
-         style="${'' if machines_shown else 'display: none;'}">
-      %if machines_shown:
-        <%include file="machines_table.mak" args="machines=machines"/>
-      %endif
-    </div>
-  %endif
-
   <h3>
-    Pending - ${len(runs['pending'])} tests
-    <button id="pending-button" class="btn">
-      ${'Hide' if pending_shown else 'Show'}
+    <span>
+      ${len(machines)} machines ${cores}
+      cores ${'%.2fM' % (nps / (cores * 1000000.0 + 1))} nps
+      (${'%.2fM' % (nps / (1000000.0 + 1))} total nps)
+      ${games_per_minute} games/minute
+      ${pending_hours} hours remaining
+    </span>
+    <button id="machines-button" class="btn">
+      ${'Hide' if machines_shown else 'Show'}
     </button>
   </h3>
-  <div id="pending"
-       style="${'' if pending_shown else 'display: none;'}">
-    %if len(runs['pending']) == 0:
-      No pending runs
-    %else:
-      <%include file="run_table.mak" args="runs=runs['pending'], show_delete=True"/>
+
+  <div id="machines"
+        style="${'' if machines_shown else 'display: none;'}">
+    %if machines_shown:
+      <%include file="machines_table.mak" args="machines=machines"/>
     %endif
   </div>
-
-  %if len(runs['failed']) > 0:
-    <h3>Failed</h3>
-    <%include file="run_table.mak" args="runs=runs['failed'], show_delete=True"/>
-  %endif
-
-  <h3>Active - ${len(runs['active'])} tests</h3>
-  <%include file="run_table.mak" args="runs=runs['active']"/>
 %endif
 
-<h3>Finished - ${num_finished_runs} tests</h3>
-<%include file="run_table.mak" args="runs=runs['finished'], pages=finished_runs_pages"/>
+<%include file="run_tables.mak"/>

--- a/fishtest/fishtest/templates/tests_user.mak
+++ b/fishtest/fishtest/templates/tests_user.mak
@@ -1,0 +1,5 @@
+<%inherit file="base.mak"/>
+
+<h2>${username}</h2>
+
+<%include file="run_tables.mak"/>


### PR DESCRIPTION
Previously, expensive calculations for unfinished runs (active, pending, failed) were being done on ALL `/tests` and `/tests/user` pages when you visit them. They're calculated when you visit any page number, but the results of these calculations are only shown on page 1. Only the homepage (page 1 of `/tests`) caches the results.

This PR should speed up page 2 and beyond of all `/tests` and `/tests/user` pages while reducing CPU usage.

Summary:
- Don't calculate unfinished runs on tests pages after page 1
- Separate view for user tests, show username at top of user tests
- Don't calculate unfinished runs on user pages after page 1
- Simplify tests view logic
- favicon.ico and robots.txt views are served by nginx
- Add a todo for calculating results_info when the run is finished, not when viewing