### PR TITLE
Fix missing word in error message for --concurrency

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -457,7 +457,7 @@ def main():
         cpu_count = int(options.concurrency)
 
     if cpu_count <= 0:
-        sys.stderr.write("Not enough CPUs to run fishtest: set --concurrency at least one\n")
+        sys.stderr.write("Not enough CPUs to run fishtest: set '--concurrency' to at least one\n")
         worker_exit()
 
     try:


### PR DESCRIPTION
This one is the right one, sorry for missing your message on the previous PR https://github.com/glinscott/fishtest/pull/966