### PR TITLE
Exact LLR for normalized Elo.

### DIFF
--- a/server/fishtest/stats/LLRcalc.py
+++ b/server/fishtest/stats/LLRcalc.py
@@ -1,43 +1,101 @@
 from __future__ import division
-
-import copy
-import math
-import sys
-
-import scipy
+import math, sys, copy
 import scipy.optimize
+
+"""
+Probability distributions (generally having a name starting with
+"pdf") are represented by a list of tuples (ai,pi), i=1,...,N.  It is
+usually assumed that the ai are strictly ascending and p1>0, pN>0.
+"""
+
+"""
+The results of a test are represented by a list of either length 3
+or 5. If the length is 3 then it should contain the frequencies of
+L,D,W. If the length is 5 then it should contain the frequencies of
+the game pairs LL,LD+DL,LW+DD+WL,DW+WD,WW.
+"""
 
 nelo_divided_by_nt = 800 / math.log(10)  # 347.43558552260146
 
 
-def MLE(pdf, s):
+def secular(pdf):
     """
-    This function computes the maximum likelood estimate for
-    a discrete distribution with expectation value s,
-    given an observed (i.e. empirical) distribution pdf.
+Solves the secular equation sum_i pi*ai/(1+x*ai)=0.
 
-    pdf is a list of tuples (ai,pi), i=1,...,N. It is assumed that
-    that the ai are strictly ascending, a1<s<aN and p1>0, pN>0.
-
-    The theory behind this function can be found in the online
-    document
-
-    http://hardy.uhasselt.be/Fishtest/support_MLE_multinomial.pdf
-
-    (see Proposition 1.1).
-    """
+"""
     epsilon = 1e-9
     v, w = pdf[0][0], pdf[-1][0]
-    assert v < s < w
-    l, u = -1 / (w - s), 1 / (s - v)
-    f = lambda x: sum([p * (a - s) / (1 + x * (a - s)) for a, p in pdf])
+    values = [ai for ai, pi in pdf]
+    v = min(values)
+    w = max(values)
+    assert v * w < 0
+    l = -1 / w
+    u = -1 / v
+    f = lambda x: sum([pi * ai / (1 + x * ai) for ai, pi in pdf])
     x, res = scipy.optimize.brentq(
         f, l + epsilon, u - epsilon, full_output=True, disp=False
     )
     assert res.converged
-    pdf_MLE = [(a, p / (1 + x * (a - s))) for a, p in pdf]
-    s_, var = stats(pdf_MLE)  # for validation
+    return x
+
+
+def uniform(pdf):
+    n = len(pdf)
+    return [(ai, 1 / n) for ai, pi in pdf]
+
+
+def MLE_expected(pdfhat, s):
+    """
+This function computes the maximum likelood estimate for
+a discrete distribution with expectation value s,
+given an observed (i.e. empirical) distribution pdfhat.
+
+The theory behind this function can be found in the online
+document
+
+http://hardy.uhasselt.be/Fishtest/support_MLE_multinomial.pdf
+
+(see Proposition 1.1).
+"""
+    pdf1 = [(ai - s, pi) for ai, pi in pdfhat]
+    x = secular(pdf1)
+    pdf_MLE = [(ai, pi / (1 + x * (ai - s))) for ai, pi in pdfhat]
+    s_, _ = stats(pdf_MLE)  # for validation
     assert abs(s - s_) < 1e-6
+    return pdf_MLE
+
+
+def MLE_t_value(pdfhat, ref, s):
+    """
+This function computes the maximum likelood estimate for
+a discrete distribution with t-value ((mu-ref)/sigma),
+given an observed (i.e. empirical) distribution pdfhat.
+
+The theory behind this function can be found in the online
+document
+
+https://hardy.uhasselt.be/Fishtest/normalized_elo_practical.pdf
+
+(see Section 4.1).
+"""
+    N = len(pdfhat)
+    pdf_MLE = uniform(pdfhat)
+    for i in range(10):
+        pdf_ = pdf_MLE
+        mu, var = stats(pdf_MLE)
+        sigma = var ** (1 / 2)
+        pdf1 = [
+            (ai - ref - s * sigma * (1 + ((mu - ai) / sigma) ** 2) / 2, pi)
+            for ai, pi in pdfhat
+        ]
+        x = secular(pdf1)
+        pdf_MLE = [
+            (pdfhat[i][0], pdfhat[i][1] / (1 + x * pdf1[i][0])) for i in range(N)
+        ]
+        if max([abs(pdf_[i][1] - pdf_MLE[i][1]) for i in range(N)]) < 1e-9:
+            break
+    mu, var = stats(pdf_MLE)  # for validation
+    assert abs(s - (mu - ref) / var ** 0.5) < 1e-5
     return pdf_MLE
 
 
@@ -54,8 +112,9 @@ def stats(pdf):
 
 def stats_ex(pdf):
     """
