### PR TITLE
On the raw stats page show pentanomial statistics from the beginning.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -145,7 +145,7 @@ class RunDb:
             # Will be filled in by tasks, indexed by task-id
             "tasks": self.generate_tasks(num_games),
             # Aggregated results
-            "results": {"wins": 0, "losses": 0, "draws": 0},
+            "results": {"wins": 0, "losses": 0, "draws": 0, "pentanomial": 5 * [0]},
             "results_stale": False,
             "finished": False,
             "approved": False,


### PR DESCRIPTION
Of course this is a purely cosmetic issue. Trinomial and pentanomial "statistics" for zero games are computed from a weak fictitious prior. They are equally meaningless.

Fixes #1015 