### PR TITLE
Fix deprecation warning for collection_names

### DIFF
--- a/server/utils/create_indexes.py
+++ b/server/utils/create_indexes.py
@@ -76,7 +76,7 @@ def create_flag_cache_indexes():
 
 
 def print_current_indexes():
-    for collection_name in db.collection_names():
+    for collection_name in db.list_collection_names():
         c = db[collection_name]
         print("Current indexes on " + collection_name + ":")
         pprint.pprint(


### PR DESCRIPTION
Fixes a deprecation warning during the initial setup of the server.
`collection_names()` is deprecated since pymongo 3.7.
See: [https://pymongo.readthedocs.io/en/stable/changelog.html#changes-in-version-3-7-0](https://pymongo.readthedocs.io/en/stable/changelog.html#changes-in-version-3-7-0)