### PR TITLE
Fallback to a default tests_repo for old runs

### DIFF
--- a/fishtest/fishtest/helpers.py
+++ b/fishtest/fishtest/helpers.py
@@ -1,6 +1,9 @@
+def tests_repo(run):
+  return run['args'].get('tests_repo', 'https://github.com/official-stockfish/Stockfish')
+
 def diff_url(run):
   return "{}/compare/{}...{}".format(
-    run['args'].get('tests_repo', 'https://github.com/mcostalba/FishCooking'),
+    tests_repo(run),
     run['args']['resolved_base'][:7],
     run['args']['resolved_new'][:7]
   )

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -266,7 +266,7 @@ Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smoot
       $copyDiffBtn = null;
     }
 
-    const apiUrlBase = "${run['args']['tests_repo']}".replace("//github.com/", "//api.github.com/repos/");
+    const apiUrlBase = "${h.tests_repo(run)}".replace("//github.com/", "//api.github.com/repos/");
     const diffApiUrl = apiUrlBase + "/compare/${run['args']['resolved_base'][:7]}...${run['args']['resolved_new'][:7]}";
 
     // Fetch the diff and decide whether to render it


### PR DESCRIPTION
Old runs are missing the `tests_repo` key because they're hardcoded to `https://github.com/mcostalba/FishCooking`.

this PR should fix https://github.com/glinscott/fishtest/issues/615 but it's probably cleaner to do a data migration and set that `tests_repo` value for old runs instead of hard-coding it in the code.