### PR TITLE
Worker changes for NNUE testing

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -28,7 +28,7 @@ from updater import update
 from datetime import datetime
 from os import path
 
-WORKER_VERSION = 81
+WORKER_VERSION = 82
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 


### PR DESCRIPTION
combined set of patches for the net download and architecture selection. (i.e. on top of https://github.com/glinscott/fishtest/pull/733)

This should be sufficient to have the worker do the right thing for the NNUE testing (modulo bugs and oversights).

I've connected my worker to this test https://dfts-0.pigazzini.it/tests/view/5f25614a9106dbb0ea3b5b57 with these patches. Seems OK.

To be done:
 - [x] add one line of output showing the architecture determined
 - [x] deal with cpuinfo failing on msys2 python (done, parse g++ output)
 - [x] use proper server name for download (prod, not dev). This can only be done after prod has been updated with #736
 - [x] increase the worker version number
 - [x] squash commit
 - [x] adjust documentation for testing (wip https://github.com/glinscott/fishtest/wiki/Creating-my-first-test#nnue-net-tests)
 - [ ] announce changes on fishcooking