### PR TITLE
List SPRT bounds also in "normalized Elo" on the raw stats page.

### DIFF
--- a/server/fishtest/templates/tests_stats.mak
+++ b/server/fishtest/templates/tests_stats.mak
@@ -1,5 +1,5 @@
 <%
-   import copy
+   import math,copy
    import fishtest.stats.stat_util
    import fishtest.stats.LLRcalc
 
@@ -24,6 +24,140 @@
       return sensitivity,norm_var_sensitivity
 
    z975=fishtest.stats.stat_util.Phi_inv(0.975)
+
+   beta=(math.log(10)/400)/4
+   conv_sens_elo=1/(2*beta)  ## conversion sensitivity<->normalized Elo
+
+   reference_draw_ratio=0.0
+
+   results3=[run['results']['losses'],run['results']['draws'],run['results']['wins']]
+   results3_=fishtest.stats.LLRcalc.regularize(results3)
+   drawelo=fishtest.stats.stat_util.draw_elo_calc(results3_)
+   draw_ratio=results3_[1]/float(sum(results3_))
+   if has_sprt:
+      elo_model=run['args']['sprt'].get('elo_model','BayesElo')
+      alpha=run['args']['sprt']['alpha']
+      beta=run['args']['sprt']['beta']
+      elo0=run['args']['sprt']['elo0']
+      elo1=run['args']['sprt']['elo1']
+      batch_size_units=run['args']['sprt'].get('batch_size',1)
+      batch_size_games=2*batch_size_units if has_pentanomial else 1
+      o=run['args']['sprt'].get('overshoot',None)
+      if elo_model=='BayesElo':
+      	 lelo0,lelo1=[fishtest.stats.stat_util.bayeselo_to_elo(elo_, drawelo) for elo_ in (elo0,elo1)]
+	 belo0,belo1=elo0,elo1
+      else:
+	 lelo0,lelo1=elo0,elo1
+	 belo0,belo1=[fishtest.stats.stat_util.elo_to_bayeselo(elo_, draw_ratio)[0] for elo_ in [elo0,elo1]]
+      score0,score1=[fishtest.stats.stat_util.L(elo_) for elo_ in (lelo0,lelo1)]
+   
+
+   if has_pentanomial:
+      results5=run['results']['pentanomial']
+      results5_=fishtest.stats.LLRcalc.regularize(results5)
+      N5,pdf5=fishtest.stats.LLRcalc.results_to_pdf(results5)
+      pdf5_s=pdf_to_string(pdf5)
+      games5=2*N5
+      avg5,var5,skewness5,exkurt5=fishtest.stats.LLRcalc.stats_ex(pdf5)
+      avg5_l=avg5-z975*(var5/N5)**.5
+      avg5_u=avg5+z975*(var5/N5)**.5
+      var5_per_game=2*var5
+      var5_per_game_l=var5_per_game*(1-z975*((exkurt5+2)/N5)**.5)
+      var5_per_game_u=var5_per_game*(1+z975*((exkurt5+2)/N5)**.5)
+      stdev5_per_game=var5_per_game**.5
+      stdev5_per_game_l=var5_per_game_l**.5 if var5_per_game_l>=0 else 0.0
+      stdev5_per_game_u=var5_per_game_u**.5
+      sens5,norm_var_sens5=sensitivity_conf(avg5,var5,skewness5,exkurt5)
+      sens5_l=sens5-z975*(norm_var_sens5/N5)**.5
+      sens5_u=sens5+z975*(norm_var_sens5/N5)**.5
+      sqrt2=2**.5
+      sens5_per_game=sens5/sqrt2
+      sens5_per_game_l=sens5_l/sqrt2
+      sens5_per_game_u=sens5_u/sqrt2
+      nelo5=conv_sens_elo*sens5/sqrt2
+      nelo5_u=conv_sens_elo*sens5_u/sqrt2
+      nelo5_l=conv_sens_elo*sens5_l/sqrt2
+      results5_DD_prob=draw_ratio-(results5_[1]+results5_[3])/(2*float(N5))
+      results5_WL_prob=results5_[2]/float(N5)-results5_DD_prob
+      if has_sprt:
+      	 LLRjumps5=list_to_string([i[0] for i in fishtest.stats.LLRcalc.LLRjumps(pdf5,score0,score1)])
+	 sp=fishtest.stats.sprt.sprt(alpha=alpha,beta=beta,elo0=lelo0,elo1=lelo1)
+	 sp.set_state(results5_)
+	 a5=sp.analytics()
+	 LLR5_l=a5['a']
+	 LLR5_u=a5['b']
+	 LLR5=fishtest.stats.LLRcalc.LLR_logistic(lelo0,lelo1,results5_)
+	 o0=0
+	 o1=0
+	 if o!=None:
+	      o0=-o['sq0']/o['m0']/2 if o['m0']!=0 else 0
+	      o1=o['sq1']/o['m1']/2 if o['m1']!=0 else 0
+	 elo5_l=a5['ci'][0]
+	 elo5_u=a5['ci'][1]
+	 elo5=a5['elo']
+	 LOS5=a5['LOS']
+	 # auxilliary
+	 LLR5_exact=N5*fishtest.stats.LLRcalc.LLR(pdf5,score0,score1)
+	 LLR5_alt  =N5*fishtest.stats.LLRcalc.LLR_alt(pdf5,score0,score1)
+	 LLR5_alt2 =N5*fishtest.stats.LLRcalc.LLR_alt2(pdf5,score0,score1)
+      else:                #assume fixed length test
+      	 elo5,elo95_5,LOS5=fishtest.stats.stat_util.get_elo(results5_)
+	 elo5_l=elo5-elo95_5
+	 elo5_u=elo5+elo95_5
+
+   N3,pdf3=fishtest.stats.LLRcalc.results_to_pdf(results3)
+   pdf3_s=pdf_to_string(pdf3)
+   games3=N3
+   avg3,var3,skewness3,exkurt3=fishtest.stats.LLRcalc.stats_ex(pdf3)
+   avg3_l=avg3-z975*(var3/N3)**.5
+   avg3_u=avg3+z975*(var3/N3)**.5
+   var3_l=var3*(1-z975*((exkurt3+2)/N3)**.5)
+   var3_u=var3*(1+z975*((exkurt3+2)/N3)**.5)
+   stdev3=var3**.5
+   stdev3_l=var3_l**.5 if var3_l>=0 else 0.0
+   stdev3_u=var3_u**.5
+   sens3,norm_var_sens3=sensitivity_conf(avg3,var3,skewness3,exkurt3)
+   sens3_l=sens3-z975*(norm_var_sens3/N3)**.5
+   sens3_u=sens3+z975*(norm_var_sens3/N3)**.5
+   sens3_per_game=sens3
+   sens3_per_game_l=sens3_l
+   sens3_per_game_u=sens3_u
+   nelo3=conv_sens_elo*sens3
+   nelo3_u=conv_sens_elo*sens3_u
+   nelo3_l=conv_sens_elo*sens3_l
+   R3_=copy.deepcopy(run['results'])
+   if has_pentanomial:
+      del R3_['pentanomial']
+      ratio=var5_per_game/var3
+      var_diff=var3-var5_per_game
+      RMS_bias=var_diff**.5 if var_diff>=0 else 0
+      RMS_bias_elo=fishtest.stats.stat_util.elo(0.5+RMS_bias)
+   if has_sprt:
+      LLRjumps3=list_to_string([i[0] for i in fishtest.stats.LLRcalc.LLRjumps(pdf3,score0,score1)])
+      sp=fishtest.stats.sprt.sprt(alpha=alpha,beta=beta,elo0=lelo0,elo1=lelo1)
+      sp.set_state(results3_)
+      a3=sp.analytics()
+      LLR3_l=a3['a']
+      LLR3_u=a3['b']
+      LLR3=fishtest.stats.LLRcalc.LLR_logistic(lelo0,lelo1,results3_)
+      elo3_l=a3['ci'][0]
+      elo3_u=a3['ci'][1]
+      elo3=a3['elo']
+      LOS3=a3['LOS']
+      # auxilliary
+      LLR3_exact=N3*fishtest.stats.LLRcalc.LLR(pdf3,score0,score1)
+      LLR3_alt  =N3*fishtest.stats.LLRcalc.LLR_alt(pdf3,score0,score1)
+      LLR3_alt2 =N3*fishtest.stats.LLRcalc.LLR_alt2(pdf3,score0,score1)
+      LLR3_be   =fishtest.stats.stat_util.LLRlegacy(belo0,belo1,results3_)
+   else:  #assume fixed length test
+      elo3,elo95_3,LOS3=fishtest.stats.stat_util.get_elo(results3_)
+      elo3_l=elo3-elo95_3
+      elo3_u=elo3+elo95_3
+      
+   if has_sprt:
+      var_per_game=var5_per_game if has_pentanomial else var3
+      nelo0=lelo0*((1-reference_draw_ratio)/4/var_per_game)**.5
+      nelo1=lelo1*((1-reference_draw_ratio)/4/var_per_game)**.5
 %>
 <!DOCTYPE html>
 <html lang="en-us">
