### PR TITLE
Disable concurrent tranfers for aws s3

### DIFF
--- a/fishtest/utils/backup.sh
+++ b/fishtest/utils/backup.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Backup MongoDB to AWS S3
+# https://docs.aws.amazon.com/cli/latest/topic/s3-config.html
 # List available backups with:
 # ${VENV}/bin/aws s3 ls s3://fishtest/backup/archive/
 # Download a backup with:
@@ -16,4 +17,5 @@ tar -cv dump | gzip -1 > dump.tar.gz
 rm -rf dump
 
 date_utc=$(date +%Y%m%d --utc)
+${VENV}/bin/aws configure set default.s3.max_concurrent_requests 1
 ${VENV}/bin/aws s3 cp dump.tar.gz s3://fishtest/backup/archive/${date_utc}/dump.tar.gz


### PR DESCRIPTION
This stops the division in chunks of the file keeping low the CPU load
during the scheduled backups

See https://docs.aws.amazon.com/cli/latest/topic/s3-config.html