### PR TITLE
Get rid of worker_key altogether.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import requests
 from fishtest.stats.stat_util import SPRT_elo
-from fishtest.util import get_worker_key
+from fishtest.util import worker_name
 from pyramid.httpexceptions import HTTPFound, HTTPUnauthorized, exception_response
 from pyramid.response import Response
 from pyramid.view import exception_view_config, view_config, view_defaults
@@ -253,7 +253,7 @@ class ApiView(object):
             task = run["tasks"][self.task_id()]
             task["last_updated"] = datetime.utcnow()
             self.request.rundb.buffer(run, False)
-            return get_worker_key(task)
+            return worker_name(task["worker_info"])
         return "Pleased to hear from you..."
 
     @view_config(route_name="api_request_spsa")

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -20,9 +20,10 @@ from fishtest.util import (
     estimate_game_duration,
     format_bounds,
     format_results,
-    get_worker_key,
     post_in_fishcooking_results,
     remaining_hours,
+    unique_key,
+    worker_name,
 )
 from pymongo import DESCENDING, MongoClient
 
@@ -350,7 +351,7 @@ class RunDb:
                 dead_task = True
                 print(
                     "dead task: run: https://tests.stockfishchess.org/tests/view/{} task_id: {} worker: {}".format(
-                        run["_id"], task_id, get_worker_key(task)
+                        run["_id"], task_id, worker_name(task["worker_info"])
                     ),
                     flush=True,
                 )
@@ -927,7 +928,7 @@ class RunDb:
         if DEBUG:
             print(
                 "Failed: https://tests.stockfishchess.org/tests/view/{} {} {}".format(
-                    run_id, task if DEBUG else task_id, get_worker_key(task)
+                    run_id, task if DEBUG else task_id, worker_name(task["worker_info"])
                 ),
                 flush=True,
             )
@@ -941,7 +942,7 @@ class RunDb:
         # Mark the task as inactive: it will be rescheduled
         print(
             "Inactive: https://tests.stockfishchess.org/tests/view/{} {} {}".format(
-                run_id, task if DEBUG else task_id, get_worker_key(task)
+                run_id, task if DEBUG else task_id, worker_name(task["worker_info"])
             ),
             flush=True,
         )
@@ -1010,7 +1011,7 @@ class RunDb:
         if "bad_tasks" not in run:
             run["bad_tasks"] = []
         for task in run["tasks"]:
-            if task["worker_key"] in chi2["bad_users"]:
+            if unique_key(task["worker_info"]) in chi2["bad_users"]:
                 purged = True
                 task["bad"] = True
                 run["bad_tasks"].append(task)

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -1,5 +1,9 @@
 <%inherit file="base.mak"/>
 
+<%
+from fishtest.util import worker_name
+%>
+
 <%namespace name="base" file="base.mak"/>
 
 %if 'spsa' in run['args']:
@@ -256,6 +260,8 @@
   <tbody>
     %for idx, task in enumerate(run['tasks'] + run.get('bad_tasks', [])):
       <%
+        if not "worker_info" in task:
+	   continue
         stats = task.get('stats', {})
         if 'stats' in task:
           total = stats['wins'] + stats['losses'] + stats['draws']
@@ -277,9 +283,9 @@
           <td>
         %endif
         %if approver and 'worker_info' in task and 'username' in task['worker_info']:
-          <a href="/user/${task['worker_info']['username']}">${task['worker_key']}</a>
+          <a href="/user/${task['worker_info']['username']}">${worker_name(task['worker_info'])}</a>
         %else:
-          ${task['worker_key']}
+          ${worker_name(task['worker_info'])}
         %endif
         </td>
         <td>


### PR DESCRIPTION
This should be a non functional conceptual simplification.

The worker key tries to solve two unrelated problems:

(1) Long ago workers did not have to a unique key, so a substitute has to be provided for the chi2 test.

(2) The unique key is not suitable for displaying, and perhaps should be kept secret as well. So the worker key is displayed instead.

Now we simply provide two functions

unique_key(worker_info)
worker_name(worker_info)

corresponding to (1,2).

Not live tested.