### PR TITLE
Fix readability of test tasks table in night mode

### DIFF
--- a/fishtest/fishtest/static/css/theme.dark.css
+++ b/fishtest/fishtest/static/css/theme.dark.css
@@ -60,6 +60,11 @@ hr {
   border-top: 1px solid #444;
 }
 
+/* Background colors for running tasks on test run pages */
+.table tbody tr.info>td {
+  background-color: #0f3373;
+}
+
 /* Text inputs and selects */
 textarea, input[type="text"], input[type="password"],
 input[type="datetime"], input[type="datetime-local"], input[type="date"],
@@ -116,12 +121,27 @@ input[type="radio"]:focus, input[type="checkbox"]:focus {
   background-color: #333;
 }
 
-/* Overrides a color that's way too light on test tasks pages */
+/* Override - test tasks table - purged tasks red background */
 td[style*="background-color:#ffebeb"] {
   background: #5f1c1c !important;
 }
 
-/* Overrides "green" description text in /nns page */
+/* Override - test tasks table - residuals green */
+td[style*="background-color:#44EB44"] {
+  background: #108e10 !important;
+}
+
+/* Override - test tasks table - residuals yellow */
+td[style*="background-color:yellow"] {
+  background: #acb700 !important;
+}
+
+/* Override - test tasks table - residuals red */
+td[style*="background-color:#FF6A6A"] {
+  background: #d65252 !important;
+}
+
+/* Override - "green" description text in /nns page */
 span[style*="background-color:palegreen"] {
   color: #111;
 }

--- a/fishtest/fishtest/static/html/SPRTcalculator.html
+++ b/fishtest/fishtest/static/html/SPRTcalculator.html
@@ -12,7 +12,6 @@
         const linkEl = document.createElement('link');
         linkEl.href = "/css/theme.dark.css";
         linkEl.rel = "stylesheet";
-        linkEl.integrity = "UAj9GRYDzOc97Pf4kC10t9FR1xjPLDCgu0Z4GLusexg=";
         document.querySelector("head").appendChild(linkEl);
       }
     </script>

--- a/fishtest/fishtest/static/html/live_elo.html
+++ b/fishtest/fishtest/static/html/live_elo.html
@@ -15,7 +15,6 @@
         const linkEl = document.createElement('link');
         linkEl.href = "/css/theme.dark.css";
         linkEl.rel = "stylesheet";
-        linkEl.integrity = "UAj9GRYDzOc97Pf4kC10t9FR1xjPLDCgu0Z4GLusexg=";
         document.querySelector("head").appendChild(linkEl);
       }
     </script>

--- a/fishtest/fishtest/static/js/application.js
+++ b/fishtest/fishtest/static/js/application.js
@@ -51,7 +51,7 @@ $(() => {
         $("<link>")
           .attr("href", "/css/theme.dark.css")
           .attr("rel", "stylesheet")
-          .attr("integrity", "sha256-UAj9GRYDzOc97Pf4kC10t9FR1xjPLDCgu0Z4GLusexg=")
+          .attr("integrity", "sha256-fCZfch3W6doEzUX7ElFTKQdXEojfSl8uO/xeECjeZWs=")
           .appendTo($("head"));
         theme = 'dark';
       } else {

--- a/fishtest/fishtest/templates/base.mak
+++ b/fishtest/fishtest/templates/base.mak
@@ -21,7 +21,7 @@
           crossorigin="anonymous"></script>
 
   <script src="/js/jquery.cookie.js" defer></script>
-  <script src="/js/application.js?v=4" defer></script>
+  <script src="/js/application.js?v=5" defer></script>
 
   <%block name="head"/>
 </head>


### PR DESCRIPTION
Updates the background colors of running tasks and cells in the residual column:

![image](https://user-images.githubusercontent.com/208617/96387456-069e9e80-1170-11eb-91f7-604978772241.png)

Fixes https://github.com/glinscott/fishtest/issues/811
Fixes https://github.com/glinscott/fishtest/issues/819