### PR TITLE
List 25 items on view pages

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -787,7 +787,7 @@ def get_paginated_finished_runs(request):
   ltc_only = request.params.get('ltc_only', False)
 
   page_idx = max(0, int(request.params.get('page', 1)) - 1)
-  page_size = 50
+  page_size = 25
   finished_runs, num_finished_runs = request.rundb.get_finished_runs(
     username=username, success_only=success_only,
     yellow_only=yellow_only, ltc_only=ltc_only,


### PR DESCRIPTION
Reduce from 50 for less IO and faster response.

See https://github.com/glinscott/fishtest/issues/690#issuecomment-647110579