### PR TITLE
Set task size to 1000 games

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -46,7 +46,7 @@ class RunDb:
         self.runs = self.db["runs"]
         self.deltas = self.db["deltas"]
 
-        self.chunk_size = 200
+        self.chunk_size = 1000
 
         global last_rundb
         last_rundb = self

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -666,7 +666,7 @@ def validate_form(request):
         # Limit on number of games played.
         # Shouldn't be hit in practice as long as it is larger than > ~200000
         # must scale with chunk_size to avoid overloading the server.
-        data["num_games"] = 2000 * request.rundb.chunk_size
+        data["num_games"] = 400 * request.rundb.chunk_size
     elif stop_rule == "spsa":
         data["num_games"] = int(request.POST["num-games"])
         if data["num_games"] <= 0:


### PR DESCRIPTION
PR following 
https://github.com/glinscott/fishtest/issues/978
With current fishtest machine distribution reasons for having such a small batch size are probably non-existent and with recent influx of cores such a small batch size can hurt fishtest performance.