### PR TITLE
Handle rate_limit API call failure

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -493,11 +493,11 @@ def run_games(worker_info, password, remote, run, task_id):
   if not os.path.exists(testing_dir):
     os.makedirs(testing_dir)
 
-  # clean up old engines (keeping the 25 most recent)
+  # clean up old engines (keeping the 50 most recent)
   engines = glob.glob(os.path.join(testing_dir, 'stockfish_*' + EXE_SUFFIX))
-  if len(engines) > 25:
+  if len(engines) > 50:
     engines.sort(key=os.path.getmtime)
-    for old_engine in engines[:len(engines)-25]:
+    for old_engine in engines[:-50]:
       try:
          os.remove(old_engine)
       except:

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -28,7 +28,7 @@ from updater import update
 from datetime import datetime
 from os import path
 
-WORKER_VERSION = 77
+WORKER_VERSION = 78
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 
@@ -85,7 +85,13 @@ rate = None
 
 def get_rate():
   global rate
-  rate = requests.get('https://api.github.com/rate_limit', timeout=HTTP_TIMEOUT).json()['rate']
+  try:
+    rate = requests.get('https://api.github.com/rate_limit', timeout=HTTP_TIMEOUT).json()['rate']
+  except Exception as e:
+    sys.stderr.write('Exception fetching rate_limit:\n')
+    print(e)
+    rate = { 'remaining': 0, 'limit': 5000 }
+    return True
   remaining = rate['remaining']
   print("API call rate limits:", rate)
   return remaining >= math.sqrt(rate['limit'])


### PR DESCRIPTION
See https://github.com/glinscott/fishtest/pull/662#issuecomment-626908989

After first failure of `rate_limit` call switch to precompiled tests.

It will retry after finishing the received 200 game batch.