### PR TITLE
Use multiples of 100 for freq.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -1056,10 +1056,14 @@ class RunDb:
         if "param_history" not in spsa:
             spsa["param_history"] = []
         L = len(spsa["params"])
-        freq = L * 25
-        if freq < 100:
-            freq = 100
-        maxlen = 250000 / freq
+        freq_max = 250000
+        freq = max(100, min(L * 25, freq_max))
+
+        # adjust freq to multiples of 100 that divide exactly into freq_max
+        freq_div = (i for i in range(100, freq_max + 1, 100) if not freq_max % i)
+        freq = [i for i in freq_div if i <= freq][-1]
+
+        maxlen = freq_max / freq
         grow_summary = len(spsa["param_history"]) < min(maxlen, spsa["iter"] / freq)
 
         # Update the current theta based on the results from the worker


### PR DESCRIPTION
The frequency modified here determines the scaling on the x-axis of graphs of tuning tests. Currently the scaling can be any multiple of 25, e.g. 375 or 425, which is not very intuitive for the user. Also, the last data point from the test is often not displayed on the graph as numbers like these tend not to divide exactly into the number of games in a test. This change ensures that the frequency is a multiple of 100 and divides neatly into 10,000, making the graph more intuitive for users.