### PR TITLE
Add yellow finished tests page and sidebar link

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -265,7 +265,7 @@ class RunDb:
                             sort=[('last_updated', DESCENDING)])
 
   def get_finished_runs(self, skip=0, limit=0, username='',
-                        success_only=False, ltc_only=False):
+                        success_only=False, yellow_only=False, ltc_only=False):
     q = {'finished': True}
     idx_hint = 'finished_runs'
     if username:
@@ -277,6 +277,9 @@ class RunDb:
     if success_only:
       q['is_green'] = True
       idx_hint = 'finished_green_runs'
+    if yellow_only:
+      q['is_yellow'] = True
+      idx_hint = 'finished_yellow_runs'
 
     c = self.runs.find(q, skip=skip, limit=limit,
                        sort=[('last_updated', DESCENDING)])

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -31,6 +31,7 @@
       <li class="nav-header">Tests</li>
       <li><a href="/tests">Overview</a></li>
       <li><a href="/tests/finished?success_only=1">Greens</a></li>
+      <li><a href="/tests/finished?yellow_only=1">Yellows</a></li>
       <li><a href="/tests/finished?ltc_only=1">LTC</a></li>
       <li><a href="/tests/run">New</a></li>
 

--- a/fishtest/fishtest/templates/tests_finished.mak
+++ b/fishtest/fishtest/templates/tests_finished.mak
@@ -4,6 +4,8 @@
   Finished Tests
   %if 'success_only' in request.url:
     - Greens
+  %elif 'yellow_only' in request.url:
+    - Yellows
   %elif 'ltc_only' in request.url:
     - LTC
   %endif


### PR DESCRIPTION
As suggested by @vondele in https://github.com/glinscott/fishtest/pull/588#issuecomment-613239579

---
![image](https://user-images.githubusercontent.com/208617/79395283-48435800-7f47-11ea-83fc-91df9eabeb13.png)

---
@ppigazzini this would require setting a new field on all runs. no need to rebuild indexes since the index was already added. just need to run a migration like this. i changed this migration from the previous migration script to update a single field on the run rather than replacing it (untested):

```python
import sys
from pymongo import MongoClient

conn = MongoClient()
runs = conn['fishtest_new']['runs']
for run in runs.find():
  try:
    if run['results_info'].get('style') == 'yellow':
      runs.update_one({ '_id': run['_id'] }, { '$set': { 'is_yellow': True } })
  except Exception as e:
    print("Unexpected error:", sys.exc_info()[0], e)
```