### PR TITLE
Add index to flag_cache, auto-expire after 7 days, new create_indexes.py

### DIFF
--- a/fishtest/fishtest/userdb.py
+++ b/fishtest/fishtest/userdb.py
@@ -14,9 +14,6 @@ class UserDb:
     self.top_month = self.db['top_month']
     self.flag_cache = self.db['flag_cache']
 
-  def init_collection(self):
-    self.users.create_index('username', unique=True)
-
   # Cache user lookups for 60s
   user_lock = threading.Lock()
   cache = {}

--- a/fishtest/utils/delta_update_users.py
+++ b/fishtest/utils/delta_update_users.py
@@ -152,6 +152,7 @@ def update_users():
   users = build_users(machines, info)
   rundb.userdb.user_cache.remove()
   rundb.userdb.user_cache.insert(users)
+  rundb.userdb.user_cache.create_index('username', unique=True)
 
   rundb.userdb.top_month.remove()
   rundb.userdb.top_month.insert(build_users(machines, top_month))


### PR DESCRIPTION
Follow-up to https://github.com/glinscott/fishtest/pull/611
- Add indexes to `flag_cache` and `user_cache` for faster lookups and lower CPU usage
- `flag_cache` documents auto-expire after 7 days using a MongoDB TTL index
- create_indexes.py now takes a list of collection names as arguments
  - since it's rare to need to re-create ALL indexes, and re-building pgn indexes is very slow
  - with no arguments, it only prints the indexes on all collections
  - for each collection name given, it drops then creates indexes on the collection

Strictly speaking, the index on IP in flag_cache should be a unique index, but practically a non-unique index avoids race conditions, and documents in this collection auto-expire anyways.

The `flag_cache` collection will need to be dropped (or have the timestamp field added to each document) for the auto-expiring to start working:

```python
from pymongo import MongoClient

conn = MongoClient()
conn['fishtest_new'].drop_collection('flag_cache')
```


See MongoDB docs for more info on TTL indexes:
https://docs.mongodb.com/manual/core/index-ttl/