### PR TITLE
Link to your tests in the sidebar for logged-in users

### DIFF
--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -33,6 +33,9 @@
       <li><a href="/tests/finished?success_only=1">Greens</a></li>
       <li><a href="/tests/finished?yellow_only=1">Yellows</a></li>
       <li><a href="/tests/finished?ltc_only=1">LTC</a></li>
+      %if request.authenticated_userid:
+        <li><a href="/tests/user/${request.authenticated_userid}">My tests</a></li>
+      %endif
       <li><a href="/tests/run">New</a></li>
 
       <li class="nav-header">Misc</li>


### PR DESCRIPTION
So you can get back to the list of your tests from any page on the site. Right now, most pages have no direct way of getting back to your tests.

See https://github.com/glinscott/fishtest/issues/625#issuecomment-619228174