### PR TITLE
New SPRT bounds for tests

### DIFF
--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -49,7 +49,7 @@
       <li><a href="/users/monthly">Top Month</a></li>
       <li><a href="/actions">Actions</a></li>
       <li><a href="/nns">NN stats</a></li>
-      <li><a href="/html/SPRTcalculator.html?elo-0=-0.25&elo-1=1.25&draw-ratio=0.78&rms-bias=30" target="_blank">SPRT Calc</a></li>
+      <li><a href="/html/SPRTcalculator.html?elo-0=-0.2&elo-1=1.1&draw-ratio=0.82&rms-bias=30" target="_blank">SPRT Calc</a></li>
 
       <li class="nav-header">Github</li>
       <li><a href="https://github.com/glinscott/fishtest" target="_blank" rel="noopener">Fishtest</a></li>

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -186,10 +186,10 @@
     <div class="flex-row stop_rule sprt">
       <label class="field-label leftmost stop_rule sprt">SPRT bounds</label>
       <select name="bounds" class="stop_rule sprt" style="width: 246px">
-        <option value="standard STC">Standard STC {-0.25, 1.25}</option>
-        <option value="standard LTC">Standard LTC {0.25, 1.25}</option>
-        <option value="regression STC">Non-regression STC {-1.25, 0.25}</option>
-        <option value="regression LTC">Non-regression LTC {-0.75, 0.25}</option>
+        <option value="standard STC">Standard STC {-0.2, 1.1}</option>
+        <option value="standard LTC">Standard LTC {0.2, 0.9}</option>
+        <option value="regression STC">Non-regression STC {-1, 0.2}</option>
+        <option value="regression LTC">Non-regression LTC {-0.7, 0.2}</option>
         <option value="custom" ${is_rerun and 'selected'}>Custom bounds...</option>
       </select>
 
@@ -197,14 +197,14 @@
              style="${args.get('sprt') or 'display: none'}">SPRT Elo0</label>
       <input type="number" step="0.05" name="sprt_elo0"
              class="sprt custom_bounds no-arrows"
-             value="${args.get('sprt', {'elo0': -0.25})['elo0']}"
+             value="${args.get('sprt', {'elo0': -0.2})['elo0']}"
              style="width: 90px; ${args.get('sprt') or 'display: none'}" />
 
       <label class="field-label sprt custom_bounds rightmost"
              style="${args.get('sprt') or 'display: none'}">SPRT Elo1</label>
       <input type="number" step="0.05" name="sprt_elo1"
              class="sprt custom_bounds no-arrows"
-             value="${args.get('sprt', {'elo1': 1.25})['elo1']}"
+             value="${args.get('sprt', {'elo1': 1.1})['elo1']}"
              style="width: 90px; ${args.get('sprt') or 'display: none'}" />
     </div>
 
@@ -334,11 +334,15 @@
     $('#submit-test').removeAttr('disabled').text('Submit test');
   });
 
+## In the future, this should be changed to normalized Elo,
+## and converted within fishtest to logistic Elo whenever needed.
+## See also https://github.com/glinscott/fishtest/issues/865#issuecomment-808808220
+
   const preset_bounds = {
-    'standard STC': [-0.25, 1.25],
-    'standard LTC': [0.25, 1.25],
-    'regression STC': [-1.25, 0.25],
-    'regression LTC': [-0.75, 0.25],
+    'standard STC': [-0.2, 1.1],
+    'standard LTC': [ 0.2, 0.9],
+    'regression STC': [-1.0, 0.2],
+    'regression LTC': [-0.7, 0.2],
   };
 
   function update_sprt_bounds(selected_bounds_name) {


### PR DESCRIPTION
New bounds for STC and LTC tests in fishtest.

The main change is that the new bounds will make LTC tests quite easier to pass Elo-wise.
We have to shrink the intervals to keep good precision, so the total cost will be about three
times longer runs in the worst case.

See discussions in https://github.com/glinscott/fishtest/issues/865 and https://discord.com/channels/435943710472011776/813919248455827515/825466226994053170

