### PR TITLE
Remove x86-64-sse42 target (corresponds to Stockfish pull request)

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -193,18 +193,12 @@ def find_arch_string():
         res='x86-64-bmi2'
      elif '-mavx2' in props['flags'] and 'x86-64-avx2' in targets:
         res='x86-64-avx2'
-     elif '-msse4.2' in props['flags'] and 'x86-64-sse42' in targets:
-        res='x86-64-sse42'
      elif '-mpopcnt' in props['flags'] and '-msse4.1' in props['flags'] and 'x86-64-modern' in targets:
         res='x86-64-modern'
-     elif '-msse4.1' in props['flags'] and 'x86-64-sse41' in targets:
-        res='x86-64-sse41'
      elif '-mssse3' in props['flags'] and 'x86-64-ssse3' in targets:
         res='x86-64-ssse3'
      elif '-mpopcnt' in props['flags'] and '-msse3' in props['flags'] and 'x86-64-sse3-popcnt' in targets:
         res='x86-64-sse3-popcnt'
-     elif '-msse3' in props['flags'] and 'x86-64-sse3' in targets:
-        res='x86-64-sse3'
      else:
         res='x86-64'
   else:


### PR DESCRIPTION
I'm not sure what exactly I should do here, but in the Stockfish pull request (https://github.com/official-stockfish/Stockfish/pull/2922 ) vondele said that fishtest worker needs to be changed also.
I don't know how to test this change but this seems simple enough?
I understand that versions need to be incremented. This is NOT done here.

Corresponds to the above-mentioned change for the Stockfish Makefile, however, should work now as is (as SSE4.2 is not used by Stockfish now, other than to display that it was compiled with SSE4.2 support).
