### PR TITLE
Scale down update_task request frequency by 2x

### DIFF
--- a/fishtest/fishtest/api.py
+++ b/fishtest/fishtest/api.py
@@ -7,7 +7,7 @@ from pyramid.view import view_config
 
 import fishtest.stats.sprt
 
-WORKER_VERSION = 72
+WORKER_VERSION = 73
 
 
 def get_flag(request):

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -27,7 +27,7 @@ from updater import update
 from datetime import datetime
 from os import path
 
-WORKER_VERSION = 72
+WORKER_VERSION = 73
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 
@@ -208,17 +208,18 @@ def main():
   with open(config_file, 'w') as f:
     config.write(f)
 
-  if options.protocol.lower() not in ['http', 'https']:
+  protocol = options.protocol.lower()
+  if protocol not in ['http', 'https']:
     sys.stderr.write('Wrong protocol, use https or http\n')
     sys.exit(1)
-  elif options.protocol.lower() == 'http' and options.port == '443':
+  elif protocol == 'http' and options.port == '443':
     # Rewrite old port 443 to 80
     options.port = '80'
-  elif options.protocol.lower() == 'https' and options.port == '80':
+  elif protocol == 'https' and options.port == '80':
     # Rewrite old port 80 to 443
     options.port = '443'
-  remote = '%s://%s:%s' % (options.protocol.lower(), options.host, options.port)
-  print('Worker version %s connecting to %s' % (WORKER_VERSION, remote))
+  remote = '{}://{}:{}'.format(protocol, options.host, options.port)
+  print('Worker version {} connecting to {}'.format(WORKER_VERSION, remote))
 
   try:
     cpu_count = min(int(options.concurrency), multiprocessing.cpu_count() - 1)


### PR DESCRIPTION
Instead of calling `/api/update_task` after each game finishes, the worker now calls it either:
- once per N games, where N is worker concurrency (min of concurrency flag and # cpus - 1)
- or after all the games in the task have been completed

This should ease the load on the server by generating less network traffic (see https://github.com/glinscott/fishtest/issues/553#issuecomment-614500983) and allow prod to handle a higher # of worker cores.