### PR TITLE
Add password strength requirement

### DIFF
--- a/server/fishtest/templates/signup.mak
+++ b/server/fishtest/templates/signup.mak
@@ -25,11 +25,11 @@
       <label class="control-label">Password:</label>
       <div class="controls">
         <input name="password" type="password" pattern=".{8,}"
-               title="Eight or more characters" required="required"/>
+               title="Eight or more characters: a password too simple or trivial to guess will be rejected" required="required"/>
       </div>
     </div>
     <div class="control-group">
-      <label class="control-label">Repeat password:</label>
+      <label class="control-label">Verify password:</label>
       <div class="controls">
         <input name="password2" type="password" required="required"/>
       </div>

--- a/server/fishtest/templates/user.mak
+++ b/server/fishtest/templates/user.mak
@@ -20,7 +20,7 @@
   <div class="control-group">
     <label class="control-label">New password:</label>
     <div class="controls">
-      <input name="password" type="password"/>
+      <input name="password" type="password" pattern=".{8,}" title="Eight or more characters: a password too simple or trivial to guess will be rejected"/>
     </div>
   </div>
   <div class="control-group">

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -7,6 +7,7 @@ from email.mime.text import MIMEText
 import fishtest.stats.stat_util
 import numpy
 import scipy.stats
+from zxcvbn import zxcvbn
 
 UUID_MAP = defaultdict(dict)
 key_lock = threading.Lock()
@@ -333,3 +334,20 @@ def delta_date(diff):
     else:
         delta = "seconds ago"
     return delta
+
+
+def password_strength(password, *args):
+    if len(password) > 0:
+        # add given username and email to user_inputs
+        # such that the chosen password isn't similar to either
+        password_analysis = zxcvbn(password, user_inputs=[i for i in args])
+        # strength scale: [0-weakest <-> 4-strongest]
+        # values below 3 will give suggestions and an (optional) warning
+        if password_analysis['score'] > 2:
+            return True, ""
+        else:
+            suggestions = password_analysis['feedback']['suggestions'][0]
+            warning = password_analysis['feedback']['warning']
+            return False, suggestions+" "+warning
+    else:
+        return False, "Non-empty password required"

--- a/server/setup.py
+++ b/server/setup.py
@@ -15,6 +15,7 @@ requires = [
     "scipy",
     "requests",
     "awscli",
+    "zxcvbn",
 ]
 
 setup(


### PR DESCRIPTION
- Fixes a bug where a non-matching verification password in user profile causes internal server error.
- Introduces an offline, password strength validation for signup and password change operations. Existing passwords in the userdb are not subject to a minimum strength evaluation.
- Adds notifications upon email and/or password updates on user profile page. Relevant errors are displayed as well, accordingly.
- Skips email update if the email field matches the db entry. 
- The mako template for user profile page specifies the same minimum 8 character requirement for the password as the signup

Fixes #953 