### PR TITLE
Show link to original test when viewing a rescheduled test

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -68,6 +68,7 @@ class RunDb:
               msg_new='',
               base_signature='',
               new_signature='',
+              rescheduled_from=None,
               base_same_as_master=None,
               start_time=None,
               sprt=None,
@@ -129,6 +130,9 @@ class RunDb:
       'approved': False,
       'approver': '',
     }
+
+    if rescheduled_from:
+      new_run['rescheduled_from'] = rescheduled_from
 
     return self.runs.insert_one(new_run).inserted_id
 

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -289,6 +289,10 @@
     <input type="hidden" name="msg_base" value="${args.get('msg_base', '')}">
     <input type="hidden" name="msg_new" value="${args.get('msg_new', '')}">
   %endif
+
+  %if is_rerun:
+    <input type="hidden" name="rescheduled_from" value="${rescheduled_from}">
+  %endif
 </form>
 
 <script type="text/javascript">

--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -62,6 +62,8 @@
             </td>
           %elif arg[0] in ['resolved_new', 'resolved_base']:
             <td>${arg[1][:7]}</td>
+          %elif arg[0] == 'rescheduled_from':
+            <td><a href="/tests/view/${arg[1]}">${arg[1]}</a></td>
           %else:
             <td>${str(markupsafe.Markup(arg[1])).replace('\n', '<br>') | n}</td>
           %endif

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -324,6 +324,9 @@ def validate_form(request):
     'info': request.POST['run-info'],
   }
 
+  if request.POST.get('rescheduled_from'):
+    data['rescheduled_from'] = request.POST['rescheduled_from']
+
   def strip_message(m):
     s = re.sub(r"[Bb]ench[ :]+[0-9]{7}\s*", "", m)
     s = re.sub(r"[ \t]+", " ", s)
@@ -496,6 +499,7 @@ def tests_run(request):
 
   return {'args': run_args,
           'is_rerun': len(run_args) > 0,
+          'rescheduled_from': request.params['id'] if 'id' in request.params else None,
           'tests_repo': u.get('tests_repo', ''),
           'bench': get_master_bench()}
 
@@ -679,6 +683,8 @@ def tests_view(request):
   results = request.rundb.get_results(run)
   run['results_info'] = format_results(results, run)
   run_args = [('id', str(run['_id']), '')]
+  if run.get('rescheduled_from'):
+    run_args.append(('rescheduled_from', run['rescheduled_from'], ''))
 
   for name in ['new_tag', 'new_signature', 'new_options', 'resolved_new',
                'base_tag', 'base_signature', 'base_options', 'resolved_base',


### PR DESCRIPTION
Implements vondele's suggestion here:
https://github.com/glinscott/fishtest/issues/625#issuecomment-617950457

So you can easily see which test a re-run came from and then get to it.
 
---
<img src="https://user-images.githubusercontent.com/208617/81512941-9f440f00-92f2-11ea-8276-d4ca36a41a85.png" width="500"/>