### PR TITLE
Adjust SPSA batch size

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -999,14 +999,15 @@ def run_games(worker_info, password, remote, run, task_id):
         tc_limit *= 2
 
     while games_remaining > 0:
+
+        batch_size = games_concurrency * 32  # update frequency
+
         if spsa_tuning:
-            games_to_play = min(games_concurrency * 2, games_remaining)
+            games_to_play = min(batch_size, games_remaining)
             pgnout = []
         else:
             games_to_play = games_remaining
             pgnout = ["-pgnout", pgn_name]
-
-        batch_size = games_concurrency * 2  # update frequency
 
         if "sprt" in run["args"]:
             batch_size = 2 * run["args"]["sprt"].get("batch_size", 1)

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -33,7 +33,7 @@ from os import path
 from games import run_games
 from updater import update
 
-WORKER_VERSION = 86
+WORKER_VERSION = 87
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 


### PR DESCRIPTION
change from 2 to 32 concurrency, should reduce load on the server with
many workers and running SPSA tasks.

This potentially improves
https://github.com/glinscott/fishtest/issues/792
https://github.com/glinscott/fishtest/issues/784