-    Computes expectation value, variance, skewness and excess
-    kurtosis for a discrete distribution."""
+Computes expectation value, variance, skewness and excess
+kurtosis for a discrete distribution.
+"""
     s, var = stats(pdf)
     m3 = sum([prob * (value - s) ** 3 for value, prob in pdf])
     m4 = sum([prob * (value - s) ** 4 for value, prob in pdf])
@@ -64,74 +123,81 @@ def stats_ex(pdf):
     return s, var, skewness, exkurt
 
 
-def LLRjumps(pdf, s0, s1):
-    pdf0, pdf1 = [MLE(pdf, s) for s in (s0, s1)]
+def LLRjumps(pdf, s0, s1, ref=None, statistic="expectation"):
+    if statistic == "expectation":
+        pdf0, pdf1 = [MLE_expected(pdf, s) for s in (s0, s1)]
+    elif statistic == "t_value":
+        pdf0, pdf1 = [MLE_t_value(pdf, ref, s) for s in (s0, s1)]
+    else:
+        assert False
     return [
         (math.log(pdf1[i][1]) - math.log(pdf0[i][1]), pdf[i][1])
         for i in range(0, len(pdf))
     ]
 
 
-def LLR(pdf, s0, s1):
+def LLR(pdf, s0, s1, ref=None, statistic="expectation"):
     """
-    This function computes the generalized log likelihood ratio (divided by N)
-    for s=s1 versus s=s0 where pdf is an empirical distribution and
-    s is the expectation value of the true distribution.
-    pdf is a list of pairs (value,probability)."""
-    return stats(LLRjumps(pdf, s0, s1))[0]
+This function computes the generalized log likelihood ratio
+(divided by N) for s=s1 versus s=s0 where pdf is an empirical
+distribution and s is score of the true distribution.
+
+"""
+    return stats(LLRjumps(pdf, s0, s1, ref=ref, statistic=statistic))[0]
 
 
 def LLR_alt(pdf, s0, s1):
     """
-    This function computes the approximate generalized log likelihood ratio (divided by N)
-    for s=s1 versus s=s0 where pdf is an empirical distribution and
-    s is the expectation value of the true distribution.
-    pdf is a list of pairs (value,probability). See
+This function computes the approximate generalized log likelihood
+ratio (divided by N) for s=s1 versus s=s0 where pdf is an empirical
+distribution and s is the expectation value of the true
+distribution. See
 
-    http://hardy.uhasselt.be/Fishtest/support_MLE_multinomial.pdf"""
+http://hardy.uhasselt.be/Fishtest/support_MLE_multinomial.pdf
+
+"""
     r0, r1 = [sum([prob * (value - s) ** 2 for value, prob in pdf]) for s in (s0, s1)]
     return 1 / 2 * math.log(r0 / r1)
 
 
 def LLR_alt2(pdf, s0, s1):
     """
-    This function computes the approximate generalized log likelihood ratio (divided by N)
-    for s=s1 versus s=s0 where pdf is an empirical distribution and
-    s is the expectation value of the true distribution.
-    pdf is a list of pairs (value,probability). See
+This function computes the approximate generalized log likelihood
+ratio (divided by N) for s=s1 versus s=s0 where pdf is an empirical
+distribution and s is the expectation value of the true
+distribution. See
 
-    http://hardy.uhasselt.be/Fishtest/GSPRT_approximation.pdf"""
+http://hardy.uhasselt.be/Fishtest/GSPRT_approximation.pdf
+
+"""
     s, var = stats(pdf)
     return (s1 - s0) * (2 * s - s0 - s1) / var / 2.0
 
 
 def LLR_drift_variance(pdf, s0, s1, s=None):
     """
-    Computes the drift and variance of the LLR
-    for a test s=s0 against s=s0
-    when the empirical distribution is pdf,
-    but the true value of s is as given by
-    the argument s. If s is not given
-    then it is assumed that pdf is the true
-    distribution."""
+Computes the drift and variance of the LLR for a test s=s0 against
+s=s0 when the empirical distribution is pdf, but the true value of s
+is as given by the argument s. If s is not given then it is assumed
+that pdf is the true distribution.
+"""
     if s != None:
