### PR TITLE
Remember the selected theme for 30 days.

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -67,8 +67,12 @@ $(() => {
         $('head link[href*="/css/theme.dark.css"]').remove();
         theme = 'light';
       }
+      let cookieExpireDate = new Date();
+      // Remember the theme for 30 days
+      cookieExpireDate.setTime(cookieExpireDate.getTime() + 30 * 24 * 60 * 60 * 1000);
       $.cookie('theme', theme, {
         path: '/',
+        expires: cookieExpireDate,
       });
     });
 


### PR DESCRIPTION
Currently the selected theme is stored only until the end of the user session.
Therefore, the user has to change the interface to dark mode every day once again -
this can be a bit annoying and hurt your eyes.
With this patch the cookie that remembers the theme is stored for 30 days.