### PR TITLE
Update page titles to match browser tab names

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -12,7 +12,7 @@
 %endif
 
 <h3>
-  <span>${run['args']['new_tag']} vs ${run['args']['base_tag']}</span>
+  <span>${page_title}</span>
   <a href="${h.diff_url(run)}" target="_blank" rel="noopener">diff</a>
 </h3>
 
@@ -283,18 +283,7 @@
 
 <script type="text/javascript" src="/js/highlight.diff.min.js"></script>
 <script>
-  %if run['args'].get('sprt'):
-    const test_type = 'SPRT';
-    const subtitle = '${run['args']['new_tag']} vs ${run['args']['base_tag']}';
-  %elif run['args'].get('spsa'):
-    const test_type = 'SPSA';
-    const subtitle = '${run['args']['new_tag']}';
-  %else:
-    const test_type = '${run['args']['num_games']} games';
-    const subtitle = '- ${run['args']['new_tag']} vs ${run['args']['base_tag']}';
-  %endif
-
-  document.title = test_type + ' ' + subtitle + ' | Stockfish Testing';
+  document.title = '${page_title}';
 
   $(function() {
     let $copyDiffBtn = $("#copy-diff");

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -1031,8 +1031,19 @@ def tests_view(request):
     last_updated = task.get('last_updated', datetime.datetime.min)
     task['last_updated'] = last_updated
 
-  return {'run': run, 'run_args': run_args, 'chi2': calculate_residuals(run),
+  if run['args'].get('sprt'):
+    page_title = 'SPRT {} vs {}'.format(run['args']['new_tag'], run['args']['base_tag'])
+  elif run['args'].get('spsa'):
+    page_title = 'SPSA {}'.format(run['args']['new_tag'])
+  else:
+    page_title = '{} games - {} vs {}'.format(
+      run['args']['num_games'],
+      run['args']['new_tag'],
+      run['args']['base_tag']
+    )
+  return {'run': run, 'run_args': run_args, 'page_title': page_title,
           'approver': has_permission('approve_run', request.context, request),
+          'chi2': calculate_residuals(run),
           'totals': '(%s active worker%s with %s core%s)'
           % (active, ('s' if active != 1 else ''),
              cores, ('s' if cores != 1 else ''))}


### PR DESCRIPTION
So when viewing a test page, the page title shows up like this:

- SPRT testBranchName vs master
- SPSA tuningBranchName
- 5000 games - anotherTestBranch

Instead of always like this regardless of test type:

- testBranchName vs testBranchName