### PR TITLE
Clean up parse_cutechess_output()

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -28,7 +28,7 @@ from updater import update
 from datetime import datetime
 from os import path
 
-WORKER_VERSION = 80
+WORKER_VERSION = 81
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 


### PR DESCRIPTION
Clean up the code removing the calls to `kill_process()`.
In this way also the Windows worker, where at the moment the cutechess-cli
STDERR is queued after the STDOUT, is able to process the STDERR.
Thanks to @vdbergh for the suggestion.