@@ -60,16 +194,6 @@
 	</table>
 % if has_sprt:
       <H4> SPRT parameters</H4>
-      <%
-      alpha=run['args']['sprt']['alpha']
-      beta=run['args']['sprt']['beta']
-      elo0=run['args']['sprt']['elo0']
-      elo1=run['args']['sprt']['elo1']
-      elo_model=run['args']['sprt'].get('elo_model','BayesElo')
-      batch_size_units=run['args']['sprt'].get('batch_size',1)
-      batch_size_games=2*batch_size_units if has_pentanomial else 1
-      o=run['args']['sprt'].get('overshoot',None)
-      %>
       <table class="table table-condensed">
 	<tr><td>Alpha</td><td>${alpha}</td></tr>
 	<tr><td>Beta</td><td>${beta}</td></tr>
@@ -78,84 +202,31 @@
 	<tr><td>Batch size (games) </td><td>${batch_size_games}</td></tr>
       </table>
 % endif  ## has_sprt
-      <H4> Logistic/BayesElo</H4>
-      <%
-       	 results3=[run['results']['losses'],run['results']['draws'],run['results']['wins']]
-	 results3_=fishtest.stats.LLRcalc.regularize(results3)
-	 drawelo=fishtest.stats.stat_util.draw_elo_calc(results3_)
-	 draw_ratio=results3_[1]/float(sum(results3_))
-	 if has_sprt:
-	    if elo_model=='BayesElo':
-	    	 lelo0,lelo1=[fishtest.stats.stat_util.bayeselo_to_elo(elo_, drawelo) for elo_ in (elo0,elo1)]
-		 belo0,belo1=elo0,elo1
-	    else:
-	         lelo0,lelo1=elo0,elo1
-		 belo0,belo1=[fishtest.stats.stat_util.elo_to_bayeselo(elo_, draw_ratio)[0] for elo_ in [elo0,elo1]]
-	    score0,score1=[fishtest.stats.stat_util.L(elo_) for elo_ in (lelo0,lelo1)]
-      %>
-      <table class="table table-condensed">	
+      <H4>Draws</H4>
+      <table class="table table-condensed" style="margin-top:1em;">	
 	<tr><td>Draw ratio</td><td>${"%.5f"%draw_ratio}</td></tr>
 	<tr><td>DrawElo (BayesElo)</td><td>${"%.2f"%drawelo}</td></tr>
