### PR TITLE
Some code cleanup in the worker

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -27,7 +27,7 @@ from updater import update
 from datetime import datetime
 from os import path
 
-WORKER_VERSION = 75
+WORKER_VERSION = 76
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 


### PR DESCRIPTION
The worker code is serial and hence in principle
quite simple. Unfortunately it has grown organically
and currently it is not so easy too follow anymore.
This makes the idea of adding new types of tests
rather unattractive.

This is PR is the first timid attempt at cleaning
up some of the worker code.

This version of the worker should be functionally
equivalent to version 75. 

The most notable changes are

- The global variable old_stats is eliminated. The fact
that such a global variable exists needlessly complicates the
logic of the worker code.

- Trinomial and pentanomial frequencies are
now kept in sync for all types of tests. This simplifies
the code a lot.

- More asserts have been added.