### PR TITLE
Use the string literal '' as iter() sentinel

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -198,12 +198,9 @@ def adjust_tc(tc, base_nps, concurrency):
   return scaled_tc, tc_limit
 
 def enqueue_output(out, queue):
-  try:
-    for line in iter(out.readline, b''):
-      queue.put(line)
-    out.close()
-  except: # Happens on closed file/killed process
-    return
+  for line in iter(out.readline, ''):
+    queue.put(line)
+
 
 w_params = None
 b_params = None


### PR DESCRIPTION
File objects for stdin, stdout and stderr by default are opened in bynary mode
and require a byte string literal b'' as iter() sentinel.

We have opened the file objects for stdout and stderr in text mode using the
"universal_newlines=True" argument in subprocess.Popen() so use the string
literal '' as iter() sentinel. Using b'' as sentinel is wrong and floods the
queue with void lines.

Drop the unnecessary closing of the stdout pipe, already done in kill_process()