### PR TITLE
Provide remote_addr="127.0.0.1" argument to DummyRequest in test_user…

### DIFF
--- a/fishtest/tests/test_users.py
+++ b/fishtest/tests/test_users.py
@@ -26,6 +26,7 @@ class Create10UsersTest(unittest.TestCase):
     request = testing.DummyRequest(
       userdb=self.rundb.userdb,
       method='POST',
+      remote_addr="127.0.0.1",
       params={
         'username': 'JoeUser',
         'password': 'secret',


### PR DESCRIPTION
…s.py.

Without this PR I get, when I invoke test_users.py locally,
```
======================================================================
ERROR: test_create_user (__main__.Create10UsersTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_users.py", line 36, in test_create_user
    response = signup(request)
  File "/home/fishtest/fishtest/fishtest/fishtest/views.py", line 101, in signup
    'remoteip': request.remote_addr}
AttributeError: 'DummyRequest' object has no attribute 'remote_addr'

----------------------------------------------------------------------
```