### PR TITLE
Finding the default net from sources.

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -361,13 +361,26 @@ def get_sha(branch, repo_url):
 
 
 def get_net(branch, repo_url):
-  """ Get the net from ucioption.cpp in the repo """
+  """ Get the net from evaluate.h or ucioption.cpp in the repo """
   api_url = repo_url.replace('https://github.com',
                              'https://raw.githubusercontent.com')
   try:
-    api_url = api_url + '/' + branch +  '/src/ucioption.cpp'
-    options = requests.get(api_url).content.decode('utf-8')
     net = None
+
+    url1 = api_url + '/' + branch +  '/src/evaluate.h'
+    options = requests.get(url1).content.decode('utf-8')
+    for line in options.splitlines():
+      if 'EvalFileDefaultName' in line and 'define' in line:
+        p = re.compile('nn-[a-z0-9]{12}.nnue')
+        m = p.search(line)
+        if m:
+          net = m.group(0)
+
+    if net:
+       return net
+
+    url2 = api_url + '/' + branch +  '/src/ucioption.cpp'
+    options = requests.get(url2).content.decode('utf-8')
     for line in options.splitlines():
       if 'EvalFile' in line and 'Option' in line:
         p = re.compile('nn-[a-z0-9]{12}.nnue')

--- a/worker/games.py
+++ b/worker/games.py
@@ -75,8 +75,21 @@ def required_net(engine):
   return net
 
 def required_net_from_source():
-  """ Parse ucioption.cpp to find default net"""
+  """ Parse evaluate.h and ucioption.cpp to find default net"""
   net = None
+
+  # NNUE code after binary embedding (Aug 2020)
+  with open('evaluate.h','r') as srcfile:
+    for line in srcfile.readlines():
+       if 'EvalFileDefaultName' in line and 'define' in line:
+          p = re.compile('nn-[a-z0-9]{12}.nnue')
+          m = p.search(line)
+          if m:
+             net = m.group(0)
+  if net:
+     return net
+
+  # NNUE code before binary embedding (Aug 2020)
   with open('ucioption.cpp','r') as srcfile:
     for line in srcfile.readlines():
        if 'EvalFile' in line and 'Option' in line:


### PR DESCRIPTION
the changes needed to embed the net in the binary:
https://github.com/official-stockfish/Stockfish/pull/3070

need a change in the magic for finding the default net from sources on both the server and worker. This should be merged before we can merge the above PR

For backwards compatibility we now need to look for the name of the default net in two places.