### PR TITLE
Fix SyntaxWarning: "is" with a literal

### DIFF
--- a/fishtest/fishtest/views.py
+++ b/fishtest/fishtest/views.py
@@ -577,7 +577,7 @@ def validate_form(request):
     master_diff = requests.get(
         api_url, headers={"Accept": "application/vnd.github.v3.diff"}
     )
-    data["base_same_as_master"] = master_diff.text is ""
+    data["base_same_as_master"] = master_diff.text == ""
 
     # Test existence of net
     new_net = get_net(data["new_tag"], data["tests_repo"])


### PR DESCRIPTION
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

The compiler now produces a SyntaxWarning when identity checks (is and is not)
are used with certain types of literals (e.g. strings, numbers).
These can often work by accident in CPython, but are not guaranteed by the
language spec.
The warning advises users to use equality tests (== and !=) instead.