### PR TITLE
Add more API tests and simplify API code

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -579,8 +579,6 @@ class RunDb:
       self.buffer(run, True)
       self.task_time = 0
 
-    return {}
-
   def approve_run(self, run_id, approver):
     run = self.get_run(run_id)
     # Can't self approve
@@ -662,7 +660,6 @@ class RunDb:
       'w_params': [],
       'b_params': [],
     }
-
     spsa = run['args']['spsa']
     if 'clipping' not in spsa:
         spsa['clipping'] = 'old'

--- a/fishtest/tests/test_api.py
+++ b/fishtest/tests/test_api.py
@@ -1,12 +1,12 @@
 import datetime
-import json
 import unittest
 import base64
 import zlib
 
-from pyramid import testing
+from pyramid.testing import DummyRequest
+from pyramid.httpexceptions import HTTPUnauthorized
 
-import fishtest.api
+from fishtest.api import ApiView, WORKER_VERSION
 from util import get_rundb
 
 
@@ -29,19 +29,34 @@ class TestApi(unittest.TestCase):
     self.task_id = 3
     for i, task in enumerate(run['tasks']):
       if i is not self.task_id:
-        run['tasks'][i]["pending"] = False
+        run['tasks'][i]['pending'] = False
 
     self.rundb.buffer(run, True)
 
     # Set up an API user (a worker)
-    self.username = 'JoeUser2'
+    self.username = 'JoeUserWorker'
     self.password = 'secret'
-    self.remote_addr = "127.0.0.1"
+    self.remote_addr = '127.0.0.1'
+    self.concurrency = 7
 
+    self.worker_info = {
+      'username': self.username,
+      'password': self.password,
+      'remote_addr': self.remote_addr,
+      'concurrency': self.concurrency,
+      'unique_key': 'unique key',
+      'version': WORKER_VERSION
+    }
     self.rundb.userdb.create_user(self.username, self.password, 'email@email.email')
     user = self.rundb.userdb.get_user(self.username)
     user['blocked'] = False
+    user['machine_limit'] = 50
     self.rundb.userdb.save_user(user)
