### PR TITLE
Change default auto-purge to false.

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -76,7 +76,7 @@ class RunDb:
               spsa=None,
               username=None,
               tests_repo=None,
-              auto_purge=True,
+              auto_purge=False,
               throughput=100,
               priority=0):
     if start_time is None:

--- a/fishtest/fishtest/templates/tests_run.mak
+++ b/fishtest/fishtest/templates/tests_run.mak
@@ -310,8 +310,7 @@
 
     <div class="flex-row">
       <label class="field-label leftmost">Advanced</label>
-      <input type="checkbox" name="auto-purge" checked="checked"
-             value="True" />
+      <input type="checkbox" name="auto-purge" value="False" />
       <span style="margin-left: 10px">Auto-purge</span>
     </div>
   </section>


### PR DESCRIPTION
currently, with NNUE we expect the different hardware to have slightly different result.
Auto-purge would need to take the ARCH=.. tags into account to work correctly.
As a zero-th order fix, switch default to off.

partially addresses #727