### PR TITLE
Rescale TC with new NPS

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -1137,7 +1137,7 @@ def homepage_results(request):
         machine["last_updated"] = delta_date(machine["last_updated"])
         if machine["nps"] != 0:
             games_per_minute += (
-                (machine["nps"] / 1600000.0)
+                (machine["nps"] / 1200000.0)
                 * (60.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
                 * (
                     int(machine["concurrency"])

--- a/fishtest/utils/delta_update_users.py
+++ b/fishtest/utils/delta_update_users.py
@@ -69,7 +69,7 @@ def process_run(run, info, deltas=None):
 def build_users(machines, info):
     for machine in machines:
         games_per_hour = (
-            (machine["nps"] / 1600000.0)
+            (machine["nps"] / 1200000.0)
             * (3600.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
             * (int(machine["concurrency"]) // machine["run"]["args"].get("threads", 1))
         )

--- a/worker/games.py
+++ b/worker/games.py
@@ -418,7 +418,7 @@ def kill_process(p):
 
 def adjust_tc(tc, base_nps, concurrency):
     factor = (
-        1600000.0 / base_nps
+        1200000.0 / base_nps
     )  # 1.6Mnps is the reference core, also used in fishtest views.
     if base_nps < 500000:
         sys.stderr.write(


### PR DESCRIPTION
as discussed in https://github.com/glinscott/fishtest/issues/764

use 1.2MNPS instead of 1.6MNPS to account for the bench slowdown after merging NNUE.
This effectively reduces TC by 25%.

No functional change.