### PR TITLE
Decrease base nps

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1166,7 +1166,7 @@ def homepage_results(request):
         machine["last_updated"] = delta_date(diff)
         if machine["nps"] != 0:
             games_per_minute += (
-                (machine["nps"] / 1200000.0)
+                (machine["nps"] / 1080000.0)
                 * (60.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
                 * (
                     int(machine["concurrency"])

--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -69,7 +69,7 @@ def process_run(run, info, deltas=None):
 def build_users(machines, info):
     for machine in machines:
         games_per_hour = (
-            (machine["nps"] / 1200000.0)
+            (machine["nps"] / 1080000.0)
             * (3600.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
             * (int(machine["concurrency"]) // machine["run"]["args"].get("threads", 1))
         )

--- a/worker/games.py
+++ b/worker/games.py
@@ -456,9 +456,9 @@ def kill_process(p):
 
 def adjust_tc(tc, base_nps, concurrency):
     factor = (
-        1200000.0 / base_nps
+        1080000.0 / base_nps
     )  # 1.6Mnps is the reference core, also used in fishtest views.
-    if base_nps < 500000:
+    if base_nps < 450000:
         sys.stderr.write(
             "This machine is too slow to run fishtest effectively - sorry!\n"
         )


### PR DESCRIPTION
The recently added new net arch introduced a slowdown. On my system it is 6.8% slower. In the commit it is said to be 15% to 20% slower. I guess this could vary quite a lot between different CPU instruction sets. For now I decreased base_nps by 10% but there are arguments to be made to change it less/more depending if we change on most commonly supported instruction set on fishtest, slowest arch or fastest arch etc.
I hope @vondele and @snicolet have recommendations on how to deal with this matter.

Edit: meant to open as a draft but well... new to git ^^