### PR TITLE
Use separate homepage sections for pending and paused tests

### DIFF
--- a/fishtest/fishtest/static/js/application.js
+++ b/fishtest/fishtest/static/js/application.js
@@ -15,12 +15,19 @@ $(() => {
             .forEach(tr => body.appendChild(tr));
     });
 
-    // clicking Show/Hide on Pending tests and Machines sections toggles them
+    // clicking Show/Hide on Pending + Paused tests and Machines sections toggles them
     $("#pending-button").click(function () {
         var active = $(this).text().trim() === 'Hide';
         $(this).text(active ? 'Show' : 'Hide');
         $("#pending").slideToggle(150);
         $.cookie('pending_state', $(this).text().trim());
+    });
+
+    $("#paused-button").click(function () {
+        var active = $(this).text().trim() === 'Hide';
+        $(this).text(active ? 'Show' : 'Hide');
+        $("#paused").slideToggle(150);
+        $.cookie('paused_state', $(this).text().trim());
     });
 
     let fetchingMachines = false;

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -18,7 +18,7 @@
           crossorigin="anonymous"></script>
 
   <script src="/js/jquery.cookie.js" defer></script>
-  <script src="/js/application.js?v=3" defer></script>
+  <script src="/js/application.js?v=4" defer></script>
 
   <%block name="head"/>
 </head>

--- a/fishtest/fishtest/templates/run_tables.mak
+++ b/fishtest/fishtest/templates/run_tables.mak
@@ -1,6 +1,9 @@
 %if page_idx == 0:
+  <% pending_approval_runs = [run for run in runs['pending'] if not run['approved']] %>
+  <% paused_runs = [run for run in runs['pending'] if run['approved']] %>
+
   <h3>
-    Pending - ${len(runs['pending'])} tests
+    Pending approval - ${len(pending_approval_runs)} tests
     <button id="pending-button" class="btn">
       ${'Hide' if pending_shown else 'Show'}
     </button>
@@ -8,10 +11,26 @@
 
   <div id="pending"
        style="${'' if pending_shown else 'display: none;'}">
-    %if len(runs['pending']) == 0:
-      No pending runs
+    %if pending_approval_runs:
+      <%include file="run_table.mak" args="runs=pending_approval_runs, show_delete=True"/>
     %else:
-      <%include file="run_table.mak" args="runs=runs['pending'], show_delete=True"/>
+      No tests pending approval
+    %endif
+  </div>
+
+  <h3>
+    Paused - ${len(paused_runs)} tests
+    <button id="paused-button" class="btn">
+      ${'Hide' if paused_shown else 'Show'}
+    </button>
+  </h3>
+
+  <div id="paused"
+       style="${'' if paused_shown else 'display: none;'}">
+    %if paused_runs:
+      <%include file="run_table.mak" args="runs=paused_runs, show_delete=True"/>
+    %else:
+      No paused tests
     %endif
   </div>
 

--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -1198,4 +1198,5 @@ def tests(request):
         **last_tests,
         "machines_shown": request.cookies.get("machines_state") == "Hide",
         "pending_shown": request.cookies.get("pending_state") == "Hide",
+        "paused_shown": request.cookies.get("paused_state") == "Hide",
     }


### PR DESCRIPTION
The `Pending` section currently mixes both tests that are pending approval, and inactive approved tests.

This separates the `Pending` section into two separate sections:
- `Pending approval` - tests that are not yet approved
- `Paused` - tests that either haven't started running yet, or were modified to have a priority of -1

Open to renaming these sections to whatever people feel is most clear.

Fixes https://github.com/glinscott/fishtest/issues/716