-% if has_sprt:
-	<tr><td>Elo0 (logistic)</td><td>${"%.3f"%lelo0}</td></tr>
-	<tr><td>Elo0 (BayesElo)</td><td>${"%.3f"%belo0}</td></tr>
-	<tr><td>Elo1 (logistic)</td><td>${"%.3f"%lelo1}</td></tr>
-	<tr><td>Elo1 (BayesElo)</td><td>${"%.3f"%belo1}</td></tr>
-	<tr><td>Score0</td><td>${"%.5f"%score0}</td></tr>
-	<tr><td>Score1</td><td>${"%.5f"%score1}</td></tr>
-% endif  ## has_sprt
       </table>
+% if has_sprt:
+      <H4> SPRT bounds </H4>
+      <table class="table table-condensed" style="margin-top:1em;margin-bottom:0.5em;">	
+      <tr>
+      <td></td></td><td>Logistic</td><td>Normalized</td><td>BayesElo</td><td>Score</td>
+      </tr>
+      <tr>
+      <td>H0</td><td>${"%.3f"%lelo0}</td><td>${"%.3f"%nelo0}</td><td>${"%.3f"%belo0}</td><td>${"%.5f"%score0}</td>
+      </tr>
+      <tr>
+      <td>H1</td><td>${"%.3f"%lelo1}</td><td>${"%.3f"%nelo1}</td><td>${"%.3f"%belo1}</td><td>${"%.5f"%score1}</td>
+      </tr>
+      </table>
+      <em> Note: normalized Elo is inversely proportional to the square root of the number of games it takes on average to
+      detect a given strength difference with a given level of significance. It is given by
+      logistic_elo/(2*standard_deviation_per_game). In other words if the draw ratio is zero and Elo differences are small
+      then normalized Elo and logistic Elo coincide.
+      </em>
+% endif  ## has_sprt
 % if has_pentanomial:
