### PR TITLE
Adjust time estimate

### DIFF
--- a/fishtest/utils/delta_update_users.py
+++ b/fishtest/utils/delta_update_users.py
@@ -9,7 +9,7 @@ from pymongo import DESCENDING
 # For tasks
 sys.path.append(os.path.expanduser('~/fishtest/fishtest'))
 from fishtest.rundb import RunDb
-from fishtest.views import parse_tc, delta_date
+from fishtest.views import estimate_game_duration, delta_date
 
 new_deltas = {}
 skip = False
@@ -30,7 +30,7 @@ def process_run(run, info, deltas=None):
     else:
       info[username]['tests'] += 1
 
-  tc = parse_tc(run['args']['tc'])
+  tc = estimate_game_duration(run['args']['tc'])
   for task in run['tasks']:
     if 'worker_info' not in task:
       continue
@@ -59,7 +59,7 @@ def process_run(run, info, deltas=None):
 
 def build_users(machines, info):
   for machine in machines:
-    games_per_hour = (machine['nps'] / 1200000.0) * (3600.0 / parse_tc(machine['run']['args']['tc'])) * int(machine['concurrency'])
+    games_per_hour = (machine['nps'] / 1600000.0) * (3600.0 / estimate_game_duration(machine['run']['args']['tc'])) * (int(machine['concurrency']) // machine['run']['args'].get('threads', 1))
     info[machine['username']]['games_per_hour'] += games_per_hour
 
   users = []

--- a/worker/games.py
+++ b/worker/games.py
@@ -163,7 +163,7 @@ def kill_process(p):
     pass
 
 def adjust_tc(tc, base_nps, concurrency):
-  factor = 1600000.0 / base_nps
+  factor = 1600000.0 / base_nps # 1.6Mnps is the reference core, also used in fishtest views.
   if base_nps < 700000:
     sys.stderr.write('This machine is too slow to run fishtest effectively - sorry!\n')
     sys.exit(1)


### PR DESCRIPTION
* rename parse_tc to estimate_game_duration: as that is what it does
* in this routine, use the current average number of moves per game (68),
  as well as the percentage of time used (92).
* Use the correct reference nps to adjust tc in views, this must match the value in the worker 1.6Mnps
* take threading of a test into account to estimate game rate.

These changes should result in more accurate estimates for games/minute and duration.

It will also affect the displayed CPU hours contribution attributed to a user,
as that is estimated from the number of games played. The latter quantity is unaffected.