### PR TITLE
Fix posting tests results on googlegroup

### DIFF
--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -302,8 +302,8 @@ def post_in_fishcooking_results(run):
 
     msg = MIMEText(body)
     msg["Subject"] = title
-    msg["From"] = "fishtest@noreply.github.com"
-    msg["To"] = "fishcooking_results@googlegroups.com"
+    msg["From"] = "fishtest@noreply.stockfishchess.org"
+    msg["To"] = "fishcooking-results@googlegroups.com"
 
     try:
         s = smtplib.SMTP("localhost")


### PR DESCRIPTION
Post on the new group https://groups.google.com/g/fishcooking-results because
the old one has not an active owner
(https://groups.google.com/g/fishcooking_results)

Use an email address from stockfishchess.org to fix the DMARC check

Fix #945