### PR TITLE
Fix race condition with request_task/stop_run

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -661,7 +661,6 @@ class RunDb:
     if run is None:
       run = self.get_run(run_id)
       save_it = True
-    run.pop('cores', None)
     run['tasks'] = [task for task in run['tasks'] if 'stats' in task]
     for task in run['tasks']:
       task['pending'] = False


### PR DESCRIPTION
Dropping 'cores' from run in stop_run causes sort to fail in
request_task

```
May 23 12:30:48 tests pserve[23821]:   File "/home/fishtest/fishtest/fishtest/fishtest/rundb.py", line 524, in <lambda>
May 23 12:30:48 tests pserve[23821]:     r['cores'] / r['args']['itp'] * 100.0,
May 23 12:30:48 tests pserve[23821]: KeyError: 'cores'

```