### PR TITLE
Link username to user tests page from tests_view pages

### DIFF
--- a/fishtest/fishtest/templates/tests_view.mak
+++ b/fishtest/fishtest/templates/tests_view.mak
@@ -34,8 +34,13 @@
       %if len(arg[2]) == 0:
         <tr>
           <td>${arg[0]}</td>
-          %if arg[0] == 'username' and approver:
-            <td><a href="/user/${arg[1]}">${arg[1]}</a></td>
+          %if arg[0] == 'username':
+            <td>
+              <a href="/tests/user/${arg[1]}">${arg[1]}</a>
+              %if approver:
+                (<a href="/user/${arg[1]}">user admin</a>)
+              %endif
+            </td>
           %elif arg[0] == 'spsa':
             <td>
               ${arg[1][0]}<br />


### PR DESCRIPTION
Fixes https://github.com/glinscott/fishtest/issues/625#issuecomment-629713265 as suggested by @silversolver1

> I mean on the page of an actual test where a user can access the stop/purge, reschedule or modify buttons, next to where the value for itp is listed, there is the word "username". here, the user's particular name does not currently link to that user's /tests/user/ page, which is the feature I am suggesting

I agree this is more practical since I've also commonly wanted to go see a list of the user's tests while on an individual test page.

---
Approvers will see a link to the user admin page in addition to the link to the user tests page.

![image](https://user-images.githubusercontent.com/208617/92331692-79333f00-f046-11ea-9d7e-4ef49d2442c9.png)
