### PR TITLE
Use sun/moon icons for actions

### DIFF
--- a/fishtest/fishtest/static/js/application.js
+++ b/fishtest/fishtest/static/js/application.js
@@ -46,8 +46,8 @@ $(() => {
     let theme = $.cookie('theme') || 'light';
     $("#change-color-theme").click(function() {
       if (theme === 'light') {
-        $("#sun").hide();
-        $("#moon").show();
+        $("#sun").show();
+        $("#moon").hide();
         $("<link>")
           .attr("href", "/css/theme.dark.css")
           .attr("rel", "stylesheet")
@@ -55,8 +55,8 @@ $(() => {
           .appendTo($("head"));
         theme = 'dark';
       } else {
-        $("#sun").show();
-        $("#moon").hide();
+        $("#sun").hide();
+        $("#moon").show();
         $('head link[href*="/css/theme.dark.css"]').remove();
         theme = 'light';
       }

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -82,9 +82,9 @@
       <li>
         <br>
         <svg id="change-color-theme" viewBox="0 0 8 8" style="width: 20px; height: 20px; background: none;">
-          <path id="sun" style="fill: black; ${'display: none;' if request.cookies.get('theme') == 'dark' else ''}"
+          <path id="sun" style="fill: white; ${'display: none;' if request.cookies.get('theme') != 'dark' else ''}"
                 d="M4 0c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm-2.5 1c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm5 0c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm-2.5 1c-1.105 0-2 .895-2 2s.895 2 2 2 2-.895 2-2-.895-2-2-2zm-3.5 1.5c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm7 0c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm-6 2.5c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm5 0c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5zm-2.5 1c-.276 0-.5.224-.5.5s.224.5.5.5.5-.224.5-.5-.224-.5-.5-.5z"></path>
-          <path id="moon" style="fill: white; ${'display: none;' if request.cookies.get('theme') != 'dark' else ''}"
+          <path id="moon" style="fill: black; ${'display: none;' if request.cookies.get('theme') == 'dark' else ''}"
                 d="M2.719 0c-1.58.53-2.719 2.021-2.719 3.781 0 2.21 1.79 4 4 4 1.76 0 3.251-1.17 3.781-2.75-.4.14-.831.25-1.281.25-2.21 0-4-1.79-4-4 0-.44.079-.881.219-1.281z"></path>
         </svg>
       </li>


### PR DESCRIPTION
The current status is obvious for light/dark modes.
Use the sun/moon icons for the action (switch to the alternative mode).

https://ux.stackexchange.com/questions/39418/night-day-mode-toggle
https://ux.stackexchange.com/questions/1318/should-a-toggle-button-show-its-current-state-or-the-state-to-which-it-will-chan?rq=1