### PR TITLE
Increase active timeout settings

### DIFF
--- a/fishtest/fishtest/rundb.py
+++ b/fishtest/fishtest/rundb.py
@@ -315,7 +315,7 @@ class RunDb:
         self.run_cache_lock.release()
 
     def scavenge(self, run):
-        old = datetime.utcnow() - timedelta(minutes=30)
+        old = datetime.utcnow() - timedelta(minutes=110)
         for task in run["tasks"]:
             if task["active"] and task["last_updated"] < old:
                 task["active"] = False

--- a/fishtest/utils/scavenge.py
+++ b/fishtest/utils/scavenge.py
@@ -13,7 +13,7 @@ from fishtest.rundb import RunDb
 rundb = RunDb()
 
 
-def scavenge_tasks(scavenge=True, minutes=60):
+def scavenge_tasks(scavenge=True, minutes=120):
     """Check for tasks that have not been updated recently"""
     for run in rundb.runs.find({"tasks": {"$elemMatch": {"active": True}}}):
         changed = False
@@ -25,7 +25,7 @@ def scavenge_tasks(scavenge=True, minutes=60):
                 task["active"] = False
                 changed = True
         if changed and scavenge:
-            rundb.runs.save(run)
+            rundb.runs.replace_one({"_id": run["_id"]}, run)
 
 
 def main():

--- a/worker/games.py
+++ b/worker/games.py
@@ -1005,7 +1005,7 @@ def run_games(worker_info, password, remote, run, task_id):
 
     while games_remaining > 0:
 
-        batch_size = games_concurrency * 32  # update frequency
+        batch_size = games_concurrency * 4  # update frequency
 
         if spsa_tuning:
             games_to_play = min(batch_size, games_remaining)

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -33,7 +33,7 @@ from os import path
 from games import run_games
 from updater import update
 
-WORKER_VERSION = 87
+WORKER_VERSION = 88
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 


### PR DESCRIPTION
Increase timeout settings because we now batch SPSA results.

In addition workers with 7 or more cores will never show as active because they post only results after 200 played games.
This is caused by a batch size of 32*concurrency.

@vondele I remember you suggested to increase this setting? What would you suggest?

We could adjust with concurrency of workers and NPS.

EDIT: See also https://github.com/glinscott/fishtest/issues/809