+
+    self.rundb.userdb.user_cache.insert_one({
+      'username': self.username,
+      'cpu_hours': 0,
+    })
     self.rundb.userdb.flag_cache.insert_one({
       'ip': self.remote_addr,
       'country_code': '??'
@@ -51,149 +66,248 @@ class TestApi(unittest.TestCase):
   def tearDownClass(self):
     self.rundb.runs.delete_one({ '_id': self.run_id })
     self.rundb.userdb.users.delete_one({ 'username': self.username })
-    self.rundb.userdb.flag_cache.delete_one({'ip': self.remote_addr })
+    self.rundb.userdb.user_cache.delete_one({ 'username': self.username })
+    self.rundb.userdb.flag_cache.delete_one({ 'ip': self.remote_addr })
     self.rundb.stop()
+    self.rundb.runs.drop()
+
+
+  def build_json_request(self, json_body):
+    return DummyRequest(
+      rundb=self.rundb,
+      userdb=self.rundb.userdb,
+      actiondb=self.rundb.actiondb,
+      remote_addr=self.remote_addr,
+      json_body=json_body
+    )
+
+  def invalid_password_request(self):
+    return self.build_json_request({
+      'username': self.username,
+      'password': 'wrong password'
+    })
+
+  def correct_password_request(self, json_body={}):
+    return self.build_json_request({
+      'username': self.username,
+      'password': self.password,
+      **json_body,
+    })
 
 
   def test_get_active_runs(self):
-    request = testing.DummyRequest(rundb=self.rundb)
-    response = json.loads(fishtest.api.active_runs(request))
+    request = DummyRequest(rundb=self.rundb)
+    response = ApiView(request).active_runs()
     self.assertTrue(self.run_id in response)
 
+
   def test_get_run(self):
-    request = testing.DummyRequest(
+    request = DummyRequest(
       rundb=self.rundb,
-      matchdict={"id": self.run_id}
+      matchdict={'id': self.run_id}
     )
-    response = json.loads(fishtest.api.get_run(request))
-    self.assertEqual(self.run_id, response["_id"])
+    response = ApiView(request).get_run()
+    self.assertEqual(self.run_id, response['_id'])
+
 
   def test_get_elo(self):
-    request = testing.DummyRequest(
+    request = DummyRequest(
       rundb=self.rundb,
-      matchdict={"id": self.run_id}
+      matchdict={'id': self.run_id}
     )
-    response = json.loads(fishtest.api.get_elo(request))
+    response = ApiView(request).get_elo()
     self.assertTrue(not response)
 
-  def test_stop_run(self):
-    request = testing.DummyRequest(
-      rundb=self.rundb,
-      userdb=self.rundb.userdb,
-      json_body={"username": self.username, "password": self.password}
-    )
-    response = fishtest.api.stop_run(request)
-    self.assertTrue(not response)
 
   def test_request_task(self):
-    request = testing.DummyRequest(
-      rundb=self.rundb,
-      userdb=self.rundb.userdb,
-      remote_addr=self.remote_addr,
-      json_body={
-        "username": self.username,
-        "password": self.password,
-        "worker_info": {
-          "remote_addr": self.remote_addr,
-          "username": self.username,
-          "concurrency": 2,
-          "version": fishtest.api.WORKER_VERSION
-        }
-      }
-    )
-    response = json.loads(fishtest.api.request_task(request))
-    self.assertEqual(self.run_id, response["run"]["_id"])
-    self.assertEqual(self.task_id, response["task_id"])
+    with self.assertRaises(HTTPUnauthorized):
+      response = ApiView(self.invalid_password_request()).update_task()
+      self.assertTrue('error' in response)
+
+    run = self.rundb.get_run(self.run_id)
+    self.assertEqual(run.get('cores'), None)
+
+    run['tasks'][self.task_id] = {
+      'num_games': 250,
+      'pending': True,
+      'active': False
+    }
+    self.rundb.buffer(run, True)
+
+    request = self.correct_password_request({ 'worker_info': self.worker_info })
+    response = ApiView(request).request_task()
+    self.assertEqual(self.run_id, response['run']['_id'])
+    self.assertEqual(self.task_id, response['task_id'])
+
+    run = self.rundb.get_run(self.run_id)
+    self.assertEqual(run['cores'], self.concurrency)
+    task = run['tasks'][self.task_id]
+    self.assertTrue(task['pending'])
+    self.assertTrue(task['active'])
+
 
   def test_update_task(self):
-    request = testing.DummyRequest(
-      rundb=self.rundb,
-      userdb=self.rundb.userdb,
-      remote_addr=self.remote_addr,
-      json_body={
-        "username": self.username,
-        "password": self.password,
-        "worker_info": {
-          "remote_addr": self.remote_addr,
-          "username": self.username,
-          "concurrency": 2,
-          "version": fishtest.api.WORKER_VERSION
-        },
-        "run_id": self.run_id,
-        "task_id": self.task_id,
-        "stats": { "wins": 1, "draws": 0, "losses": 0 }
-      }
-    )
-    self.assertFalse(self.rundb.get_run(self.run_id)["results_stale"])
-    response = json.loads(fishtest.api.update_task(request))
-    self.assertTrue(response["task_alive"])
-    self.assertTrue(self.rundb.get_run(self.run_id)["results_stale"])
+    self.assertFalse(self.rundb.get_run(self.run_id)['results_stale'])
 
-    request.json_body["stats"] = { "wins": 120, "draws": 100, "losses": 0 }
-    response = json.loads(fishtest.api.update_task(request))
-    self.assertTrue(response["task_alive"])
+    with self.assertRaises(HTTPUnauthorized):
+      response = ApiView(self.invalid_password_request()).update_task()
+      self.assertTrue('error' in response)
 
-    request.json_body["stats"] = { "wins": 120, "draws": 100, "losses": 30 }
-    response = json.loads(fishtest.api.update_task(request))
-    self.assertFalse(response["task_alive"])
+    run = self.rundb.get_run(self.run_id)
+    run['tasks'][self.task_id] = {
+      'num_games': 250,
+      'pending': True,
+      'active': False
+    }
+    if run['args'].get('spsa'):
+      del run['args']['spsa']
+    self.rundb.buffer(run, True)
+    request = self.correct_password_request({ 'worker_info': self.worker_info })
+    ApiView(request).request_task()
+
+    request = self.correct_password_request({
+      'worker_info': self.worker_info,
+      'run_id': self.run_id,
+      'task_id': self.task_id,
+      'stats': { 'wins': 1, 'draws': 0, 'losses': 0 }
+    })
+
+    run = self.rundb.get_run(self.run_id)
+    run['tasks'][self.task_id]['pending'] = True
+    run['tasks'][self.task_id]['active'] = True
+    self.rundb.buffer(run, True)
+
+    response = ApiView(request).update_task()
+    self.assertTrue(response['task_alive'])
+    self.assertTrue(self.rundb.get_run(self.run_id)['results_stale'])
+
+    request.json_body['stats'] = { 'wins': 120, 'draws': 100, 'losses': 0 }
+    response = ApiView(request).update_task()
+    self.assertTrue(response['task_alive'])
+    self.assertTrue(self.rundb.get_run(self.run_id)['results_stale'])
+
+    task_num_games = run['tasks'][self.task_id]['num_games']
+    request.json_body['stats'] = { 'wins': task_num_games, 'draws': 0, 'losses': 0 }
+    response = ApiView(request).update_task()
+    self.assertTrue(self.rundb.get_run(self.run_id)['results_stale'])
+    self.assertFalse(response['task_alive'])
+
 
   def test_failed_task(self):
-    request = testing.DummyRequest(
-      rundb=self.rundb,
-      userdb=self.rundb.userdb,
-      remote_addr=self.remote_addr,
-      json_body={
-        "username": self.username,
-        "password": self.password,
-        "run_id": self.run_id,
-        "task_id": 0,
-      }
-    )
-    response = json.loads(fishtest.api.failed_task(request))
-    self.assertFalse(response["task_alive"])
+    request = self.correct_password_request({
+      'run_id': self.run_id,
+      'task_id': 0,
+    })
+    response = ApiView(request).failed_task()
+    self.assertFalse(response['task_alive'])
 
-  def test_upload_pgn(self):
-    request = testing.DummyRequest(
-      rundb=self.rundb,
-      userdb=self.rundb.userdb,
-      remote_addr=self.remote_addr,
-      json_body={
-        "username": self.username,
-        "password": self.password,
-        "run_id": self.run_id,
-        "task_id": 0,
-        "pgn": base64.b64encode(zlib.compress("1. e4".encode('utf-8'))).decode()
-      }
-    )
-    response = json.loads(fishtest.api.upload_pgn(request))
+    run = self.rundb.get_run(self.run_id)
+    run['tasks'][self.task_id]['active'] = True
+    run['tasks'][self.task_id]['worker_info'] = self.worker_info
+    self.rundb.buffer(run, True)
+    run = self.rundb.get_run(self.run_id)
+    self.assertTrue(run['tasks'][self.task_id]['active'])
+
+    request = self.correct_password_request({
+      'run_id': self.run_id,
+      'task_id': self.task_id,
+    })
+    response = ApiView(request).failed_task()
+    self.assertTrue(not response)
+    self.assertFalse(run['tasks'][self.task_id]['active'])
+
+
+  def test_stop_run(self):
+    with self.assertRaises(HTTPUnauthorized):
+      response = ApiView(self.invalid_password_request()).stop_run()
+      self.assertTrue('error' in response)
+
+    run = self.rundb.get_run(self.run_id)
+    self.assertFalse(run['finished'])
+
+    request = self.correct_password_request({ 'run_id': self.run_id })
+    response = ApiView(request).stop_run()
     self.assertTrue(not response)
 
-  def test_request_spsa(self):
-    request = testing.DummyRequest(
-      rundb=self.rundb,
-      userdb=self.rundb.userdb,
-      json_body={
-        "username": self.username,
-        "password": self.password,
-        "run_id": self.run_id,
-        "task_id": 0,
+    self.rundb.userdb.user_cache.update_one({ 'username': self.username }, {
+      '$set': {
+        'cpu_hours': 10000
       }
-    )
-    response = json.loads(fishtest.api.request_spsa(request))
-    self.assertFalse(response["task_alive"])
+    })
+    user = self.rundb.userdb.user_cache.find_one({ 'username': self.username })
+    self.assertTrue(user['cpu_hours'] == 10000)
+
+    response = ApiView(request).stop_run()
+    self.assertTrue(not response)
+
+    run = self.rundb.get_run(self.run_id)
+    self.assertTrue(run['finished'])
+    self.assertEqual(run['stop_reason'], 'API request')
+
+    run['finished'] = False
+    self.rundb.buffer(run, True)
+
+
+  def test_upload_pgn(self):
+    pgn_text = '1. e4 e5 2. d4 d5'
+    request = self.correct_password_request({
+      'run_id': self.run_id,
+      'task_id': self.task_id,
+      'pgn': base64.b64encode(zlib.compress(pgn_text.encode('utf-8'))).decode()
+    })
+    response = ApiView(request).upload_pgn()
+    self.assertTrue(not response)
+
+    pgn_filename_prefix = '{}-{}'.format(self.run_id, self.task_id)
+    pgn = self.rundb.get_pgn(pgn_filename_prefix)
+    self.assertEqual(pgn, pgn_text)
+    self.rundb.pgndb.delete_one({ 'run_id': pgn_filename_prefix })
+
+
+  def test_request_spsa(self):
+    request = self.correct_password_request({
+      'run_id': self.run_id,
+      'task_id': 0,
+    })
+    response = ApiView(request).request_spsa()
+    self.assertFalse(response['task_alive'])
+
+    run = self.rundb.get_run(self.run_id)
+    run['args']['spsa'] = {
+      'iter': 1,
+      'alpha': 1,
+      'gamma': 1,
+      'A': 1,
+      'params': [{
+        'name': 'param name',
+        'a': 1,
+        'c': 1,
+        'theta': 1,
+        'min': 0,
+        'max': 100,
+      }]
+    }
+    run['tasks'][self.task_id]['pending'] = True
+    run['tasks'][self.task_id]['active'] = True
+    self.rundb.buffer(run, True)
+    request = self.correct_password_request({
+      'run_id': self.run_id,
+      'task_id': self.task_id,
+    })
+    response = ApiView(request).request_spsa()
+    self.assertTrue(response['task_alive'])
+    self.assertTrue(response['w_params'] is not None)
+    self.assertTrue(response['b_params'] is not None)
+
 
   def test_request_version(self):
-    request = testing.DummyRequest(
-      rundb=self.rundb,
-      userdb=self.rundb.userdb,
-      json_body={"username": self.username, "password": "wrong"}
-    )
-    response = json.loads(fishtest.api.request_version(request))
-    self.assertTrue('error' in response)
-    request.json_body={"username": self.username, "password": self.password}
-    response = json.loads(fishtest.api.request_version(request))
-    self.assertEqual(fishtest.api.WORKER_VERSION, response["version"])
+    with self.assertRaises(HTTPUnauthorized):
+      response = ApiView(self.invalid_password_request()).request_version()
+      self.assertTrue('error' in response)
+
+    response = ApiView(self.correct_password_request()).request_version()
+    self.assertEqual(WORKER_VERSION, response['version'])
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
   unittest.main()

--- a/fishtest/tests/test_users.py
+++ b/fishtest/tests/test_users.py
@@ -4,7 +4,7 @@ import datetime
 from pyramid import testing
 
 from fishtest.views import login, signup
-from fishtest.api import stop_run
+from fishtest.api import ApiView
 
 import util
 
@@ -61,12 +61,12 @@ class Create50LoginTest(unittest.TestCase):
       }
     )
     response = login(request)
-    self.assertTrue('Invalid password' in request.session.pop_flash())
+    self.assertTrue('Invalid password' in request.session.pop_flash('error'))
 
     # Correct password, but still blocked from logging in
     request.params['password'] = 'secret'
     login(request)
-    self.assertTrue('Blocked' in request.session.pop_flash())
+    self.assertTrue('Blocked' in request.session.pop_flash('error'))
 
     # Unblock, then user can log in successfully
     user = self.rundb.userdb.get_user('JoeUser')
@@ -110,8 +110,8 @@ class Create90APITest(unittest.TestCase):
         'message': 'travis'
       }
     )
-    response = stop_run(request)
-    self.assertEqual(response, '{}')
+    response = ApiView(request).stop_run()
+    self.assertEqual(response, {})
     run = request.rundb.get_run(request.json_body['run_id'])
     self.assertEqual(run['stop_reason'], 'travis')
 


### PR DESCRIPTION
Added more comprehensive test coverage for API endpoints and actual use cases from workers. Simplified the API code a bit. Should be no functional change.

Add more API tests
- Use helper methods for more succinct tests
  - for building requests with invalid passwords
  - for building requests with correct passwords
- Add test cases for all API endpoints used by workers

Simplify API code
- Use a view class for API views
  - Set renderer type json for all views by default
  - Don't need manual json encoding with json renderer
- Use a separate method for authentication check
  - Use exception view for handling failed auth