### PR TITLE
Add a default test contempt parameter

### DIFF
--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -97,19 +97,19 @@
       <label class="field-label leftmost">Test type</label>
       <div class="btn-group choose-test-type">
         <div class="btn" id="fast_test"
-             data-options='{"tc": "10+0.1", "threads": 1, "options": "Hash=16", "bounds": "standard STC"}'>
+             data-options='{"tc": "10+0.1", "threads": 1, "options": "Hash=16 Contempt=24", "bounds": "standard STC"}'>
           short (STC)
         </div>
         <div class="btn" id="slow_test"
-             data-options='{"tc": "60+0.6", "threads": 1, "options": "Hash=64", "bounds": "standard LTC"}'>
+             data-options='{"tc": "60+0.6", "threads": 1, "options": "Hash=64 Contempt=24", "bounds": "standard LTC"}'>
           long (LTC)
         </div>
         <div class="btn" id="fast_smp_test"
-             data-options='{"tc": "5+0.05", "threads": 8, "options": "Hash=64", "bounds": "standard STC"}'>
+             data-options='{"tc": "5+0.05", "threads": 8, "options": "Hash=64 Contempt=24", "bounds": "standard STC"}'>
           SMP (STC)
         </div>
         <div class="btn" id="slow_smp_test"
-             data-options='{"tc": "20+0.2", "threads": 8, "options": "Hash=256", "bounds": "standard LTC"}'>
+             data-options='{"tc": "20+0.2", "threads": 8, "options": "Hash=256 Contempt=24", "bounds": "standard LTC"}'>
           SMP (LTC)
         </div>
       </div>

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -143,11 +143,11 @@
     <div class="flex-row">
       <label class="field-label leftmost">Test options</label>
       <input type="text" name="new-options"
-             value="${args.get('new_options', 'Hash=16')}">
+             value="${args.get('new_options', 'Hash=16 Contempt=24')}">
 
       <label class="field-label">Base options</label>
       <input type="text" name="base-options"
-             value="${args.get('base_options', 'Hash=16')}">
+             value="${args.get('base_options', 'Hash=16 Contempt=24')}">
     </div>
 
     <div class="flex-row">


### PR DESCRIPTION
Add a default parameter for contempt to fishtest.  This allows us the flexibility to use a separate default contempt for fishtest testing from SF own default contempt.  Currently it's set to 24 to keep things the same but I don't know what the best value for testing purposes should be.  Discussion is welcome here.
See comments in https://github.com/official-stockfish/Stockfish/pull/2740

Note: I am unfamiliar with .mak files so if my changes aren't correct please advise.  Also I'm not sure if lines 146 and 150 should also be changed and if so what the exact syntax should be.  Ty.