### PR TITLE
Reduce somewhat the minimum NPS

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -293,7 +293,7 @@ def kill_process(p):
 
 def adjust_tc(tc, base_nps, concurrency):
   factor = 1600000.0 / base_nps # 1.6Mnps is the reference core, also used in fishtest views.
-  if base_nps < 700000:
+  if base_nps < 500000:
     sys.stderr.write('This machine is too slow to run fishtest effectively - sorry!\n')
     sys.exit(1)
 


### PR DESCRIPTION
with NNUE some machines get excluded (e.g. opteron cores), which we could keep

Non-urgent worker change.