### PR TITLE
Worker fingerprint

### DIFF
--- a/server/fishtest/templates/machines_table.mak
+++ b/server/fishtest/templates/machines_table.mak
@@ -2,9 +2,9 @@
        style="max-width: 960px;">
   <thead>
     <tr>
-      <th>Machine</th>
+      <th>User</th>
       <th>Cores</th>
-      <th>UUID</th>
+      <th>Fingerprint (machine-path-config-key)</th>
       <th>MNps</th>
       <th>System</th>
       <th>Version</th>
@@ -23,7 +23,7 @@
             % endif
             ${machine['concurrency']}
           </td>
-          <td>${machine['unique_key'].split('-')[0]}</td>
+	  <td>${machine.get('fingerprint',machine['unique_key'].split('-')[0])}</td>
           <td>${f"{machine['nps'] / 1000000:.2f}"}</td>
           <td>${machine['uname']}</td>
           <td>${machine['version']}</td>


### PR DESCRIPTION
This should make it possible to more easily track workers that are frequently restarted.
    
The fingerprint is shown on the machines table instead of the UUID (but it contains the former UUID field).
    
The fingerprint consists of 3 fixed parts which are respectively hashed versions of:
    
    - The output of uuid.getnode() (normally the MAC address).
    - The pathname of the worker script.
    - The config options (even when modified by the command line).
    
The fourth part is the first field of the UUID (which is itself randomly generated).
