### PR TITLE
Switch folder to fix the update process

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -10,7 +10,7 @@ from pyramid.httpexceptions import HTTPFound, HTTPUnauthorized, exception_respon
 from pyramid.response import Response
 from pyramid.view import exception_view_config, view_config, view_defaults
 
-WORKER_VERSION = 96
+WORKER_VERSION = 97
 
 flag_cache = {}
 

--- a/worker/games.py
+++ b/worker/games.py
@@ -149,11 +149,13 @@ def required_net_from_source():
 def download_net(remote, testing_dir, net):
     url = remote + "/api/nn/" + net
     r = requests.get(url, allow_redirects=True)
-    open(os.path.join(testing_dir, net), "wb").write(r.content)
+    with open(os.path.join(testing_dir, net), "wb") as f:
+        f.write(r.content)
 
 
 def validate_net(testing_dir, net):
-    content = open(os.path.join(testing_dir, net), "rb").read()
+    with open(os.path.join(testing_dir, net), "rb") as f:
+        content = f.read()
     hash = hashlib.sha256(content).hexdigest()
     return hash[:12] == net[3:15]
 

--- a/worker/updater.py
+++ b/worker/updater.py
@@ -50,6 +50,8 @@ def update(restart=True, test=False):
 
     # rename the testing_dir to backup possible user custom files
     # and to trigger the download of update files
+    # the worker runs games from the "testing" folder so change the folder
+    os.chdir(worker_dir)
     testing_dir = os.path.join(worker_dir, "testing")
     if os.path.exists(testing_dir):
         try:

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -37,7 +37,7 @@ from os import path
 from games import run_games
 from updater import update
 
-WORKER_VERSION = 96
+WORKER_VERSION = 97
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 


### PR DESCRIPTION
The worker is running games from the "testing" folder, so switch folder
before moving the "testing" folder.

Also fix a couple of file reading/writing.
Raise version and trigger the wokers update.

Fix #891