### PR TITLE
Hide master diff link if base branch is same as stockfish master

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -123,8 +123,11 @@
       %endif
     </div>
   %endif
-  <a href="https://github.com/official-stockfish/Stockfish/compare/master...${run['args']['resolved_base'][:7]}"
-     target="_blank" rel="noopener">Master diff</a>
+
+  %if not run.get('base_same_as_master'):
+    <a href="https://github.com/official-stockfish/Stockfish/compare/master...${run['args']['resolved_base'][:7]}"
+       target="_blank" rel="noopener">Master diff</a>
+  %endif
 
   <hr>
 


### PR DESCRIPTION
The master diff link now only shows up if:

- the base branch is not the same as stockfish master
- we don't know if the base branch is the same (old runs)

See https://github.com/glinscott/fishtest/issues/625#issuecomment-618030661