-      <%
-	 results5=run['results']['pentanomial']
-	 results5_=fishtest.stats.LLRcalc.regularize(results5)
-	 N5,pdf5=fishtest.stats.LLRcalc.results_to_pdf(results5)
-	 pdf5_s=pdf_to_string(pdf5)
-	 games5=2*N5
-         avg5,var5,skewness5,exkurt5=fishtest.stats.LLRcalc.stats_ex(pdf5)
-	 avg5_l=avg5-z975*(var5/N5)**.5
-	 avg5_u=avg5+z975*(var5/N5)**.5
-	 var5_per_game=2*var5
-	 var5_per_game_l=var5_per_game*(1-z975*((exkurt5+2)/N5)**.5)
-	 var5_per_game_u=var5_per_game*(1+z975*((exkurt5+2)/N5)**.5)
-	 stdev5_per_game=var5_per_game**.5
-	 stdev5_per_game_l=var5_per_game_l**.5 if var5_per_game_l>=0 else 0.0
-	 stdev5_per_game_u=var5_per_game_u**.5
-	 sens5,norm_var_sens5=sensitivity_conf(avg5,var5,skewness5,exkurt5)
-	 sens5_l=sens5-z975*(norm_var_sens5/N5)**.5
-	 sens5_u=sens5+z975*(norm_var_sens5/N5)**.5
-	 sqrt2=2**.5
-	 sens5_per_game=sens5/sqrt2
-	 sens5_per_game_l=sens5_l/sqrt2
-	 sens5_per_game_u=sens5_u/sqrt2
-	 results5_DD_prob=draw_ratio-(results5_[1]+results5_[3])/(2*float(N5))
-	 results5_WL_prob=results5_[2]/float(N5)-results5_DD_prob
-	 if has_sprt:
-	    LLRjumps5=list_to_string([i[0] for i in fishtest.stats.LLRcalc.LLRjumps(pdf5,score0,score1)])
-	    sp=fishtest.stats.sprt.sprt(alpha=alpha,beta=beta,elo0=lelo0,elo1=lelo1)
-	    sp.set_state(results5_)
-	    a5=sp.analytics()
-	    LLR5_l=a5['a']
-	    LLR5_u=a5['b']
-	    LLR5=fishtest.stats.LLRcalc.LLR_logistic(lelo0,lelo1,results5_)
-	    o0=0
-	    o1=0
-	    if o!=None:
-	       o0=-o['sq0']/o['m0']/2 if o['m0']!=0 else 0
-	       o1=o['sq1']/o['m1']/2 if o['m1']!=0 else 0
-	    elo5_l=a5['ci'][0]
-	    elo5_u=a5['ci'][1]
-	    elo5=a5['elo']
-	    LOS5=a5['LOS']
-	    # auxilliary
-	    LLR5_exact=N5*fishtest.stats.LLRcalc.LLR(pdf5,score0,score1)
-	    LLR5_alt  =N5*fishtest.stats.LLRcalc.LLR_alt(pdf5,score0,score1)
-	    LLR5_alt2 =N5*fishtest.stats.LLRcalc.LLR_alt2(pdf5,score0,score1)
-	 else:                #assume fixed length test
-	    elo5,elo95_5,LOS5=fishtest.stats.stat_util.get_elo(results5_)
-	    elo5_l=elo5-elo95_5
-	    elo5_u=elo5+elo95_5
-	 %>
       <H4> Pentanomial statistics</H4>
       <H5> Basic statistics </H5>
       <table class="table table-condensed">
