### PR TITLE
Show username in page titles when viewing a user's tests

### DIFF
--- a/fishtest/fishtest/templates/tests_user.mak
+++ b/fishtest/fishtest/templates/tests_user.mak
@@ -3,3 +3,7 @@
 <h2>${username}</h2>
 
 <%include file="run_tables.mak"/>
+
+<script>
+  document.title = '${username} | Stockfish Testing';
+</script>

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -292,7 +292,7 @@
 
 <script type="text/javascript" src="/js/highlight.diff.min.js"></script>
 <script>
-  document.title = '${page_title}';
+  document.title = '${page_title} | Stockfish Testing';
 
   $(function() {
     let $copyDiffBtn = $("#copy-diff");


### PR DESCRIPTION
So if you have a browser tab open while viewing a user's tests, it will show their username in the tab title instead of just "Stockfish Testing Framework"