-        pdf = MLE(pdf, s)
+        pdf = MLE_expected(pdf, s)
     jumps = LLRjumps(pdf, s0, s1)
     return stats(jumps)
 
 
 def LLR_drift_variance_alt2(pdf, s0, s1, s=None):
     """
-    Computes the approximated drift and variance of the LLR
-    for a test s=s0 against s=s0
-    approximated by a Brownian motion, when
-    the empirical distribution is pdf,
-    but the true value of s is as given by
-    the argument s. If s is not given
-    the it is assumed that pdf is the true
-    distribution. See
+Computes the approximated drift and variance of the LLR for a test
+s=s0 against s=s0 approximated by a Brownian motion, when the
+empirical distribution is pdf, but the true value of s is as given by
+the argument s. If s is not given the it is assumed that pdf is the
+true distribution. See
 
-    http://hardy.uhasselt.be/Fishtest/GSPRT_approximation.pdf"""
+http://hardy.uhasselt.be/Fishtest/GSPRT_approximation.pdf
+
+"""
     s_, v_ = stats(pdf)
     # replace v_ by its MLE if requested
     s, v = (s_, v_) if s == None else (s, v_ + (s - s_) ** 2)
@@ -145,8 +211,9 @@ def L_(x):
 
 
 def regularize(l):
-    """
-    If necessary mix in a small prior for regularization."""
+    """ 
+If necessary mix in a small prior for regularization.
+"""
     epsilon = 1e-3
     l = copy.copy(l)
     for i in range(0, len(l)):
@@ -163,22 +230,26 @@ def results_to_pdf(results):
 
 
 def LLR_logistic(elo0, elo1, results):
-    """
-    This function computes the generalized log-likelihood ratio for "results"
-    which should be a list of either length 3 or 5. If the length
-    is 3 then it should contain the frequencies of L,D,W. If the length
-    is 5 then it should contain the frequencies of the game pairs
-    LL,LD+DL,LW+DD+WL,DW+WD,WW.
-    elo0,elo1 are in logistic elo."""
+    """ 
+This function computes the generalized log-likelihood ratio for "results"
+using the statistic "expectation". elo0,elo1 are in logistic elo.
+"""
     s0, s1 = [L_(elo) for elo in (elo0, elo1)]
     N, pdf = results_to_pdf(results)
-    return N * LLR(pdf, s0, s1)
+    return N * LLR(pdf, s0, s1, statistic="expectation")
 
 
-def LLR_normalized(nelo0, nelo1, results):
+def LLR_normalized_alt(nelo0, nelo1, results):
     """
