### PR TITLE
Set page title on test pages to test type+branches

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -284,6 +284,19 @@
 
 <script type="text/javascript" src="/js/highlight.diff.min.js"></script>
 <script>
+  %if run['args'].get('sprt'):
+    const test_type = 'SPRT';
+    const subtitle = '${run['args']['new_tag']} vs ${run['args']['base_tag']}';
+  %elif run['args'].get('spsa'):
+    const test_type = 'SPSA';
+    const subtitle = '${run['args']['new_tag']}';
+  %else:
+    const test_type = '${run['args']['num_games']} games';
+    const subtitle = '- ${run['args']['new_tag']} vs ${run['args']['base_tag']}';
+  %endif
+
+  document.title = test_type + ' ' + subtitle + ' | Stockfish Testing';
+
   $(function() {
     let $copyDiffBtn = $("#copy-diff");
     if (document.queryCommandSupported && document.queryCommandSupported("copy")) {


### PR DESCRIPTION
If you have a lot of stockfish test browser tabs open, they all say `Stockfish Testing Framework` which makes it hard to look for a particular test you might have open.

On tests pages, depending on the test type, the browser tab titles will be more descriptive:

- SPRT testBranchName vs master
- SPSA tuningBranchName
- 5000 games - anotherTestBranch