### PR TITLE
Enable submit test button if arriving from browser back button

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -292,6 +292,12 @@
 </form>
 
 <script type="text/javascript">
+  $(window).bind('pageshow', function() {
+    // If pressing the 'back' button to get back to this page, make sure
+    // the submit test button is enabled again.
+    $('#submit-test').removeAttr('disabled').text('Submit test');
+  });
+
   const preset_bounds = {
     'standard STC': [-0.5, 1.5],
     'standard LTC': [0.25, 1.75],


### PR DESCRIPTION
When using the browser back button to get to the 'create new test' form, the submit button might be stuck in the 'Submitting test...' state.

This PR should fix that issue in Firefox. Chrome didn't seem to have the issue. Fixes https://github.com/glinscott/fishtest/issues/647