-    See
-    http://hardy.uhasselt.be/Fishtest/normalized_elo_practical.pdf"""
+This function computes the generalized log-likelihood ratio for "results"
+using the approximation in
+
+https://hardy.uhasselt.be/Fishtest/normalized_elo_practical.pdf
+
+(see Section 4.2).
+
+nelo0,nelo1 are in normalized Elo.
+"""
     count, pdf = results_to_pdf(results)
     mu, var = stats(pdf)
     if len(results) == 5:
@@ -191,6 +262,25 @@ def LLR_normalized(nelo0, nelo1, results):
         assert False
     nt0, nt1 = [nelo / nelo_divided_by_nt for nelo in (nelo0, nelo1)]
     nt = (mu - 0.5) / sigma_pg
+
     return (games / 2.0) * math.log(
         (1 + (nt - nt0) * (nt - nt0)) / (1 + (nt - nt1) * (nt - nt1))
     )
+
+
+def LLR_normalized(nelo0, nelo1, results):
+    """
+This function computes the generalized log-likelihood ratio for "results"
+using the statistic "t_value". nelo0,nelo1 are in normalized elo.
+"""
+    nt0, nt1 = [nelo / nelo_divided_by_nt for nelo in (nelo0, nelo1)]
+    sqrt2 = 2 ** 0.5
+    t0, t1 = (
+        (nt0, nt1)
+        if len(results) == 3
+        else (nt0 * sqrt2, nt1 * sqrt2)
+        if len(results) == 5
+        else None
+    )
+    N, pdf = results_to_pdf(results)
+    return N * LLR(pdf, t0, t1, ref=1 / 2, statistic="t_value")

--- a/server/fishtest/templates/tests_stats.mak
+++ b/server/fishtest/templates/tests_stats.mak
@@ -142,6 +142,7 @@
       LLR3_alt  =N3*fishtest.stats.LLRcalc.LLR_alt(pdf3,score03,score13)
       LLR3_alt2 =N3*fishtest.stats.LLRcalc.LLR_alt2(pdf3,score03,score13)
       LLR3_normalized=fishtest.stats.LLRcalc.LLR_normalized(nelo03,nelo13,results3_)
+      LLR3_normalized_alt=fishtest.stats.LLRcalc.LLR_normalized_alt(nelo03,nelo13,results3_)
       LLR3_be   =fishtest.stats.stat_util.LLRlegacy(belo0,belo1,results3_)
       if has_pentanomial:	
       	 LLRjumps5=list_to_string([i[0] for i in fishtest.stats.LLRcalc.LLRjumps(pdf5,score0,score1)])
@@ -168,6 +169,7 @@
 	 LLR5_alt  =N5*fishtest.stats.LLRcalc.LLR_alt(pdf5,score0,score1)
 	 LLR5_alt2 =N5*fishtest.stats.LLRcalc.LLR_alt2(pdf5,score0,score1)
 	 LLR5_normalized=fishtest.stats.LLRcalc.LLR_normalized(nelo0,nelo1,results5_)
+	 LLR5_normalized_alt=fishtest.stats.LLRcalc.LLR_normalized_alt(nelo0,nelo1,results5_)
 
    else:  #assume fixed length test
       elo3,elo95_3,LOS3=fishtest.stats.stat_util.get_elo(results3_)
@@ -259,19 +261,15 @@
 % if has_sprt:
       <H5> Generalized Log Likelihood Ratio </H5>
       <table class="table table-condensed" style="margin-top:1em;margin-bottom:0.5em;">
-      	<tr><td>Multinomial</td><td>${"%.5f"%LLR5_exact}</td></tr>
-      	<tr><td>Alt</td><td>${"%.5f"%LLR5_alt}</td></tr>
-      	<tr><td>Alt2</td><td>${"%.5f"%LLR5_alt2}</td></tr>
-	<tr><td>Normalized</td><td>${"%.5f"%LLR5_normalized}</td></tr>
+      	<tr><td>Logistic (exact)</td><td>${"%.5f"%LLR5_exact}</td></tr>
+      	<tr><td>Logistic (alt)</td><td>${"%.5f"%LLR5_alt}</td></tr>
+      	<tr><td>Logistic (alt2)</td><td>${"%.5f"%LLR5_alt2}</td></tr>
+	<tr><td>Normalized (exact)</td><td>${"%.5f"%LLR5_normalized}</td></tr>
+	<tr><td>Normalized (alt)</td><td>${"%.5f"%LLR5_normalized_alt}</td></tr>
       </table>
-      <em> Note: the monikers Alt and Alt2 are from the source code. Alt (which is 
-      no longer used) is faster to compute than the multinomial LLR
-      which requires
-      numerically solving a rational equation.
-      The simple Alt2 is used for Elo estimation. The normalized LLR is a variant
-      of Alt which is well adapted to the normalized Elo model.
-      Note that we are not aware of any literature
-      indicating that any of these LLR quantities is theoretically better than the others.
+      <em> The quantities labeled alt and alt2 are various approximations for the
+      exact quantities. Simulations indicate that the exact quantities perform
+      better under extreme conditions.
       </em>
 % endif ## has_sprt
       <H5> Auxilliary statistics </H5>	
@@ -322,10 +320,11 @@
 % if has_sprt:
        <H5> Generalized Log Likelihood Ratio </H5>
        <table class="table table-condensed" style="margin-top:1em;margin-bottom:0.5em;">
-       	<tr><td>Multinomial</td><td>${"%.5f"%LLR3_exact}</td></tr>
-       	<tr><td>Alt</td><td>${"%.5f"%LLR3_alt}</td></tr>
-      	<tr><td>Alt2</td><td>${"%.5f"%LLR3_alt2}</td></tr>
-      	<tr><td>Normalized</td><td>${"%.5f"%LLR3_normalized}</td></tr>
+       	<tr><td>Logistic (exact)</td><td>${"%.5f"%LLR3_exact}</td></tr>
+       	<tr><td>Logistic (alt)</td><td>${"%.5f"%LLR3_alt}</td></tr>
+      	<tr><td>Logistic (alt2)</td><td>${"%.5f"%LLR3_alt2}</td></tr>
+      	<tr><td>Normalized (exact)</td><td>${"%.5f"%LLR3_normalized}</td></tr>
+      	<tr><td>Normalized (alt)</td><td>${"%.5f"%LLR3_normalized_alt}</td></tr>
 	<tr><td>BayesElo</td><td>${"%.5f"%LLR3_be}</td></tr>	
 	</table>
        <em> Note: BayesElo is the LLR as computed using the BayesElo model. It is not clear how to


### PR DESCRIPTION
I have now found a relatively elegant numerical procedure to compute the exact LLR for normalized Elo. It is documented in S4.1 of this document

https://hardy.uhasselt.be/Fishtest/normalized_elo_practical.pdf

I simulated it for a SPRT<0,5> with a draw ratio of 99% and the error probabilities were close to 0.0500.