### PR TITLE
Set pyramid to version 1.10

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -6,7 +6,7 @@ README = ""
 CHANGES = ""
 
 requires = [
-    "pyramid",
+    "pyramid==1.10",
     "pyramid_debugtoolbar",
     "pyramid_mako",
     "waitress",


### PR DESCRIPTION
With the new pyramid 2.0 some server tests are failing with the message:
```
    from pyramid.session import UnencryptedCookieSessionFactoryConfig
ImportError: cannot import name 'UnencryptedCookieSessionFactoryConfig' from 'pyramid.session' (unknown location)
```

See:
https://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-2.0.html