### PR TITLE
Add SPRT bounds for classical tests.

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -188,6 +188,8 @@
       <select name="bounds" class="stop_rule sprt" style="width: 246px">
         <option value="standard STC">Standard STC {-0.2, 1.1}</option>
         <option value="standard LTC">Standard LTC {0.2, 0.9}</option>
+	<option value="classical STC">Classical STC {-0.3, 1.6}</option>
+	<option value="classical LTC">Classical LTC {0.4, 1.7}</option>
         <option value="regression STC">Non-regression STC {-1, 0.2}</option>
         <option value="regression LTC">Non-regression LTC {-0.7, 0.2}</option>
         <option value="custom" ${is_rerun and 'selected'}>Custom bounds...</option>
@@ -341,6 +343,8 @@
   const preset_bounds = {
     'standard STC': [-0.2, 1.1],
     'standard LTC': [ 0.2, 0.9],
+    'classical STC': [-0.3, 1.6],
+    'classical LTC': [ 0.4, 1.7],
     'regression STC': [-1.0, 0.2],
     'regression LTC': [-0.7, 0.2],
   };


### PR DESCRIPTION
Implementing the proposed bounds for classical tests:

classical LTC: Elo{ 0.4;1.7} nElo{0.75,3.25} LTC regression rate 0.9%, 160k games peak, 1.05 elo 50% pass, draw rate 0.73416
classical STC: Elo{-0.3,1.6} nElo{-0.5,2.5} STC regression rate 11.8%, 113.5k games peak, 0.65 elo 50% pass, draw rate 0.60113

See https://discord.com/channels/435943710472011776/813919248455827515/829456512841547787 for the relevant discussion. This is being done to bring the classical STC/LTC bounds in line with the current normalized elo bounds. As an aside, this is my first pull request, my apologies if I've done something wrong here. 