### PR TITLE
Switch "UUID/Cores" columns in machines table

### DIFF
--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -61,7 +61,7 @@
       <li><a href="https://groups.google.com/g/fishcooking-results" target="_blank" rel="noopener">History</a></li>
       <li><a href="https://hxim.github.io/Stockfish-Evaluation-Guide/" target="_blank" rel="noopener">Eval Guide</a></li>
       <li><a href="https://github.com/glinscott/fishtest/wiki/Regression-Tests" target="_blank" rel="noopener">Regression</a></li>
-      <li><a href="http://abrok.eu/stockfish/" target="_blank" rel="noopener">Compiles</a></li>
+      <li><a href="https://abrok.eu/stockfish/" target="_blank" rel="noopener">Compiles</a></li>
       <li><a href="https://discord.gg/nv8gDtt" target="_blank" rel="noopener">Discord</a></li>
 
       <li class="nav-header">Admin</li>

--- a/server/fishtest/templates/machines_table.mak
+++ b/server/fishtest/templates/machines_table.mak
@@ -3,8 +3,8 @@
   <thead>
     <tr>
       <th>Machine</th>
-      <th>UUID</th>
       <th>Cores</th>
+      <th>UUID</th>
       <th>MNps</th>
       <th>System</th>
       <th>Version</th>
@@ -16,7 +16,6 @@
     %for machine in machines:
       <tr>
         <td>${machine['username']}</td>
-        <td>${machine['unique_key'].split('-')[0]}</td>
         <td>
           %if 'country_code' in machine:
             <div class="flag flag-${machine['country_code'].lower()}"
@@ -24,6 +23,7 @@
           %endif
           ${machine['concurrency']}
         </td>
+        <td>${machine['unique_key'].split('-')[0]}</td>
         <td>${'%.2f' % (machine['nps'] / 1000000.0)}</td>
         <td>${machine['uname']}</td>
         <td>${machine['version']}</td>


### PR DESCRIPTION
This copy the elements order used for the "Worker" column in tasks table.
Also change a link to https.