### PR TITLE
Bug in ordering users in website: fixing attempt

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -1,4 +1,4 @@
-const getCellValue = (tr, idx) => tr.children[idx].innerText || tr.children[idx].textContent;
+const getCellValue = (tr, idx) => tr.children[idx].dataset.diff || tr.children[idx].innerText || tr.children[idx].textContent;
 
 const comparer = (idx, asc) => (a, b) => ((v1, v2) =>
     v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2)

--- a/server/fishtest/templates/users.mak
+++ b/server/fishtest/templates/users.mak
@@ -37,7 +37,7 @@
  %for user in users:
   <tr>
    <td>${user['username']}</td>
-   <td style="text-align:right">${user['last_updated']}</td>
+   <td data-diff="${user['diff']}" style="text-align:right">${user['last_updated']}</td>
    <td style="text-align:right">${int(user['games_per_hour'])}</td>
    <td style="text-align:right">${int(user['cpu_hours'])}</td>
    <td style="text-align:right">${int(user['games'])}</td>

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -1,7 +1,7 @@
 import smtplib
 import threading
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from email.mime.text import MIMEText
 
 import fishtest.stats.stat_util
@@ -322,17 +322,23 @@ def post_in_fishcooking_results(run):
         print("Unable to post results to fishcooking forum")
 
 
-def delta_date(date):
+def diff_date(date):
     if date != datetime.min:
         diff = datetime.utcnow() - date
-        if diff.days != 0:
-            delta = "%d days ago" % (diff.days)
-        elif diff.seconds / 3600 > 1:
-            delta = "%d hours ago" % (diff.seconds / 3600)
-        elif diff.seconds / 60 > 1:
-            delta = "%d minutes ago" % (diff.seconds / 60)
-        else:
-            delta = "seconds ago"
     else:
+        diff = timedelta.max
+    return diff
+
+
+def delta_date(diff):
+    if diff == timedelta.max:
         delta = "Never"
+    elif diff.days != 0:
+        delta = "%d days ago" % (diff.days)
+    elif diff.seconds / 3600 > 1:
+        delta = "%d hours ago" % (diff.seconds / 3600)
+    elif diff.seconds / 60 > 1:
+        delta = "%d minutes ago" % (diff.seconds / 60)
+    else:
+        delta = "seconds ago"
     return delta

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -11,6 +11,7 @@ import fishtest.stats.stat_util
 import requests
 from fishtest.util import (
     calculate_residuals,
+    diff_date,
     delta_date,
     estimate_game_duration,
     format_results,
@@ -904,7 +905,8 @@ def tests_stats(request):
 def tests_machines(request):
     machines = request.rundb.get_machines()
     for machine in machines:
-        machine["last_updated"] = delta_date(machine["last_updated"])
+        diff = diff_date(machine["last_updated"])
+        machine["last_updated"] = delta_date(diff)
     return {"machines": machines}
 
 
@@ -1157,7 +1159,8 @@ def homepage_results(request):
     games_per_minute = 0.0
     machines = request.rundb.get_machines()
     for machine in machines:
-        machine["last_updated"] = delta_date(machine["last_updated"])
+        diff = diff_date(machine["last_updated"])
+        machine["last_updated"] = delta_date(diff)
         if machine["nps"] != 0:
             games_per_minute += (
                 (machine["nps"] / 1200000.0)

--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -9,7 +9,7 @@ from pymongo import DESCENDING
 # For tasks
 sys.path.append(os.path.expanduser("~/fishtest/fishtest"))
 from fishtest.rundb import RunDb
-from fishtest.util import delta_date, estimate_game_duration
+from fishtest.util import delta_date, estimate_game_duration, diff_date
 
 new_deltas = {}
 skip = False
@@ -80,9 +80,13 @@ def build_users(machines, info):
         user = info[u]
         try:
             if isinstance(user["last_updated"], str):
-                user["last_updated"] = delta_date(user["task_last_updated"])
+                diff = diff_date(user["task_last_updated"])
+                user["diff"] = diff.total_seconds()
+                user["last_updated"] = delta_date(diff)
             else:
-                user["last_updated"] = delta_date(user["last_updated"])
+                diff = diff_date(user["last_updated"])
+                user["diff"] = diff.total_seconds()
+                user["last_updated"] = delta_date(diff)
         except:
             pass
         users.append(user)


### PR DESCRIPTION
Ordering users in https://tests.stockfishchess.org/users using "last active" filter led to a wrong output: the program order alphabetically the strings in the column instead of the time passed.
![immagine](https://user-images.githubusercontent.com/73311422/112209486-cb6e3300-8c19-11eb-8b6f-4b8c882c3185.png)

So I try to introduce an user-defined html attribute whose value is the time difference used by delta_date to write the corresponding strings. In order to do this I split the function delta_date in two parts creating a new function called diff_date whose output is the desired time difference in datetime.datetime format. I rewrite every delta_date call letting them to be compliant with the new definition. Hence I converted diff in isoformat and I stored it in user["diff"]. In application.js I introduced another "or" in the first line: my aim is to let the program search "data-diff" attribute, and only if it doesn't exist it would search innerText.

As I write on discord commits are not tested.