### PR TITLE
Stop the test after failing to setup an engine

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -883,26 +883,37 @@ def run_games(worker_info, password, remote, run, task_id):
     cutechess = os.path.join(testing_dir, "cutechess-cli" + EXE_SUFFIX)
 
     # Build from sources new and base engines as needed
-    if not os.path.exists(new_engine):
-        setup_engine(
-            new_engine,
-            worker_dir,
-            testing_dir,
-            remote,
-            sha_new,
-            repo_url,
+    try:
+        if not os.path.exists(new_engine):
+            setup_engine(
+                new_engine,
+                worker_dir,
+                testing_dir,
+                remote,
+                sha_new,
+                repo_url,
+                worker_info["concurrency"],
+            )
+
+        if not os.path.exists(base_engine):
+            setup_engine(
+                base_engine,
+                worker_dir,
+                testing_dir,
+                remote,
+                sha_base,
+                repo_url,
+                worker_info["concurrency"],
+            )
+    except Exception as e:
+        result["message"] = "{}-{}cores-{}: {}".format(
+            worker_info["username"],
             worker_info["concurrency"],
+            worker_info["unique_key"].split("-")[0],
+            str(e),
         )
-    if not os.path.exists(base_engine):
-        setup_engine(
-            base_engine,
-            worker_dir,
-            testing_dir,
-            remote,
-            sha_base,
-            repo_url,
-            worker_info["concurrency"],
-        )
+        send_api_post_request(remote + "/api/stop_run", result)
+        raise
 
     os.chdir(testing_dir)
 


### PR DESCRIPTION
In case of a bug thas is OS dependent we can have some workers that waste CPU
failing to setup the engine while the test seems to run fine in the dashboard.
The fishtest server already stops a test only for user with at least 1000 hours
of CPU contributed, so a beginner mistake in setup the worker toolchain
cannot stop a test.