### PR TITLE
Persistent logins and http-only auth cookies

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -39,8 +39,9 @@ def main(global_config, **settings):
 
   with open(os.path.expanduser('~/fishtest.secret'), 'r') as f:
     secret = f.read()
-  config.set_authentication_policy(AuthTktAuthenticationPolicy(
-    secret, callback=group_finder, hashalg='sha512'))
+  config.set_authentication_policy(
+    AuthTktAuthenticationPolicy(
+      secret, callback=group_finder, hashalg='sha512', http_only=True))
   config.set_authorization_policy(ACLAuthorizationPolicy())
 
   config.add_static_view('html', 'static/html', cache_max_age=3600)

--- a/fishtest/fishtest/templates/login.mak
+++ b/fishtest/fishtest/templates/login.mak
@@ -13,17 +13,26 @@
   <form class="form-horizontal" action="" method="POST">
     <legend>Login</legend>
     <div class="control-group">
-      <label class="control-label">Login:</label>
+      <label class="control-label">Username</label>
       <div class="controls">
-        <input name="username"/>
+        <input name="username" type="text" />
       </div>
     </div>
+
     <div class="control-group">
-      <label class="control-label">Password:</label>
+      <label class="control-label">Password</label>
       <div class="controls">
         <input name="password" type="password" />
       </div>
     </div>
+
+    <div class="control-group">
+      <label class="control-label">Stay logged in</label>
+      <div class="controls">
+        <input name="stay_logged_in" type="checkbox" />
+      </div>
+    </div>
+
     <div class="control-group">
       <div class="controls">
         <button type="submit" class="btn btn-primary">Login</button>


### PR DESCRIPTION
Login sessions now persist between browser sessions (for a year) instead of until the browser window is closed if the user checks the 'stay logged in' checkbox during login.

The auth cookie is now http-only to prevent XSS attacks from stealing user sessions. For example, if you try `alert(document.cookie)` in prod, the auth cookie currently shows up there.

Partial fix for https://github.com/glinscott/fishtest/issues/610.
Still would be nice to redirect to the page you wanted to visit before the login prompt.

---
<img src="https://user-images.githubusercontent.com/208617/79701400-ce72dd80-826a-11ea-8c2b-e8ea53f58db0.png" width="500" />