### PR TITLE
Mark reported core count on tests if suspicious (main test page).

### DIFF
--- a/fishtest/fishtest/templates/run_table.mak
+++ b/fishtest/fishtest/templates/run_table.mak
@@ -123,7 +123,8 @@ ${pagination()}
           %endif
           @ ${run['args']['tc']} th ${str(run['args'].get('threads',1))}
           <br>
-          ${('cores: '+str(run['cores'])) if not run['finished'] and 'cores' in run else ''}
+          ${('cores: '+("~" if (datetime.utcnow() - run["last_updated"] > timedelta(hours=1)) else "")
+                      +str(run['cores'])) if not run['finished'] and 'cores' in run else ''}
         </td>
 
         <td style="word-break: break-word;">


### PR DESCRIPTION
[ For discussion, not necessarily this exact code change. May not be appropriate for SPSA, I am not sure. ]

Nice work guys on #792 and #809 !

In a similar matter, but not for spsa jobs, I think jobs often appear active but actually have no active cores running if many workers are withdrawn from fishtest at one time. If fishtest is getting more jobs at the time, the number of cores to allocate to individual jobs decreases and the job does not even get a few extra cores to add to the missing cores which fishtest thinks are still there.
Depending on timeouts / the normal fluctuation of worker allocation, fishtest eventually corrects itself, but it can be frustrating if the user realises their job is not progressing.

Could we do a patch something like this PR to add a subtle indication that the cores number may be unreliable? This would give us a bit more feedback on the main test page - we could see how this goes and then maybe gradually use this to correct some of the causes and/or use a similar technique to try to improve the reported core count and hours remaining at the top of the main test page.

The code here says ` hours = 1 ` but I would hope to change this to something shorter (10 mins or so?) if it works ok. (How often are LTC results sent back if running on 1 core?)