@@ -167,18 +238,18 @@
       </table>
 % if has_sprt:
       <H5> Generalized Log Likelihood Ratio </H5>
-      <em> The monikers Alt and Alt2 are from the source code. Alt (which is 
+      <table class="table table-condensed" style="margin-top:1em;margin-bottom:0.5em;">
+      	<tr><td>Exact</td><td>${"%.5f"%LLR5_exact}</td></tr>
+      	<tr><td>Alt</td><td>${"%.5f"%LLR5_alt}</td></tr>
+      	<tr><td>Alt2</td><td>${"%.5f"%LLR5_alt2}</td></tr>
+      </table>
+      <em> Note: the monikers Alt and Alt2 are from the source code. Alt (which is 
       no longer used) is faster to compute than the exact LLR which requires
       numerically solving a rational equation.
       The simple Alt2 is used for Elo estimation.
       Note that we are not aware of any literature
       indicating that any of these LLR quantities is theoretically better than the others.
       </em>
-      <table class="table table-condensed" style="margin-top:1em;">
-      	<tr><td>Exact</td><td>${"%.5f"%LLR5_exact}</td></tr>
-      	<tr><td>Alt</td><td>${"%.5f"%LLR5_alt}</td></tr>
-      	<tr><td>Alt2</td><td>${"%.5f"%LLR5_alt2}</td></tr>
-      </table>
 % endif ## has_sprt
       <H5> Auxilliary statistics </H5>	
       <table class="table table-condensed">	
@@ -198,9 +269,9 @@
 	<tr><td>Variance/game</td><td>${"%.5f [%.5f, %.5f]"%(var5_per_game,var5_per_game_l,var5_per_game_u)}</td></tr>
 	<tr><td>Stdev/game</td><td>${"%.5f [%.5f, %.5f]"%(stdev5_per_game,stdev5_per_game_l,stdev5_per_game_u)}</td></tr>
 % if has_sprt:
-	<tr><td>Sensitivity ((score-0.5)/stdev)/game</td><td>${"%.5f"%(sens5_per_game)}</td></tr>
+	<tr><td>Normalized Elo</td><td>${"%.2f"%(nelo5)}</td></tr>
 % else:
-	<tr><td>Sensitivity ((score-0.5)/stdev)/game</td><td>${"%.5f [%.5f, %.5f]"%(sens5_per_game,sens5_per_game_l,sens5_per_game_u)}</td></tr>
+	<tr><td>Normalized Elo</td><td>${"%.2f [%.2f, %.2f]"%(nelo5,nelo5_l,nelo5_u)}</td></tr>
 % endif  ## has_sprt
 % if has_sprt:
 	<tr><td>LLR jumps [0-2]</td><td>${LLRjumps5}</td></tr>	
@@ -217,53 +288,6 @@
       interesting information from the comparison between the two. </em>
       </p>
 % endif  ## has_pentanomial
-      <%
-	 N3,pdf3=fishtest.stats.LLRcalc.results_to_pdf(results3)
-	 pdf3_s=pdf_to_string(pdf3)
-	 games3=N3
-         avg3,var3,skewness3,exkurt3=fishtest.stats.LLRcalc.stats_ex(pdf3)
-	 avg3_l=avg3-z975*(var3/N3)**.5
-	 avg3_u=avg3+z975*(var3/N3)**.5
-	 var3_l=var3*(1-z975*((exkurt3+2)/N3)**.5)
-	 var3_u=var3*(1+z975*((exkurt3+2)/N3)**.5)
-	 stdev3=var3**.5
-	 stdev3_l=var3_l**.5 if var3_l>=0 else 0.0
-	 stdev3_u=var3_u**.5
-	 sens3,norm_var_sens3=sensitivity_conf(avg3,var3,skewness3,exkurt3)
-	 sens3_l=sens3-z975*(norm_var_sens3/N3)**.5
-	 sens3_u=sens3+z975*(norm_var_sens3/N3)**.5
-	 sens3_per_game=sens3
-	 sens3_per_game_l=sens3_l
-	 sens3_per_game_u=sens3_u
-	 R3_=copy.deepcopy(run['results'])
-	 if has_pentanomial:
-	    	 del R3_['pentanomial']
-		 ratio=var5_per_game/var3
-		 var_diff=var3-var5_per_game
-		 RMS_bias=var_diff**.5 if var_diff>=0 else 0
-		 RMS_bias_elo=fishtest.stats.stat_util.elo(0.5+RMS_bias)
-	 if has_sprt:
-	 	 LLRjumps3=list_to_string([i[0] for i in fishtest.stats.LLRcalc.LLRjumps(pdf3,score0,score1)])
-		 sp=fishtest.stats.sprt.sprt(alpha=alpha,beta=beta,elo0=lelo0,elo1=lelo1)
-		 sp.set_state(results3_)
-		 a3=sp.analytics()
-		 LLR3_l=a3['a']
-		 LLR3_u=a3['b']
-		 LLR3=fishtest.stats.LLRcalc.LLR_logistic(lelo0,lelo1,results3_)
-	 	 elo3_l=a3['ci'][0]
-	 	 elo3_u=a3['ci'][1]
-	 	 elo3=a3['elo']
-	 	 LOS3=a3['LOS']
-		 # auxilliary
-	         LLR3_exact=N3*fishtest.stats.LLRcalc.LLR(pdf3,score0,score1)
-	         LLR3_alt  =N3*fishtest.stats.LLRcalc.LLR_alt(pdf3,score0,score1)
-	         LLR3_alt2 =N3*fishtest.stats.LLRcalc.LLR_alt2(pdf3,score0,score1)
-		 LLR3_be   =fishtest.stats.stat_util.LLRlegacy(belo0,belo1,results3_)
-	 else:                #assume fixed length test
-	 	elo3,elo95_3,LOS3=fishtest.stats.stat_util.get_elo(results3_)
-		elo3_l=elo3-elo95_3
-		elo3_u=elo3+elo95_3
-	 %>
      <H5> Basic statistics</H5>
       <table class="table table-condensed">
 	<tr><td>Elo</td><td>${"%.4f [%.4f, %.4f]"%(elo3,elo3_l,elo3_u)}</td></tr>
@@ -274,14 +298,14 @@
       </table>
 % if has_sprt:
        <H5> Generalized Log Likelihood Ratio </H5>
-       <em> BayesElo is the LLR as computed using the BayesElo model. It is not clear how to
-       generalize it to the pentanomial case. </em>
-       <table class="table table-condensed" style="margin-top:1em;">
+       <table class="table table-condensed" style="margin-top:1em;margin-bottom:0.5em;">
        	<tr><td>Exact</td><td>${"%.5f"%LLR3_exact}</td></tr>
        	<tr><td>Alt</td><td>${"%.5f"%LLR3_alt}</td></tr>
       	<tr><td>Alt2</td><td>${"%.5f"%LLR3_alt2}</td></tr>
 	<tr><td>BayesElo</td><td>${"%.5f"%LLR3_be}</td></tr>	
 	</table>
+       <em> Note: BayesElo is the LLR as computed using the BayesElo model. It is not clear how to
+       generalize it to the pentanomial case. </em>
 % endif  ## has_sprt
      <H5> Auxilliary statistics</H5>
       <table class="table table-condensed">
@@ -300,9 +324,9 @@
 	<tr><td>Variance/game</td><td>${"%.5f [%.5f, %.5f]"%(var3,var3_l,var3_u)}</td></tr>
 	<tr><td>Stdev/game</td><td>${"%.5f [%.5f, %.5f]"%(stdev3,stdev3_l,stdev3_u)}</td></tr>
 % if has_sprt:
-	<tr><td>Sensitivity ((score-0.5)/stdev)/game</td><td>${"%.5f"%(sens3_per_game)}</td></tr>
+	<tr><td>Normalized Elo</td><td>${"%.2f"%(nelo3)}</td></tr>
 % else:
-	<tr><td>Sensitivity ((score-0.5)/stdev)/game</td><td>${"%.5f [%.5f, %.5f]"%(sens3_per_game,sens3_per_game_l,sens3_per_game_u)}</td></tr>
+	<tr><td>Normalized Elo</td><td>${"%.2f [%.2f, %.2f]"%(nelo3,nelo3_l,nelo3_u)}</td></tr>
 % endif  ## has_sprt
 % if has_sprt:
 	<tr><td>LLR jumps [loss, draw, win]</td><td>${LLRjumps3}</td></tr>


### PR DESCRIPTION
Normalized Elo is inversely proportional to the square root of the number of games it takes on average to detect a given strength difference with a given level of significance. In this PR it is given by
```
logistic_elo/(2*standard_deviation_per_game)
```
which in case of a perfectly balanced book and small Elo differences is equal to
```
 logistic_elo/sqrt(1-draw_ratio)
```
In other words if the draw ratio is zero, the book is perfectly balanced, and Elo differences are small then normalized Elo and logistic Elo coincide. We say that zero is the "reference draw ratio". A reference draw ratio different from zero would also work. This seems less intuitive however.

The advantage of expressing SPRT bounds in normalized Elo (which is currently not done) would be that the expected test length no longer depends on the draw ratio or the book (cfr the issue with non NNUE tests which take very long on average).

Normalized Elo is discussed here

http://hardy.uhasselt.be/Fishtest/normalized_elo.pdf

In this PR we use a different normalization factor which is perhaps more intuitive.

Here is a table with conversions for various draw ratios (assuming a perfectly balanced book)

| draw ratio | 0.0 | 0.3 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 |
|- |------|-----|-----|----|-|-|-|
| Normalized Elo| 5.00 | 5.00 | 5.00| 5.00 | 5.00 |5.00 |5.00|
| Logistic Elo| 5.00| 4.18 | 3.54 | 3.16 | 2.74 | 2.24 | 1.58|

**Note** A `SPRT(0,5)`  with bounds expressed in normalized Elo takes about `42k` games to complete (expected worst case) regardless of the book or the draw ratio. One can verify this with the SPRT calculator by just putting in the above values in logistic Elo for the corresponding draw ratio (and `RMS bias=0`).