### PR TITLE
Get rid of the flag "task['pending']".

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -267,10 +267,8 @@ from fishtest.util import worker_name
           else:
             continue
 
-          if task['active'] and task['pending']:
+          if task['active']:
             active_style = 'info'
-          elif task['active'] and not task['pending']:
-            active_style = 'error'
           else:
             active_style = ''
         %>

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -42,15 +42,10 @@ class TestApi(unittest.TestCase):
         task = {
             "num_games": self.rundb.chunk_size,
             "stats": {"wins": 0, "draws": 0, "losses": 0, "crashes": 0},
-            "pending": True,
             "active": True,
         }
 
         run["tasks"].append(task)
-
-        for i, task in enumerate(run["tasks"]):
-            if i is not self.task_id:
-                run["tasks"][i]["pending"] = False
 
         self.rundb.buffer(run, True)
 
@@ -142,7 +137,6 @@ class TestApi(unittest.TestCase):
         run["tasks"][self.task_id] = {
             "num_games": self.rundb.chunk_size,
             "stats": {"wins": 0, "draws": 0, "losses": 0, "crashes": 0},
-            "pending": True,
             "active": False,
         }
         self.rundb.buffer(run, True)
@@ -155,7 +149,6 @@ class TestApi(unittest.TestCase):
         run = self.rundb.get_run(self.run_id)
         self.assertEqual(run["cores"], self.concurrency)
         task = run["tasks"][response["task_id"]]
-        self.assertTrue(task["pending"])
         self.assertTrue(task["active"])
 
     def test_update_task(self):
@@ -170,7 +163,6 @@ class TestApi(unittest.TestCase):
         run = self.rundb.get_run(self.run_id)
         run["tasks"][self.task_id] = {
             "num_games": self.rundb.chunk_size,
-            "pending": True,
             "active": True,
         }
         self.worker_info = {
@@ -266,7 +258,6 @@ class TestApi(unittest.TestCase):
         self.assertFalse(response["task_alive"])
         run = self.rundb.get_run(self.run_id)
         task = run["tasks"][self.task_id]
-        self.assertFalse(task["pending"])
         self.assertFalse(task["active"])
 
     def test_failed_task(self):
@@ -351,7 +342,6 @@ class TestApi(unittest.TestCase):
                 {"name": "param name", "a": 1, "c": 1, "theta": 1, "min": 0, "max": 100}
             ],
         }
-        run["tasks"][self.task_id]["pending"] = True
         run["tasks"][self.task_id]["active"] = True
         self.rundb.buffer(run, True)
         request = self.correct_password_request(
@@ -530,7 +520,7 @@ class TestRunFinished(unittest.TestCase):
         self.assertTrue(run["finished"])
         self.assertFalse(run["results_stale"])
         self.assertTrue(
-            all([not t["pending"] and not t["active"] for t in run["tasks"]])
+            all([not t["active"] for t in run["tasks"]])
         )
         self.assertTrue("Total: {}".format(num_games) in run["results_info"]["info"][1])
 


### PR DESCRIPTION
The pending flag is True when a task is not finished. It was always redundant since it can be recomputed from the number of games received on a task and the task size.

However, now that there is no task migration any longer, the pending flag has become even more redundant since, if a worker goes offline, the task it was working on will never receive any further updates, no matter what the pending flag says.

Another issue with the pending flag is that the word "pending" is also used in other contexts (e.g. a run may be pending). This creates confusion.