### PR TITLE
Fix worker test: exiting early when given no args

### DIFF
--- a/worker/test_worker.py
+++ b/worker/test_worker.py
@@ -34,13 +34,10 @@ class workerTest(unittest.TestCase):
         self.assertTrue(config.has_option("parameters", "port"))
         self.assertTrue(config.has_option("parameters", "concurrency"))
 
-    def test_worker_script(self):
-        p = subprocess.Popen(["python", "worker.py"], stderr=subprocess.PIPE)
-        result = p.stderr.readline()
-        if not isinstance(result, str):
-            result = result.decode("utf-8")
-        self.assertEqual(result, "worker.py [username] [password]\n")
-        p.stderr.close()
+    def test_worker_script_with_no_args(self):
+        with subprocess.Popen(["python", "worker.py"]) as p:
+            p.communicate()
+            self.assertEqual(p.returncode, 1)
 
     def test_setup_exception(self):
         cwd = os.getcwd()


### PR DESCRIPTION
Fixes a flaky worker test and a subprocess warning when running that test.

i see this test fail when running the test locally and also in recent Travis builds:
https://travis-ci.org/github/glinscott/fishtest/builds/738772657
https://travis-ci.org/github/glinscott/fishtest/builds

here's the failing test output. note that `worker.py [username] [password]` does get printed to stderr but it's no longer being picked up in the unit test. i simplified the test to check against the expected non-zero return code to work around this. not sure why the test started failing.

```
test_worker_script (test_worker.workerTest) ... Worker started in /home/travis/build/glinscott/fishtest/worker ...
Memory: 8364236800
FAIL
/opt/python/3.6.7/lib/python3.6/subprocess.py:766: ResourceWarning: subprocess 3919 is still running
  ResourceWarning, source=self)
/opt/python/3.6.7/lib/python3.6/unittest/case.py:633: ResourceWarning: unclosed file <_io.BufferedReader name=3>
  outcome.errors.clear()
======================================================================
FAIL: test_worker_script (test_worker.workerTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/glinscott/fishtest/worker/test_worker.py", line 42, in test_worker_script
    self.assertEqual(result, "worker.py [username] [password]\n")
AssertionError: '' != 'worker.py [username] [password]\n'
+ worker.py [username] [password]
```