### PR TITLE
Use safe "-games" option in cutechess-cli

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -1051,10 +1051,8 @@ def run_games(worker_info, password, remote, run, task_id):
             [
                 cutechess,
                 "-repeat",
-                "-rounds",
-                str(int(games_to_play / 2)),
                 "-games",
-                " 2",
+                str(int(games_to_play)),
                 "-tournament",
                 "gauntlet",
             ]


### PR DESCRIPTION
The options `-rounds str(int(games_to_play / 2)) -games 2` was introduced
to mute a cutechess-cli warning.
In fishtest the rounding works because the pentanomial code updates the result
with game pairs, so an unfinished run (after a worker stop) has an even number
of games_to_play.
Use the safer `-games str(int(games_to_play))` option that mutes the warning
and works also with an odd number of games_to_play.

From a prompt by @ianfab