### PR TITLE
Fix some chars showing up as html entities in test commit msgs

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -71,7 +71,11 @@
       %else:
         <tr>
           <td>${arg[0]}</td>
-          <td><a href="${arg[2]}" target="_blank" rel="noopener">${arg[1]}</a></td>
+          <td>
+            <a href="${arg[2]}" target="_blank" rel="noopener">
+              ${str(markupsafe.Markup(arg[1]))}
+            </a>
+          </td>
         </tr>
       %endif
     %endfor

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -746,7 +746,8 @@ def tests_view(request):
         strval = str(value)
       except:
         strval = value.encode('ascii', 'replace')
-      strval = html.escape(strval)
+      if name not in ['new_tag', 'base_tag']:
+        strval = html.escape(strval)
       run_args.append((name, strval, url))
 
   active = 0


### PR DESCRIPTION
So apostrophes don't show up as `&#x27;`

Before:
new_tag `tDblpawns (Tune doubled pawns penalty using vondele&#x27;s tuning )`

After:
new_tag `tDblpawns (Tune doubled pawns penalty using vondele's tuning )`