### PR TITLE
Enforce even sized worker updates.

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -553,12 +553,14 @@ class RunDb:
     # Guard against incorrect results
     count_games = lambda d: d['wins'] + d['losses'] + d['draws']
     num_games = count_games(stats)
-    old_num_games = count_games(task['stats']) if 'stats' in task else num_games
+    old_num_games = count_games(task['stats']) if 'stats' in task else 0
     spsa_games = count_games(spsa) if 'spsa' in run['args'] else 0
     if (num_games < old_num_games
         or (spsa_games > 0 and num_games <= 0)
         or (spsa_games > 0 and 'stats' in task and num_games <= old_num_games)
         ):
+      return {'task_alive': False}
+    if (num_games-old_num_games)%2!=0: # the worker should only runs game pairs
       return {'task_alive': False}
     if 'sprt' in run['args']:
       batch_size=2*run['args']['sprt'].get('batch_size',1)

--- a/fishtest/tests/test_rundb.py
+++ b/fishtest/tests/test_rundb.py
@@ -54,7 +54,7 @@ class CreateRunDBTest(unittest.TestCase):
     run = self.rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': self.rundb.chunk_size-3,
                                              'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker2')
     self.assertEqual(run, {'task_alive': False})
-    run = self.rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': self.rundb.chunk_size-3,
+    run = self.rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': self.rundb.chunk_size-4,
                                              'crashes': 0, 'time_losses': 0}, 1000000, '', 'worker1')
     self.assertEqual(run, {'task_alive': True})
     run = self.rundb.update_task(run_id, 0, {'wins': 1, 'losses': 1, 'draws': self.rundb.chunk_size-2,


### PR DESCRIPTION
The current worker cannot handle tasks with an odd number of games.
On the other hand it will (should...) never send odd sized updates
itself. Enforce this contract server side.

Some unit tests updated.