### PR TITLE
Simplify displaying params in SPSA table

### DIFF
--- a/fishtest/fishtest/static/css/application.css
+++ b/fishtest/fishtest/static/css/application.css
@@ -21,3 +21,13 @@
 th {
   cursor: pointer;
 }
+
+/* tests_view page */
+.spsa-param-row td {
+  text-align: right;
+  padding-right: 10px;
+}
+
+.spsa-param-row td:first-child {
+  text-align: left;
+}

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -8,7 +8,7 @@
         integrity="sha384-4FeI0trTH/PCsLWrGCD1mScoFu9Jf2NdknFdFoJhXZFwsvzZ3Bo5sAh7+zL8Xgnd"
         crossorigin="anonymous"
         rel="stylesheet">
-  <link href="/css/application.css" rel="stylesheet">
+  <link href="/css/application.css?v=1" rel="stylesheet">
 
   <script src="https://code.jquery.com/jquery-3.4.1.min.js"
           integrity="sha384-vk5WoKIaW/vJyUAd9n/wmopsmNhiy+L2Z+SBxGYnUkunIxVxAv/UtMOhba/xskxh"

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -24,7 +24,7 @@
 
 <div class="row-fluid">
 
-<div class="span8">
+<div class="span8" style="min-width: 540px">
   <h4>Details</h4>
 
 	<%! import markupsafe %>
@@ -51,7 +51,7 @@
                 </thead>
                 <tbody>
                   %for row in arg[1][1:]:
-                    <tr>
+                    <tr class="spsa-param-row">
                       %for element in row:
                         <td>${element}</td>
                       %endfor
@@ -112,6 +112,7 @@
 
   <br/>
   <br/>
+
   %if run.get('base_same_as_master') is not None:
     <div id="master-diff"
         class="alert ${'alert-success' if run['base_same_as_master'] else 'alert-error'}">
@@ -129,13 +130,13 @@
 
   <form class="form" action="/tests/modify" method="POST">
     <label class="control-label">Number of games:</label>
-    <input name="num-games" value="${run['args']['num_games']}">
+    <input type="text" name="num-games" value="${run['args']['num_games']}">
 
     <label class="control-label">Adjust priority (higher is more urgent):</label>
-    <input name="priority" value="${run['args']['priority']}">
+    <input type="text" name="priority" value="${run['args']['priority']}">
 
     <label class="control-label">Adjust throughput%:</label>
-    <input name="throughput" value="${run['args'].get('throughput', 1000)}">
+    <input type="text" name="throughput" value="${run['args'].get('throughput', 1000)}">
 
     <input type="hidden" name="run" value="${run['_id']}" />
     <button type="submit" class="btn btn-primary">Modify</button>
@@ -164,24 +165,30 @@
 </div>
 
 %if 'spsa' in run['args']:
-<div id="div_spsa_preload" style="background-image:url('/img/preload.gif'); width: 256px; height: 32px; display: none;">
-<div style="height: 100%; width: 100%; text-align:center; padding-top: 5px;">
-Loading graph...
-</div></div>
-<div id="div_spsa_error" style="display: none; border: 1px solid red; color: red; width: 400px; "></div>
-<div id="chart_toolbar" style="display: none;">
-Gaussian Kernel Smoother&nbsp;&nbsp;<div class="btn-group"><button id="btn_smooth_plus" class="btn">&nbsp;&nbsp;&nbsp;+&nbsp;&nbsp;&nbsp;</button>
-<button id="btn_smooth_minus" class="btn">&nbsp;&nbsp;&nbsp;−&nbsp;&nbsp;&nbsp;</button>
-</div>
-<div class="btn-group">
-<button id="btn_view_individual" type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-    View Individual Parameter<span class="caret"></span>
-  </button>
-  <ul class="dropdown-menu" role="menu" id="dropdown_individual"></ul>
-</div>
-<button id="btn_view_all" class="btn">View All</button>
-</div>
-<div id="div_spsa_history_plot"></div>
+  <div id="div_spsa_preload" style="background-image:url('/img/preload.gif'); width: 256px; height: 32px; display: none;">
+    <div style="height: 100%; width: 100%; text-align: center; padding-top: 5px;">
+    Loading graph...
+    </div>
+  </div>
+
+  <div id="div_spsa_error" style="display: none; border: 1px solid red; color: red; width: 400px"></div>
+  <div id="chart_toolbar" style="display: none">
+    Gaussian Kernel Smoother&nbsp;&nbsp;
+    <div class="btn-group">
+      <button id="btn_smooth_plus" class="btn">&nbsp;&nbsp;&nbsp;+&nbsp;&nbsp;&nbsp;</button>
+      <button id="btn_smooth_minus" class="btn">&nbsp;&nbsp;&nbsp;−&nbsp;&nbsp;&nbsp;</button>
+    </div>
+
+    <div class="btn-group">
+      <button id="btn_view_individual" type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+        View Individual Parameter<span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu" role="menu" id="dropdown_individual"></ul>
+    </div>
+
+    <button id="btn_view_all" class="btn">View All</button>
+  </div>
+  <div id="div_spsa_history_plot"></div>
 %endif
 
 <section id="diff-section" style="display: none">

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -1000,12 +1000,12 @@ def tests_view(request):
       for p in params:
         value.append([
           p['name'],
-          p['theta'],
-          p['start'],
-          p['min'],
-          p['max'],
-          '{:.6f}'.format(p['c'] / (iter_local ** gamma)),
-          '{:.6f}'.format(p['a'] / (A + iter_local) ** alpha)
+          '{:.2f}'.format(p['theta']),
+          int(p['start']),
+          int(p['min']),
+          int(p['max']),
+          '{:.3f}'.format(p['c'] / (iter_local ** gamma)),
+          '{:.3f}'.format(p['a'] / (A + iter_local) ** alpha)
         ])
     if 'tests_repo' in run['args']:
       if name == 'new_tag':


### PR DESCRIPTION
- Use integers for numbers that start off as ints
- Right-align numbers to line up digits and decimal points
- Show less sig figs when not needed

---
Before
![image](https://user-images.githubusercontent.com/208617/79909332-cc378d00-83ea-11ea-9097-4887b6e88c49.png)

---
After
![image](https://user-images.githubusercontent.com/208617/79909352-d6f22200-83ea-11ea-86a3-c52b6c511dc9.png)
