### PR TITLE
Simple worker heartbeat to detect dead workers

### DIFF
--- a/fishtest/fishtest/__init__.py
+++ b/fishtest/fishtest/__init__.py
@@ -88,6 +88,7 @@ def main(global_config, **settings):
     config.add_route("api_failed_task", "/api/failed_task")
     config.add_route("api_stop_run", "/api/stop_run")
     config.add_route("api_request_version", "/api/request_version")
+    config.add_route("api_beat", "/api/beat")
     config.add_route("api_request_spsa", "/api/request_spsa")
     config.add_route("api_active_runs", "/api/active_runs")
     config.add_route("api_get_run", "/api/get_run/{id}")

--- a/fishtest/fishtest/api.py
+++ b/fishtest/fishtest/api.py
@@ -90,7 +90,10 @@ class ApiView(object):
         return str(self.request.json_body["run_id"])
 
     def task_id(self):
-        return int(self.request.json_body["task_id"])
+        tid = self.request.json_body["task_id"]
+        if tid is not None:
+            return int(tid)
+        return tid
 
     @view_config(route_name="api_active_runs")
     def active_runs(self):
@@ -233,6 +236,16 @@ class ApiView(object):
     def request_version(self):
         self.require_authentication()
         return {"version": WORKER_VERSION}
+
+    @view_config(route_name="api_beat")
+    def beat(self):
+        self.require_authentication()
+        if self.task_id() is not None:
+            run = self.request.rundb.get_run(self.run_id())
+            task = run["tasks"][self.task_id()]
+            task["last_updated"] = datetime.utcnow()
+            self.request.rundb.buffer(run, False)
+        return "Pleased to hear from you..."
 
     @view_config(route_name="api_request_spsa")
     def request_spsa(self):

--- a/fishtest/tests/test_api.py
+++ b/fishtest/tests/test_api.py
@@ -329,6 +329,17 @@ class TestApi(unittest.TestCase):
         response = ApiView(self.correct_password_request()).request_version()
         self.assertEqual(WORKER_VERSION, response["version"])
 
+    def test_beat(self):
+        with self.assertRaises(HTTPUnauthorized):
+            response = ApiView(self.invalid_password_request()).beat()
+            self.assertTrue("error" in response)
+
+        request = self.correct_password_request(
+            {"run_id": self.run_id, "task_id": self.task_id}
+        )
+        response = ApiView(request).beat()
+        self.assertEqual("Pleased to hear from you...", response)
+
 
 class TestRunFinished(unittest.TestCase):
     @classmethod

--- a/fishtest/utils/scavenge.py
+++ b/fishtest/utils/scavenge.py
@@ -13,7 +13,7 @@ from fishtest.rundb import RunDb
 rundb = RunDb()
 
 
-def scavenge_tasks(scavenge=True, minutes=120):
+def scavenge_tasks(scavenge=True, minutes=5):
     """Check for tasks that have not been updated recently"""
     for run in rundb.runs.find({"tasks": {"$elemMatch": {"active": True}}}):
         changed = False

--- a/worker/games.py
+++ b/worker/games.py
@@ -696,7 +696,7 @@ def parse_cutechess_output(
                         break
                     except Exception as e:
                         sys.stderr.write("Exception from calling update_task:\n")
-                        print(e)
+                        print(e, file=sys.stderr)
                         # traceback.print_exc(file=sys.stderr)
                     time.sleep(HTTP_TIMEOUT)
                 if not update_succeeded:


### PR DESCRIPTION
See #818 

Add a simple worker heartbeat (every 60s) for reliable scavenging (remove as active after 3 minutes).

Also show a worker immediately when it receives a task and do not wait for the first batch of games to be completed.

Finally replace `utils/scavenge.py` with server logic.
