### PR TITLE
Enable toggling between light and dark mode

### DIFF
--- a/fishtest/fishtest/static/css/application.css
+++ b/fishtest/fishtest/static/css/application.css
@@ -6,6 +6,10 @@
   }
 }
 
+body {
+  transition: background 0.2s ease-in-out;
+}
+
 .flash-message {
   margin-top: 20px;
 }
@@ -34,4 +38,8 @@ th {
 
 .spsa-param-row td:first-child {
   text-align: left;
+}
+
+#change-color-theme:hover {
+  cursor: pointer;
 }

--- a/fishtest/fishtest/static/css/theme.dark.css
+++ b/fishtest/fishtest/static/css/theme.dark.css
@@ -1,0 +1,127 @@
+/* A custom dark color theme for overriding bootstrap 2.3.2 css rules */
+
+body {
+  background: #111;
+  color: #fafafa;
+}
+
+a {
+  color: #63daff;
+}
+
+a:hover, a:focus {
+  color: #e1ffff;
+}
+
+.btn-link {
+  color: #63daff;
+}
+
+.btn {
+  text-shadow: none;
+}
+
+.btn:focus {
+  outline: none;
+}
+
+legend {
+  color: #fafafa;
+}
+
+hr {
+  border-top: 1px solid #444;
+  border-bottom: 1px solid #333;
+}
+
+/* Left-side main navigation sidebar */
+.nav-header {
+  color: #ccc;
+}
+
+.nav-list>li>a, .nav-list .nav-header {
+  text-shadow: 0 1px 0 rgba(10, 10, 10, 0.5);
+}
+
+.nav>li>a:hover, .nav>li>a:focus {
+  background: #222;
+}
+
+/* Tables */
+.table {
+  color: #fafafa;
+}
+
+.table-striped tbody>tr:nth-child(odd)>td, .table-striped tbody>tr:nth-child(odd)>th {
+  background-color: #222;
+}
+
+.table th, .table td {
+  border-top: 1px solid #444;
+}
+
+/* Text inputs and selects */
+textarea, input[type="text"], input[type="password"],
+input[type="datetime"], input[type="datetime-local"], input[type="date"],
+input[type="month"], input[type="time"], input[type="week"], input[type="number"],
+input[type="email"], input[type="url"], input[type="search"], input[type="tel"],
+input[type="color"], .uneditable-input {
+  background: #444;
+  border: 1px solid #101010;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.5);
+}
+
+textarea:focus, input[type="text"]:focus, input[type="password"]:focus,
+input[type="datetime"]:focus, input[type="datetime-local"]:focus, input[type="date"]:focus,
+input[type="month"]:focus, input[type="time"]:focus, input[type="week"]:focus,
+input[type="number"]:focus, input[type="email"]:focus, input[type="url"]:focus,
+input[type="search"]:focus, input[type="tel"]:focus, input[type="color"]:focus,
+.uneditable-input:focus {
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgb(106 216 241 / 60%);
+}
+
+select, textarea, input[type="text"], input[type="password"],
+input[type="datetime"], input[type="datetime-local"], input[type="date"],
+input[type="month"], input[type="time"], input[type="week"], input[type="number"],
+input[type="email"], input[type="url"], input[type="search"], input[type="tel"],
+input[type="color"], .uneditable-input {
+  color: white;
+}
+
+select {
+  border: 1px solid #555;
+  background-color: #333;
+}
+
+select:focus, input[type="file"]:focus,
+input[type="radio"]:focus, input[type="checkbox"]:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+/* Button groups */
+.btn-group>.btn:not(.btn-info) {
+  background: #2f2f2f;
+  border-color: #333;
+  color: white;
+}
+
+/* Pagination links */
+.pagination ul>li>a, .pagination ul>li>span {
+  background-color: #111;
+  border-color: #292929;
+}
+
+.pagination ul>li>a:hover, .pagination ul>li>a:focus, .pagination ul>.active>a, .pagination ul>.active>span {
+  background-color: #333;
+}
+
+/* Overrides a color that's way too light on test tasks pages */
+td[style*="background-color:#ffebeb"] {
+  background: #5f1c1c !important;
+}
+
+/* Overrides "green" description text in /nns page */
+span[style*="background-color:palegreen"] {
+  color: #111;
+}

