### PR TITLE
Use format <master>..<test> for diff URL

### DIFF
--- a/server/fishtest/helpers.py
+++ b/server/fishtest/helpers.py
@@ -4,18 +4,30 @@ def tests_repo(run):
     )
 
 
+def tests_repo_api(run):
+    """Return URL for GitHub API of the repository"""
+    return run["args"].get(
+        "tests_repo", "https://github.com/official-stockfish/Stockfish"
+        ).replace(
+            "//github.com/", "//api.github.com/repos/", 1)
+
+
 def master_diff_url(run):
     return "https://github.com/official-stockfish/Stockfish/compare/master...{}".format(
         run["args"]["resolved_base"][:10]
     )
 
 
-def diff_url(run):
+def diff_url(run, *, api_url=False):
+    """Produces GitHub diff URL
+
+    Uses the two-dotted format for non-API, the three-dotted format for API."""
     if run["args"].get("spsa"):
         return master_diff_url(run)
     else:
-        return "{}/compare/{}...{}".format(
-            tests_repo(run),
+        return "{}/compare/{}{}{}".format(
+            tests_repo(run) if not api_url else tests_repo_api(run),
             run["args"]["resolved_base"][:10],
+            ".." if not api_url else "...",
             run["args"]["resolved_new"][:10],
         )

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -329,7 +329,7 @@
     }
 
     // Fetch the diff and decide whether to show it on the page
-    const diffApiUrl = "${h.diff_url(run)}".replace("//github.com/", "//api.github.com/repos/");
+    const diffApiUrl = "${h.diff_url(run, api_url=True)}";
     $.ajax({
       url: diffApiUrl,
       headers: {


### PR DESCRIPTION
```
This shows the full diff when master has diverged from the test
branch.

This is helpful no to disguise an outdated master when chekcing the test
diff.
```

The "new test" form will complain when master in the base repo is not up to date. But it does _not_ warn when the old master is _used_ instead. With this change, the approver obtains a chance to notice this error.

