### PR TITLE
Server changes to set the batch size for sprt tests.

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -40,7 +40,7 @@ class RunDb:
     self.runs = self.db['runs']
     self.deltas = self.db['deltas']
 
-    self.chunk_size = 250
+    self.chunk_size = 200
 
     global last_rundb
     last_rundb = self
@@ -559,6 +559,10 @@ class RunDb:
         or (spsa_games > 0 and 'stats' in task and num_games <= old_num_games)
         ):
       return {'task_alive': False}
+    if 'sprt' in run['args']:
+      batch_size=2*run['args']['sprt'].get('batch_size',1)
+      if num_games%batch_size != 0:
+        return {'task_alive': False}
 
     all_tasks_finished = False
 

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -405,16 +405,21 @@ def validate_form(request):
   data['base_same_as_master'] = master_diff.text is ''
 
   # Integer parameters
+
   if stop_rule == 'sprt':
+    sprt_batch_size_games=8
+    assert(sprt_batch_size_games%2==0)
+    assert(request.rundb.chunk_size%sprt_batch_size_games==0)
     data['sprt'] = fishtest.stats.stat_util.SPRT(alpha=0.05,
                                                  beta=0.05,
                                                  elo0=float(request.POST['sprt_elo0']),
                                                  elo1=float(request.POST['sprt_elo1']),
-                                                 elo_model='logistic')
+                                                 elo_model='logistic',
+                                                 batch_size=sprt_batch_size_games//2)  #game pairs
     # Limit on number of games played.
     # Shouldn't be hit in practice as long as it is larger than > ~200000
     # must scale with chunk_size to avoid overloading the server.
-    data['num_games'] = 1000 * request.rundb.chunk_size
+    data['num_games'] = 2000 * request.rundb.chunk_size
   elif stop_rule == 'spsa':
     data['num_games'] = int(request.POST['num-games'])
     if data['num_games'] <= 0:

--- a/fishtest/tests/test_api.py
+++ b/fishtest/tests/test_api.py
@@ -186,7 +186,7 @@ class TestApi(unittest.TestCase):
 
     # Task is still active
     request.json_body['stats'] = {
-      'wins': 120, 'draws': 100, 'losses': 0, 'crashes': 0
+      'wins': 90, 'draws': 100, 'losses': 0, 'crashes': 0
     }
     response = ApiView(request).update_task()
     self.assertTrue(response['task_alive'])


### PR DESCRIPTION
Server changes to set the batch size for sprt tests.
    
In this PR the batch size is set to 8 which seems like a reasonable value. As the batch size has to be a divisor of the chunk size, the latter was changed to 200 (formerly 250). To compensate  for the smaller chunk size the initial maximum number of games for an sprt test is changed to 2000 times the chunk size (formerly 1000 times the chunk size).
    
 One unittest is updated.
