### PR TITLE
Disable base branch/signature fields for SPSA tests

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -122,18 +122,18 @@
              value="${args.get('new_tag', '')}" ${'readonly' if is_rerun else ''}>
 
       <label class="field-label">Base branch</label>
-      <input type="text" name="base-branch"
+      <input type="text" name="base-branch" id="base-branch"
              value="${args.get('base_tag', 'master')}" ${'readonly' if is_rerun else ''}>
     </div>
 
     <div class="flex-row">
       <label class="field-label leftmost">Test signature</label>
-      <input type="number" name="test-signature" class="no-arrows"
+      <input type="number" name="test-signature" class="no-arrows" id="test-signature"
              placeholder="Defaults to last commit message"
              value="${args.get('new_signature', '')}" ${'readonly' if is_rerun else ''}>
 
       <label class="field-label">Base signature</label>
-      <input type="number" name="base-signature" class="no-arrows"
+      <input type="number" name="base-signature" class="no-arrows" id="base-signature"
              value="${args.get('base_signature', bench)}" ${'readonly' if is_rerun else ''}>
     </div>
 
@@ -348,6 +348,22 @@
       $('.stop_rule').hide();
       $('#stop_rule_field').val(stop_rule);
       $('.' + stop_rule).show();
+      if (stop_rule === 'spsa') {
+        // base branch and test branch should be the same for SPSA tests
+        $('#base-branch').attr('readonly', 'true').val($('#test-branch').val());
+        $('#test-branch').on('input', function() {
+          $('#base-branch').val($(this).val());
+        })
+        $('#base-signature').attr('readonly', 'true').val($('#test-signature').val());
+        $('#test-signature').on('input', function() {
+          $('#base-signature').val($(this).val());
+        })
+      } else {
+        $('#base-branch').removeAttr('readonly');
+        $('#base-signature').removeAttr('readonly');
+        $('#test-branch').off('input');
+        $('#test-signature').off('input');
+      }
       if (stop_rule === 'sprt') {
         update_sprt_bounds($('select[name=bounds]').val());
       }


### PR DESCRIPTION
The base branch/signature should always match the test branch/signature for SPSA tests.

In this PR, when a user selects an SPSA test type, the base branch/signature fields are disabled and match whatever the user puts into the test branch/signature fields. This change prevents people from submitting invalid SPSA tests through the UI. Users can also safely do less work by not having to copy/paste the same info into two sets of fields.

Fixes https://github.com/linrock/Stockfish/commit/a548e8e66f544fba3b174c27d27a9a939e5a5759#commitcomment-38631870

---

![image](https://user-images.githubusercontent.com/208617/80016672-6e19b100-84a1-11ea-9fba-3535dca4e890.png)
