### PR TITLE
Show short new/base commit hashes on tests_view pages

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -60,6 +60,8 @@
                 </tbody>
               </table>
             </td>
+          %elif arg[0] in ['resolved_new', 'resolved_base']:
+            <td>${arg[1][:7]}</td>
           %else:
             <td>${str(markupsafe.Markup(arg[1])).replace('\n', '<br>') | n}</td>
           %endif


### PR DESCRIPTION
Edit: i changed this PR to show short hashes on tests_view pages since when copying the hashes, it's more common to use a short prefix than the entire hash. the links are removed since the `base_tag` and `new_tag` fields link to the commit already. maybe there's a better way to present this info more succinctly?

---

<img src="https://user-images.githubusercontent.com/208617/80018311-d36ea180-84a3-11ea-826c-34463158d4dc.png" width="500" />