--- a/fishtest/fishtest/static/html/live_elo.html
+++ b/fishtest/fishtest/static/html/live_elo.html
@@ -6,7 +6,19 @@
     <title>Elo estimates from SPRT tests</title>
     <link rel="stylesheet" type="text/css" href="/css/live_elo.css?2">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+          integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
+          rel="stylesheet"
+          crossorigin="anonymous">
+    <script>
+      if (document.cookie.match(/theme=dark/)) {
+        const linkEl = document.createElement('link');
+        linkEl.href = "/css/theme.dark.css";
+        linkEl.rel = "stylesheet";
+        linkEl.integrity = "UAj9GRYDzOc97Pf4kC10t9FR1xjPLDCgu0Z4GLusexg=";
+        document.querySelector("head").appendChild(linkEl);
+      }
+    </script>
   </head>
   <body>
     <div class="container">

--- a/fishtest/fishtest/static/js/application.js
+++ b/fishtest/fishtest/static/js/application.js
@@ -16,14 +16,14 @@ $(() => {
     });
 
     // clicking Show/Hide on Pending + Paused tests and Machines sections toggles them
-    $("#pending-button").click(function () {
+    $("#pending-button").click(function() {
         var active = $(this).text().trim() === 'Hide';
         $(this).text(active ? 'Show' : 'Hide');
         $("#pending").slideToggle(150);
         $.cookie('pending_state', $(this).text().trim());
     });
 
-    $("#paused-button").click(function () {
+    $("#paused-button").click(function() {
         var active = $(this).text().trim() === 'Hide';
         $(this).text(active ? 'Show' : 'Hide');
         $("#paused").slideToggle(150);
@@ -31,7 +31,7 @@ $(() => {
     });
 
     let fetchingMachines = false;
-    $("#machines-button").click(function () {
+    $("#machines-button").click(function() {
         const active = $(this).text().trim() === 'Hide';
         $(this).text(active ? 'Show' : 'Hide');
         if (!active && !$("#machines table")[0] && !fetchingMachines) {
@@ -40,6 +40,29 @@ $(() => {
         }
         $("#machines").toggle();
         $.cookie('machines_state', $(this).text().trim());
+    });
+
+    // Click the sun/moon icons to change the color theme of the site
+    let theme = $.cookie('theme') || 'light';
+    $("#change-color-theme").click(function() {
+      if (theme === 'light') {
+        $("#sun").hide();
+        $("#moon").show();
+        $("<link>")
+          .attr("href", "/css/theme.dark.css")
+          .attr("rel", "stylesheet")
+          .attr("integrity", "sha256-UAj9GRYDzOc97Pf4kC10t9FR1xjPLDCgu0Z4GLusexg=")
+          .appendTo($("head"));
+        theme = 'dark';
+      } else {
+        $("#sun").show();
+        $("#moon").hide();
+        $('head link[href*="/css/theme.dark.css"]').remove();
+        theme = 'light';
+      }
+      $.cookie('theme', theme, {
+        path: '/',
+      });
     });
 
     // CSRF protection for links and forms

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -8,7 +8,10 @@
         integrity="sha384-4FeI0trTH/PCsLWrGCD1mScoFu9Jf2NdknFdFoJhXZFwsvzZ3Bo5sAh7+zL8Xgnd"
         crossorigin="anonymous"
         rel="stylesheet">
-  <link href="/css/application.css?v=2" rel="stylesheet">
+  <link href="/css/application.css?v=3" rel="stylesheet">
+  %if request.cookies.get('theme') == 'dark':
+    <link href="/css/theme.dark.css" rel="stylesheet">
+  %endif
 
   <script src="https://code.jquery.com/jquery-3.4.1.min.js"
           integrity="sha384-vk5WoKIaW/vJyUAd9n/wmopsmNhiy+L2Z+SBxGYnUkunIxVxAv/UtMOhba/xskxh"
@@ -75,6 +78,15 @@
         %else:
           <a href="/pending">Pending</a>
         %endif
+      </li>
+      <li>
+        <br>
+        <svg id="change-color-theme" viewBox="0 0 8 8" style="width: 20px; height: 20px; background: none;">
+          <path id="sun" style="fill: black; ${'display: none;' if request.cookies.get('theme') == 'dark' else ''}"
+                d="M4 0c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm-2.5 1c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm5 0c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm-2.5 1c-1.105 0-2 .895-2 2s.895 2 2 2 2-.895 2-2-.895-2-2-2zm-3.5 1.5c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm7 0c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm-6 2.5c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm5 0c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm-2.5 1c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5z"></path>
+          <path id="moon" style="fill: white; ${'display: none;' if request.cookies.get('theme') != 'dark' else ''}"
+                d="M2.719 0c-1.58.53-2.719 2.021-2.719 3.781 0 2.21 1.79 4 4 4 1.76 0 3.251-1.17 3.781-2.75-.4.14-.831.25-1.281.25-2.21 0-4-1.79-4-4 0-.44.079-.881.219-1.281z"></path>
+        </svg>
       </li>
     </ul>
   </div>

--- a/fishtest/fishtest/templates/signup.mak
+++ b/fishtest/fishtest/templates/signup.mak
@@ -6,7 +6,7 @@
 
 <div>
   <p></p>
-  <p>Signing up to fishtest allows you to contribute with CPU time or with patches to test. </p>
+  <p>Signing up to fishtest allows you to contribute with CPU time or with patches to test.</p>
   <p>Your contribution is much appreciated.</p>
   <p>Once a new user account is created, a human needs to manually activate it. This is usually quick, but sometimes takes a few hours.</p>
 
@@ -17,7 +17,7 @@
     <div class="control-group">
       <label class="control-label">Username:</label>
       <div class="controls">
-        <input name="username" pattern="[A-Za-z0-9]{2,}"
+        <input name="username" pattern="[A-Za-z0-9]{2,}" type="text"
                title="Only letters and digits and at least 2 long" required="required"/>
       </div>
     </div>

--- a/fishtest/fishtest/templates/tests_stats.mak
+++ b/fishtest/fishtest/templates/tests_stats.mak
@@ -25,15 +25,18 @@
 <html lang="en-us">
   <head>
     <title>Raw statistics for ${run['_id']}</title>
-	<link href="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css"
-	      integrity="sha384-4FeI0trTH/PCsLWrGCD1mScoFu9Jf2NdknFdFoJhXZFwsvzZ3Bo5sAh7+zL8Xgnd"
-	      crossorigin="anonymous"
-	      rel="stylesheet">
+    <link href="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css"
+          integrity="sha384-4FeI0trTH/PCsLWrGCD1mScoFu9Jf2NdknFdFoJhXZFwsvzZ3Bo5sAh7+zL8Xgnd"
+          crossorigin="anonymous"
+          rel="stylesheet">
     <style>
       td {
         width: 20%;
       }
     </style>
+    %if request.cookies.get('theme') == 'dark':
+      <link href="/css/theme.dark.css" rel="stylesheet">
+    %endif
   </head>
   <body>
 % if not has_spsa:


### PR DESCRIPTION
This PR adds a sun and a moon icon to the bottom of the sidebar. Clicking on the icons will switch the site between light and dark modes. Dark mode is implemented as a CSS file that's injected into the page to override the default CSS.

<img src="https://user-images.githubusercontent.com/208617/95801555-a4a1ed00-0cc8-11eb-911f-4d7dff52bab9.png" width="80" /><img src="https://user-images.githubusercontent.com/208617/95801566-ad92be80-0cc8-11eb-8e26-eb2b6a7d51c7.png" width="80" />

Example of how the homepage looks in dark mode:

![image](https://user-images.githubusercontent.com/208617/95801675-1843fa00-0cc9-11eb-87b3-b1afb77b592c.png)

All suggestions welcome! Some pages that I was unable to view in dev may have unreadable text in dark mode and will need to be fixed. Some standalone pages don't use bootstrap 2 so they haven't been updated to respect dark mode yet. 

Fixes https://github.com/glinscott/fishtest/issues/599