### PR TITLE
Restore waitress default for connections/threads

### DIFF
--- a/fishtest/production.ini
+++ b/fishtest/production.ini
@@ -29,8 +29,8 @@ trusted_proxy_headers = x-forwarded-for x-forwarded-host x-forwarded-proto x-for
 clear_untrusted_proxy_headers = yes
 
 # Match connection limit with max number of workers
-connection_limit = 500
-threads = 16
+connection_limit = 100
+threads = 4
 
 ###
 # logging configuration


### PR DESCRIPTION
Default values and higher values showed the same performance in some tests with
2000 machines 17000 cores.

Restoring the threads default values allows to save some RAM useful
to raise the MongoDB cache.