### PR TITLE
Adjust Elo range on dial for live_elo

### DIFF
--- a/fishtest/fishtest/static/html/SPRTcalculator.html
+++ b/fishtest/fishtest/static/html/SPRTcalculator.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <title>Chess SPRT Calculator</title>
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+        <link href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
         <style>
             .form-control.number {
               width: 4em;

--- a/fishtest/fishtest/static/html/live_elo.html
+++ b/fishtest/fishtest/static/html/live_elo.html
@@ -4,9 +4,9 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Elo estimates from SPRT tests</title>
-    <link rel="stylesheet" type="text/css" href="/css/live_elo.css?1">
+    <link rel="stylesheet" type="text/css" href="/css/live_elo.css?2">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
   </head>
   <body>
     <div class="container">

--- a/fishtest/fishtest/static/js/live_elo.js
+++ b/fishtest/fishtest/static/js/live_elo.js
@@ -81,7 +81,7 @@ function set_gauges(LLR,a,b,LOS,elo,ci_lower,ci_upper){
         width: 500, height: 150,
         yellowFrom: a, yellowTo: b,
         max:b, min: a,
-        minorTicks: 5
+        minorTicks: 3
     };
     LLR_chart.draw(LLR_chart_data, LLR_chart_options);
 
@@ -91,8 +91,8 @@ function set_gauges(LLR,a,b,LOS,elo,ci_lower,ci_upper){
     ]);
     var ELO_chart_options = {
         width: 500, height: 150,
-        max:6, min: -6,
-        minorTicks: 5
+        max:4, min: -4,
+        minorTicks: 4
     };
     if(ci_lower<0 && ci_upper>0){
         ELO_chart_options.redFrom=ci_lower;


### PR DESCRIPTION
small change reducing the range on the Elo dial from [-6, 6] -> [-4, 4].
Covers 99.9% of patches, and gives a little more details for typical patches around 1Elo.