### PR TITLE
Use normalized Elo input for Fishtest

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -18,6 +18,7 @@ from fishtest.userdb import UserDb
 from fishtest.util import (
     calculate_residuals,
     estimate_game_duration,
+    format_bounds,
     format_results,
     get_worker_key,
     post_in_fishcooking_results,
@@ -420,14 +421,9 @@ class RunDb:
                 if "sprt" in run["args"]:
                     sprt = run["args"]["sprt"]
                     elo_model = sprt.get("elo_model", "BayesElo")
-                    if elo_model == "BayesElo":
-                        run["results_info"]["info"].append(
-                            ("[%.2f,%.2f]") % (sprt["elo0"], sprt["elo1"])
-                        )
-                    else:
-                        run["results_info"]["info"].append(
-                            ("{%.2f,%.2f}") % (sprt["elo0"], sprt["elo1"])
-                        )
+                    run["results_info"]["info"].append(
+                        format_bounds(elo_model,sprt["elo0"],sprt["elo1"])
+                    )
         return (runs, pending_hours, cores, nps)
 
     def get_finished_runs(

--- a/server/fishtest/stats/LLRcalc.py
+++ b/server/fishtest/stats/LLRcalc.py
@@ -7,6 +7,8 @@ import sys
 import scipy
 import scipy.optimize
 
+nelo_divided_by_nt = 800 / math.log(10)  # 347.43558552260146
+
 
 def MLE(pdf, s):
     """
@@ -171,3 +173,24 @@ def LLR_logistic(elo0, elo1, results):
     s0, s1 = [L_(elo) for elo in (elo0, elo1)]
     N, pdf = results_to_pdf(results)
     return N * LLR(pdf, s0, s1)
+
+
+def LLR_normalized(nelo0, nelo1, results):
+    """
+    See
+    http://hardy.uhasselt.be/Fishtest/normalized_elo_practical.pdf"""
+    count, pdf = results_to_pdf(results)
+    mu, var = stats(pdf)
+    if len(results) == 5:
+        sigma_pg = (2 * var) ** 0.5
+        games = 2 * count
+    elif len(results) == 3:
+        sigma_pg = var ** 0.5
+        games = count
+    else:
+        assert False
+    nt0, nt1 = [nelo / nelo_divided_by_nt for nelo in (nelo0, nelo1)]
+    nt = (mu - 0.5) / sigma_pg
+    return (games / 2.0) * math.log(
+        (1 + (nt - nt0) * (nt - nt0)) / (1 + (nt - nt1) * (nt - nt1))
+    )

--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -49,7 +49,7 @@
       <li><a href="/users/monthly">Top Month</a></li>
       <li><a href="/actions">Actions</a></li>
       <li><a href="/nns">NN stats</a></li>
-      <li><a href="/html/SPRTcalculator.html?elo-model=Logistic&elo-0=-0.2&elo-1=1.1&draw-ratio=0.82&rms-bias=30" target="_blank">SPRT Calc</a></li>
+      <li><a href="/html/SPRTcalculator.html?elo-model=Normalized&elo-0=-0.5&elo-1=2.5&draw-ratio=0.82&rms-bias=30" target="_blank">SPRT Calc</a></li>
 
       <li class="nav-header">Github</li>
       <li><a href="https://github.com/glinscott/fishtest" target="_blank" rel="noopener">Fishtest</a></li>

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -1,5 +1,11 @@
 <%inherit file="base.mak"/>
 
+<%
+from fishtest.util import format_bounds
+elo_model="normalized" 
+fb=lambda e0,e1:format_bounds(elo_model,e0,e1)
+%>
+
 <style>
   input[type=number].no-arrows::-webkit-inner-spin-button,
   input[type=number].no-arrows::-webkit-outer-spin-button {
@@ -184,14 +190,14 @@
     </div>
 
     <div class="flex-row stop_rule sprt">
+      <input type="hidden" name="elo_model" id="elo_model_field" value=${elo_model} />
       <label class="field-label leftmost stop_rule sprt">SPRT bounds</label>
+
       <select name="bounds" class="stop_rule sprt" style="width: 246px">
-        <option value="standard STC">Standard STC {-0.2, 1.1}</option>
-        <option value="standard LTC">Standard LTC {0.2, 0.9}</option>
-	<option value="classical STC">Classical STC {-0.3, 1.6}</option>
-	<option value="classical LTC">Classical LTC {0.4, 1.7}</option>
-        <option value="regression STC">Non-regression STC {-1, 0.2}</option>
-        <option value="regression LTC">Non-regression LTC {-0.7, 0.2}</option>
+        <option value="standard STC">Standard STC ${fb(-0.5, 2.5)}</option>
+        <option value="standard LTC">Standard LTC ${fb(0.5, 3.5)}</option>
+        <option value="regression STC">Non-regression STC ${fb(-2.5, 0.5)}</option>
+        <option value="regression LTC">Non-regression LTC ${fb(-2.5, 0.5)}</option>
         <option value="custom" ${is_rerun and 'selected'}>Custom bounds...</option>
       </select>
 
@@ -199,14 +205,15 @@
              style="${args.get('sprt') or 'display: none'}">SPRT Elo0</label>
       <input type="number" step="0.05" name="sprt_elo0"
              class="sprt custom_bounds no-arrows"
-             value="${args.get('sprt', {'elo0': -0.2})['elo0']}"
+	     ## The bounds handling should be cleaned up...
+             value="${args.get('sprt', {'elo0': -0.5})['elo0']}"
              style="width: 90px; ${args.get('sprt') or 'display: none'}" />
 
       <label class="field-label sprt custom_bounds rightmost"
              style="${args.get('sprt') or 'display: none'}">SPRT Elo1</label>
       <input type="number" step="0.05" name="sprt_elo1"
              class="sprt custom_bounds no-arrows"
-             value="${args.get('sprt', {'elo1': 1.1})['elo1']}"
+             value="${args.get('sprt', {'elo1': 2.5})['elo1']}"
              style="width: 90px; ${args.get('sprt') or 'display: none'}" />
     </div>
 
@@ -341,12 +348,10 @@
 ## See also https://github.com/glinscott/fishtest/issues/865#issuecomment-808808220
 
   const preset_bounds = {
-    'standard STC': [-0.2, 1.1],
-    'standard LTC': [ 0.2, 0.9],
-    'classical STC': [-0.3, 1.6],
-    'classical LTC': [ 0.4, 1.7],
-    'regression STC': [-1.0, 0.2],
-    'regression LTC': [-0.7, 0.2],
+    'standard STC': [-0.5, 2.5],
+    'standard LTC': [ 0.5, 3.5],
+    'regression STC': [-2.5, 0.5],
+    'regression LTC': [-2.5, 0.5],
   };
 
   function update_sprt_bounds(selected_bounds_name) {

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -149,6 +149,10 @@ def calculate_residuals(run):
     return chi2
 
 
+def format_bounds(elo_model,elo0,elo1):
+    seps={'BayesElo':r'[]','logistic':r'{}','normalized':r'<>'}
+    return "%s%.2f,%.2f%s" % (seps[elo_model][0],elo0,elo1,seps[elo_model][1])
+
 def format_results(run_results, run):
     result = {"style": "", "info": []}
 
@@ -178,28 +182,15 @@ def format_results(run_results, run):
         elo_model = sprt.get("elo_model", "BayesElo")
         if not "llr" in sprt:  # legacy
             fishtest.stats.stat_util.update_SPRT(run_results, sprt)
-        if elo_model == "BayesElo":
-            result["info"].append(
-                "LLR: %.2f (%.2lf,%.2lf) [%.2f,%.2f]"
-                % (
-                    sprt["llr"],
-                    sprt["lower_bound"],
-                    sprt["upper_bound"],
-                    sprt["elo0"],
-                    sprt["elo1"],
-                )
+        result["info"].append(
+            "LLR: %.2f (%.2lf,%.2lf) %s"
+            % (
+                sprt["llr"],
+                sprt["lower_bound"],
+                sprt["upper_bound"],
+                format_bounds(elo_model,sprt["elo0"],sprt["elo1"])
             )
-        else:
-            result["info"].append(
-                "LLR: %.2f (%.2lf,%.2lf) {%.2f,%.2f}"
-                % (
-                    sprt["llr"],
-                    sprt["lower_bound"],
-                    sprt["upper_bound"],
-                    sprt["elo0"],
-                    sprt["elo1"],
-                )
-            )
+        )
     else:
         if "pentanomial" in run_results.keys():
             elo, elo95, los = fishtest.stats.stat_util.get_elo(

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -615,12 +615,15 @@ def validate_form(request):
         sprt_batch_size_games = 8
         assert sprt_batch_size_games % 2 == 0
         assert request.rundb.chunk_size % sprt_batch_size_games == 0
+        elo_model=request.POST["elo_model"]
+        if elo_model not in ['BayesElo','logistic','normalized']:
+            raise Exception("Unknown Elo model")
         data["sprt"] = fishtest.stats.stat_util.SPRT(
             alpha=0.05,
             beta=0.05,
             elo0=float(request.POST["sprt_elo0"]),
             elo1=float(request.POST["sprt_elo1"]),
-            elo_model="logistic",
+            elo_model=elo_model,
             batch_size=sprt_batch_size_games // 2,
         )  # game pairs
         # Limit on number of games played.


### PR DESCRIPTION
Specify SPRT bounds in normalized Elo.
    
The normalized bounds are indicated using `<>` brackets. Currently they are
```    
    standard STC  : <-0.5, 2.5>
    standard LTC  : < 0.5, 3.5>
    regression STC: <-2.5, 0.5>
    regression LTC: <-2.5, 0.5>
```    
leading to a peak expected test duration of `116K` games.
    
Specific changes:
    
Update LLRcalc.py, sprt.py and stat_util.py to understand normalized Elo bounds.
    
Introduce a new Elo model 'normalized' for the sprt object.
    
Clean up the raw stats page. In particular give variables referring to 'sensitivity' a 'nt' (normalized t) prefix. 'Exact LLR' is renamed to 'Multinomial LLR'.
    
Add appropriate bound conversions to the raw stats page.
    
Show normalized LLR's on the raw stats page.
    
Generic bounds formatting ([],{} or <>).

Put normalized bounds in tests_run.mak. Send the Elo model via a hidden field but validate on the server.
    
Change defaults for the SPRT calculator.
    
Fix some cosmetic bugs in the latest SPRT calculator.
