### PR TITLE
Upgrade bootstrap from 2.3.2 to 5.1.1

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -7,7 +7,27 @@
 }
 
 body {
+  font-size: 14px;
   transition: background 0.2s ease-in-out;
+}
+
+a {
+  color: #0088cc;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #0088cc;
+}
+
+h2, h3, h4 {
+  font-weight: bold;
+}
+
+legend {
+  padding-bottom: 5px;
+  border-bottom: 1px solid #e5e5e5;
+  margin-bottom: 20px;
 }
 
 .flash-message {
@@ -15,15 +35,45 @@ body {
 }
 
 .elo-results {
+  background: #f5f5f5;
   font-size: 12px;
   margin: 2px;
   padding: 1px;
   line-height: 13px;
+  padding: 3px;
 }
 
 .checkbox.inline {
   margin-left: 20px;
   margin-right: 0;
+}
+
+/** Left navigation */
+.nav-list {
+  margin-bottom: 0;
+}
+
+.nav-header {
+  color: #999999;
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  margin-bottom: 3px;
+  padding-left: 15px;
+}
+
+.nav li + .nav-header {
+  margin-top: 12px;
+}
+
+/* Links in the left navigation */
+.nav li a {
+  display: block;
+  padding: 3px 15px;
+}
+
+.nav li a:hover {
+  background: #eeeeee;
 }
 
 th {
@@ -40,6 +90,28 @@ th {
   text-align: left;
 }
 
+#change-color-theme {
+  margin-left: 15px;
+}
+
 #change-color-theme:hover {
   cursor: pointer;
+}
+
+/* Pagination links */
+.page-link {
+  color: #0088cc;
+}
+
+.pagination li.disabled .page-link {
+  color: rgb(153, 153, 153);
+}
+
+.pagination li.active .page-link {
+  color: rgb(153, 153, 153);
+  background: rgb(245, 245, 245);
+}
+
+.pagination li:not(.active) .page-link:hover {
+  background-color: #f5f5f5;
 }

--- a/server/fishtest/static/css/theme.dark.css
+++ b/server/fishtest/static/css/theme.dark.css
@@ -66,7 +66,16 @@ hr {
 }
 
 .table th, .table td {
+  color: #b1ada7;
   border-top: 1px solid #444;
+}
+
+.table th {
+  border-bottom-color: #444 !important;
+}
+
+tbody, td, tfoot, th, thead, tr {
+  border-color: #444;
 }
 
 /* Background colors for running tasks on test run pages */
@@ -91,6 +100,8 @@ input[type="month"]:focus, input[type="time"]:focus, input[type="week"]:focus,
 input[type="number"]:focus, input[type="email"]:focus, input[type="url"]:focus,
 input[type="search"]:focus, input[type="tel"]:focus, input[type="color"]:focus,
 .uneditable-input:focus {
+  color: #b1ada7;
+  background: #444;
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgb(106 216 241 / 60%);
 }
 
@@ -121,13 +132,25 @@ input[type="radio"]:focus, input[type="checkbox"]:focus {
 }
 
 /* Pagination links */
-.pagination ul>li>a, .pagination ul>li>span {
+.pagination li .page-link {
+  color: #3ba9e0;
   background-color: #111;
   border-color: #292929;
 }
 
-.pagination ul>li>a:hover, .pagination ul>li>a:focus, .pagination ul>.active>a, .pagination ul>.active>span {
-  background-color: #333;
+.pagination li.disabled .page-link {
+  color: #999;
+  background: transparent;
+}
+
+.pagination li.active .page-link {
+  color: #999;
+  background: #333;
+}
+
+.pagination li:not(.active) .page-link:hover {
+  background-color: #444;
+  color: white;
 }
 
 /* Override - test tasks table - purged tasks red background */

--- a/server/fishtest/static/html/SPRTcalculator.html
+++ b/server/fishtest/static/html/SPRTcalculator.html
@@ -3,10 +3,12 @@
   <head>
     <meta charset="utf-8">
     <title>Chess SPRT Calculator</title>
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"
-          integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu"
-          crossorigin="anonymous"
-          rel="stylesheet">
+
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
+          integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
+          crossorigin="anonymous">
+
     <script>
       if (document.cookie.match(/theme=dark/)) {
         const linkEl = document.createElement('link');
@@ -31,35 +33,37 @@
   <body>
     <div class=container>
       <h1 class=page-header>Chess SPRT Calculator</h1>
-      <form id=parameters class=form-inline>
-	<div class=form-group>
-	  <label for=elo-model>Elo model</label>
-	  <select id=elo-model class='form-control'>
-	    <option>Normalized</option>
-	    <option>Logistic</option>
-	  </select>
-	</div>
-        <div class=form-group>
+      <form id=parameters class="form-inline row">
+        <div class="col-auto form-group">
+          <label for="elo-model">Elo model</label>
+          <select id="elo-model" class='form-select'>
+            <option>Normalized</option>
+            <option>Logistic</option>
+          </select>
+        </div>
+        <div class="col-auto form-group">
           <label for=elo-0>Elo0</label>
           <input id=elo-0 class='form-control number'>
         </div>
-        <div class=form-group>
+        <div class="col-auto form-group">
           <label for=elo-1>Elo1</label>
           <input id=elo-1 class='form-control number'>
         </div>
-        <div class=form-group>
+        <div class="col-auto form-group">
           <label for=draw-ratio>Draw ratio</label>
           <input id=draw-ratio class='form-control number'>
         </div>
-        <div class=form-group>
+        <div class="col-auto form-group">
           <label for=rms-bias>RMS bias</label>
           <input id=rms-bias class='form-control number'>
         </div>
-        <div class=form-group style="width:3em;"></div>
-        <input class='btn btn-success' type=button value=Calculate onclick="draw_charts();">
+        <div class="col-auto form-group" style="position: relative">
+          <input class='btn btn-success' style="position: absolute; bottom: 0"
+                 type=button value=Calculate onclick="draw_charts();">
+        </div>
       </form>
       <hr>
-      <div id="mouse_screen">
+      <div id="mouse_screen" style="display: flex;">
         <div id="pass_prob_chart_div" class="chart-div"></div>
         <div id="expected_chart_div" class="chart-div"></div>
       </div>

--- a/server/fishtest/static/html/live_elo.html
+++ b/server/fishtest/static/html/live_elo.html
@@ -6,10 +6,12 @@
     <title>Elo estimates from SPRT tests</title>
     <link rel="stylesheet" type="text/css" href="/css/live_elo.css?2">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
-          integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z"
-          crossorigin="anonymous"
-          rel="stylesheet">
+
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
+          integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
+          crossorigin="anonymous">
+
     <script>
       if (document.cookie.match(/theme=dark/)) {
         const linkEl = document.createElement('link');

--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -58,7 +58,7 @@ $(() => {
         $("<link>")
           .attr("href", "/css/theme.dark.css")
           .attr("rel", "stylesheet")
-          .attr("integrity", "sha256-++XBVj1eZZyB4dsYkr5pz7CFUOqJiNoKs8l0OF7nV60=")
+          .attr("integrity", "sha256-289tThSsKTG6H2LsvaJuWzMPansls8Ac+Dojfrx4KDs=")
           .appendTo($("head"));
         theme = 'dark';
       } else {

--- a/server/fishtest/templates/actions.mak
+++ b/server/fishtest/templates/actions.mak
@@ -21,7 +21,7 @@
 <button type="submit" class="btn btn-success">Select</button>
 </form>
 
-<table class="table table-striped table-condensed">
+<table class="table table-striped table-sm">
   <thead>
     <tr>
       <th>Time</th>

--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -4,10 +4,11 @@
     <title>Stockfish Testing Framework</title>
     <meta name="csrf-token" content="${request.session.get_csrf_token()}" />
 
-    <link href="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css"
-          integrity="sha384-4FeI0trTH/PCsLWrGCD1mScoFu9Jf2NdknFdFoJhXZFwsvzZ3Bo5sAh7+zL8Xgnd"
-          crossorigin="anonymous"
-          rel="stylesheet">
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
+          integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
+          crossorigin="anonymous">
+
     <link href="/css/application.css?v=3" rel="stylesheet">
     % if request.cookies.get('theme') == 'dark':
         <link href="/css/theme.dark.css" rel="stylesheet">
@@ -16,8 +17,9 @@
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"
             integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
             crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"
-            integrity="sha384-vOWIrgFbxIPzY09VArRHMsxned7WiY6hzIPtAIIeTFuii9y3Cr6HE6fcHXy5CFhc"
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
             crossorigin="anonymous"></script>
 
     <script src="/js/jquery.cookie.js" defer></script>
@@ -28,8 +30,8 @@
 
   <body>
     <div class="clearfix"
-         style="width: 100px; float: left; padding: 12px 0;">
-      <ul class="nav nav-list">
+         style="width: 100px; float: left; padding: 16px 0;">
+      <ul class="nav nav-list flex-column">
 
         <li class="nav-header">Tests</li>
         <li><a href="/tests">Overview</a></li>
@@ -102,18 +104,20 @@
             % if request.session.peek_flash('error'):
                 <% flash = request.session.pop_flash('error') %>
                 % for message in flash:
-                    <div class="alert alert-error">
-                    <button type="button" class="close" data-dismiss="alert">&times;</button>
-                    ${message}
+                    <div class="alert alert-error alert-dismissible">
+                      ${message}
+                      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+                      </button>
                     </div>
                 % endfor
             % endif
             % if request.session.peek_flash():
                 <% flash = request.session.pop_flash() %>
                 % for message in flash:
-                    <div class="alert alert-success">
-                    <button type="button" class="close" data-dismiss="alert">&times;</button>
-                    ${message}
+                    <div class="alert alert-success alert-dismissible">
+                      ${message}
+                      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">
+                      </button>
                     </div>
                 % endfor
             % endif

--- a/server/fishtest/templates/elo_results.mak
+++ b/server/fishtest/templates/elo_results.mak
@@ -2,7 +2,7 @@
 
 <%
   def get_run_style(run):
-    ret = 'white-space:nowrap;'
+    ret = 'white-space:nowrap; border: 1px solid rgba(0,0,0,0.15);'
     style = run['results_info'].get('style','')
     if style != '':
       ret += 'background-color:' + style+';'
@@ -26,7 +26,7 @@
 </%def>
 
 % if 'sprt' in run['args'] and not 'Pending' in run['results_info']['info'][0]:
-    <a href="${'/html/live_elo.html?' + str(run['_id'])}" style="text-decoration:none">
+    <a href="${'/html/live_elo.html?' + str(run['_id'])}" style="color: inherit">
 % endif
 % if show_gauge:
     <div id="chart_div_${str(run['_id'])}" style="width:90px;float:left;"></div>
@@ -36,7 +36,7 @@
         <div style="margin-left:90px;">
     % endif
 % endif
-<pre style="${get_run_style(run)}" class="elo-results">
+<pre style="${get_run_style(run)}" class="rounded elo-results">
   ${list_info(run)}
 </pre>
 % if show_gauge:

--- a/server/fishtest/templates/login.mak
+++ b/server/fishtest/templates/login.mak
@@ -12,29 +12,30 @@
 <div>
   <form class="form-horizontal" action="" method="POST">
     <legend>Login</legend>
-    <div class="control-group">
-      <label class="control-label">Username</label>
-      <div class="controls">
-        <input name="username" type="text" />
+    <div class="form-group row mb-3">
+      <label class="col-form-label col-sm-2 text-end">Username</label>
+      <div class="col-sm-3">
+        <input name="username" type="text" class="form-control" />
       </div>
     </div>
 
-    <div class="control-group">
-      <label class="control-label">Password</label>
-      <div class="controls">
-        <input name="password" type="password" />
+    <div class="form-group row mb-3">
+      <label class="col-form-label col-sm-2 text-end">Password</label>
+      <div class="col-sm-3">
+        <input name="password" type="password" class="form-control" />
       </div>
     </div>
 
-    <div class="control-group">
-      <label class="control-label">Stay logged in</label>
-      <div class="controls">
-        <input name="stay_logged_in" type="checkbox" />
+    <div class="form-group row mb-3">
+      <label class="col-form-label col-sm-2 form-check-label text-end">Stay logged in</label>
+      <div class="col-sm-3">
+        <input name="stay_logged_in" type="checkbox" class="form-check-input" />
       </div>
     </div>
 
-    <div class="control-group">
-      <div class="controls">
+    <div class="form-group row">
+      <div class="col-sm-2"></div>
+      <div class="col-sm-4">
         <button type="submit" class="btn btn-primary">Login</button>
       </div>
     </div>

--- a/server/fishtest/templates/machines_table.mak
+++ b/server/fishtest/templates/machines_table.mak
@@ -1,4 +1,4 @@
-<table class="table table-striped table-condensed"
+<table class="table table-striped table-sm"
        style="max-width: 960px;">
   <thead>
     <tr>

--- a/server/fishtest/templates/nn_upload.mak
+++ b/server/fishtest/templates/nn_upload.mak
@@ -41,8 +41,8 @@
     padding-right: 30px;
   }
 
-  #upload-nn input, #upload-nn select {
-    margin: 0;
+  #upload-nn input {
+    margin: 15px 0;
   }
 
   .quarter-size {

--- a/server/fishtest/templates/nns.mak
+++ b/server/fishtest/templates/nns.mak
@@ -9,11 +9,11 @@ and achieved the status of <i>default net</i> during the development of Stockfis
 The recommended net for a given Stockfish executable can be found as the default value of the EvalFile UCI option.
 </p>
 
-<button id="non_default-button" class="btn">
-      ${'Hide non default nets' if non_default_shown else 'Show non default nets'}
+<button id="non_default-button" class="btn btn-sm btn-light border">
+  ${'Hide non default nets' if non_default_shown else 'Show non default nets'}
 </button>
 
-<table class="table table-striped table-condensed" style="max-width: 900px;">
+<table class="table table-striped table-sm" style="max-width: 900px;">
   <thead>
     <tr>
       <th>Time</th>

--- a/server/fishtest/templates/pending.mak
+++ b/server/fishtest/templates/pending.mak
@@ -1,7 +1,7 @@
 <%inherit file="base.mak"/>
 <h3>Pending Users</h3>
 
-<table class="table table-striped table-condensed">
+<table class="table table-striped table-sm">
   <thead>
     <tr>
       <th>Username</th>
@@ -22,7 +22,7 @@
 
 <h3>Idle Users</h3>
 
-<table class="table table-striped table-condensed">
+<table class="table table-striped table-sm">
   <thead>
     <tr>
       <th>Username</th>

--- a/server/fishtest/templates/run_table.mak
+++ b/server/fishtest/templates/run_table.mak
@@ -38,35 +38,35 @@
 
 <%def name="pagination()">
   % if pages and len(pages) > 3:
-      <h3>
-        <span class="pagination pagination-small">
-          <ul>
-            % for page in pages:
-                <li class="${page['state']}">
-                  % if page['state'] not in ['disabled', 'active']:
-                      <a href="${page['url']}">${page['idx']}</a>
-                  % else:
-                      <a>${page['idx']}</a>
-                  % endif
-                </li>
-            % endfor
-          </ul>
-        </span>
-      </h3>
+      <nav>
+        <ul class="pagination pagination-sm">
+        % for page in pages:
+            <li class="${page['state']}">
+              % if page['state'] not in ['disabled', 'active']:
+                  <a class="page-link" href="${page['url']}">${page['idx']}</a>
+              % else:
+                  <a class="page-link">${page['idx']}</a>
+              % endif
+            </li>
+        % endfor
+        </ul>
+      </nav>
   % endif
 </%def>
 
 ${pagination()}
 
-<table class="table table-striped table-condensed">
+<table class="table table-striped table-sm">
   <tbody>
     % for run in runs:
         <tr>
           % if show_delete:
               <td style="width: 1%;">
                 <div class="dropdown">
-                  <button type="submit" class="btn btn-danger btn-mini" data-toggle="dropdown">
-                    <i class="icon-trash icon-white"></i>
+                  <button type="submit" class="btn btn-danger btn-sm" data-bs-toggle="dropdown">
+                    <svg viewBox="0 0 8 8" style="width: 12px; height: 12px; fill: white; background: none;">
+                      <path d="M3 0c-.55 0-1 .45-1 1h-1c-.55 0-1 .45-1 1h7c0-.55-.45-1-1-1h-1c0-.55-.45-1-1-1h-1zm-2 3v4.813c0 .11.077.188.188.188h4.625c.11 0 .188-.077.188-.188v-4.813h-1v3.5c0 .28-.22.5-.5.5s-.5-.22-.5-.5v-3.5h-1v3.5c0 .28-.22.5-.5.5s-.5-.22-.5-.5v-3.5h-1z" data-id="trash"></path>
+                    </svg>
                   </button>
                   <div class="dropdown-menu" role="menu">
                     <form action="/tests/delete" method="POST" style="display: inline;">
@@ -80,15 +80,21 @@ ${pagination()}
               </td>
 
               <td style="width: 1%;">
-                % if run.get('approved', False):
-                    <button class="btn btn-success btn-mini">
-                      <i class="icon-thumbs-up"></i>
-                    </button>
-                % else:
-                    <button class="btn btn-warning btn-mini">
-                      <i class="icon-question-sign"></i>
-                    </button>
-                % endif
+                %if run.get('approved', False):
+                   <button class="btn btn-success btn-sm">
+                     ## thumbs up
+                     <svg viewBox="0 0 8 8" style="width: 12px; height: 12px; fill: white; background: none;">
+                       <path d="M4.438 0c-.19.021-.34.149-.438.344-.13.26-1.101 2.185-1.281 2.375-.19.18-.439.281-.719.281v4.001h3.5c.21 0 .389-.133.469-.313 0 0 1.031-2.908 1.031-3.188 0-.28-.22-.5-.5-.5h-1.5c-.28 0-.5-.25-.5-.5s.389-1.574.469-1.844c.08-.27-.053-.545-.313-.625l-.219-.031zm-4.438 3v4h1v-4h-1z" data-id="thumb-up"></path>
+                     </svg>
+                   </button>
+                %else:
+                   <button class="btn btn-warning btn-sm">
+                     ## question mark
+                     <svg viewBox="0 0 8 8" style="width: 12px; height: 12px; fill: white; background: none;">
+                       <path d="M4.469 0c-.854 0-1.48.256-1.875.656s-.54.901-.594 1.281l1 .125c.036-.26.125-.497.313-.688.188-.19.491-.375 1.156-.375.664 0 1.019.163 1.219.344.199.181.281.405.281.656 0 .833-.313 1.063-.813 1.5-.5.438-1.188 1.083-1.188 2.25v.25h1v-.25c0-.833.344-1.063.844-1.5.5-.438 1.156-1.083 1.156-2.25 0-.479-.168-1.02-.594-1.406-.426-.387-1.071-.594-1.906-.594zm-.5 7v1h1v-1h-1z" data-id="question-mark"></path>
+                     </svg>
+                   </button>
+                %endif
               </td>
           % endif
 

--- a/server/fishtest/templates/run_tables.mak
+++ b/server/fishtest/templates/run_tables.mak
@@ -2,13 +2,13 @@
     <% pending_approval_runs = [run for run in runs['pending'] if not run['approved']] %>
     <% paused_runs = [run for run in runs['pending'] if run['approved']] %>
 
-    <h3>
+    <h4>
       Pending approval - ${len(pending_approval_runs)} tests
-      <button id="pending-button" class="btn">
+      <button id="pending-button" class="btn btn-sm btn-light border">
         ${'Hide' if pending_shown else 'Show'}
       </button>
-    </h3>
-
+    </h4>
+  
     <div id="pending"
          style="${'' if pending_shown else 'display: none;'}">
       % if pending_approval_runs:
@@ -18,12 +18,12 @@
       %endif
     </div>
 
-    <h3>
+    <h4>
       Paused - ${len(paused_runs)} tests
-      <button id="paused-button" class="btn">
+      <button id="paused-button" class="btn btn-sm btn-light border">
         ${'Hide' if paused_shown else 'Show'}
       </button>
-    </h3>
+    </h4>
 
     <div id="paused"
          style="${'' if paused_shown else 'display: none;'}">
@@ -39,9 +39,9 @@
         <%include file="run_table.mak" args="runs=failed_runs, show_delete=True"/>
     % endif
 
-    <h3>Active - ${len(runs['active'])} tests</h3>
+    <h4>Active - ${len(runs['active'])} tests</h4>
     <%include file="run_table.mak" args="runs=runs['active']"/>
 % endif
 
-<h3>Finished - ${num_finished_runs} tests</h3>
+<h4>Finished - ${num_finished_runs} tests</h4>
 <%include file="run_table.mak" args="runs=finished_runs, pages=finished_runs_pages"/>

--- a/server/fishtest/templates/signup.mak
+++ b/server/fishtest/templates/signup.mak
@@ -14,42 +14,53 @@
     <input type="hidden" name="csrf_token"
            value="${request.session.get_csrf_token()}" />
     <legend>Create new user</legend>
-    <div class="control-group">
-      <label class="control-label">Username:</label>
-      <div class="controls">
+
+    <div class="form-group row mb-3">
+      <label class="col-form-label col-sm-2 text-end">Username</label>
+      <div class="col-sm-3">
         <input name="username" pattern="[A-Za-z0-9]{2,}" type="text"
-               title="Only letters and digits and at least 2 long" required="required"/>
+               title="Only letters and digits and at least 2 long" required="required"
+               class="form-control" />
       </div>
     </div>
-    <div class="control-group">
-      <label class="control-label">Password:</label>
-      <div class="controls">
+
+    <div class="form-group row mb-3">
+      <label class="col-form-label col-sm-2 text-end">Password</label>
+      <div class="col-sm-3">
         <input name="password" type="password" pattern=".{8,}"
-               title="Eight or more characters: a password too simple or trivial to guess will be rejected" required="required"/>
+               title="Eight or more characters: a password too simple or trivial to guess will be rejected"
+               required="required"
+               class="form-control" />
       </div>
     </div>
-    <div class="control-group">
-      <label class="control-label">Verify password:</label>
-      <div class="controls">
-        <input name="password2" type="password" required="required"/>
+
+    <div class="form-group row mb-3">
+      <label class="col-form-label col-sm-2 text-end">Verify password</label>
+      <div class="col-sm-3">
+        <input name="password2" type="password" required="required" class="form-control" />
       </div>
     </div>
-    <div class="control-group">
-      <label class="control-label">E-mail:</label>
-      <div class="controls">
-        <input name="email" type="email" required="required"/>
+
+    <div class="form-group row mb-3">
+      <label class="col-form-label col-sm-2 text-end">E-mail</label>
+      <div class="col-sm-3">
+        <input name="email" type="email" required="required" class="form-control" />
       </div>
     </div>
-    <div class="control-group">
-      <div class="controls">
+
+    <div class="form-group mb-3">
+      <div class="col-sm-4 offset-sm-2">
         <div class="g-recaptcha"
              data-sitekey="6LePs8YUAAAAABMmqHZVyVjxat95Z1c_uHrkugZM"></div>
       </div>
     </div>
-    <div class="control-group">
-      <div class="controls">
+
+    <div class="form-group row">
+      <div class="col-sm-2"></div>
+      <div class="col-sm-4">
         <button type="submit" class="btn btn-primary">Create User</button>
       </div>
     </div>
+
   </form>
 </div>

--- a/server/fishtest/templates/tests.mak
+++ b/server/fishtest/templates/tests.mak
@@ -5,7 +5,7 @@
 <h2>Stockfish Testing Queue</h2>
 
 % if page_idx == 0:
-    <h3>
+    <h4>
       <span>
         ${len(machines)} machines ${cores}
         cores ${f"{nps / (cores * 1000000 + 1):.2f}"} MNps
@@ -13,10 +13,10 @@
         ${games_per_minute} games/minute
         ${pending_hours} hours remaining
       </span>
-      <button id="machines-button" class="btn">
+      <button id="machines-button" class="btn btn-sm btn-light border">
         ${'Hide' if machines_shown else 'Show'}
       </button>
-    </h3>
+    </h4>
 
     <div id="machines"
           style="${'' if machines_shown else 'display: none;'}">

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -41,7 +41,7 @@ else:
   }
 
   .field-label.leftmost {
-    width: 75px;
+    width: 100px;
     flex-shrink: 0;
   }
 
@@ -76,7 +76,7 @@ else:
   }
 
   .choose-test-type .btn {
-    width: 75px;
+    width: 98px;
   }
 
   #create-new-test label:hover {
@@ -108,25 +108,25 @@ else:
   <section class="test-settings" style="margin-bottom: 35px">
     <div class="flex-row">
       <label class="field-label leftmost">Test type</label>
-      <div class="btn-group choose-test-type">
-        <div class="btn" id="fast_test"
+      <div class="btn-group btn-group-sm text-nowrap choose-test-type">
+        <div class="btn border" id="fast_test"
              data-options='{"tc": "10+0.1", "new_tc": "10+0.1", "threads": 1, "options": "Hash=16 Use NNUE=true", "bounds": "standard STC"}'>
           short (STC)
         </div>
-        <div class="btn" id="slow_test"
+        <div class="btn border" id="slow_test"
              data-options='{"tc": "60+0.6", "new_tc": "60+0.6", "threads": 1, "options": "Hash=64 Use NNUE=true", "bounds": "standard LTC"}'>
           long (LTC)
         </div>
-        <div class="btn" id="fast_smp_test"
+        <div class="btn border" id="fast_smp_test"
              data-options='{"tc": "5+0.05", "new_tc": "5+0.05", "threads": 8, "options": "Hash=64 Use NNUE=true", "bounds": "standard STC"}'>
           SMP (STC)
         </div>
-        <div class="btn" id="slow_smp_test"
+        <div class="btn border" id="slow_smp_test"
              data-options='{"tc": "20+0.2", "new_tc": "20+0.2", "threads": 8, "options": "Hash=256 Use NNUE=true", "bounds": "standard LTC"}'>
           SMP (LTC)
         </div>
       </div>
-      <button type="submit" class="btn btn-primary rightmost" id="submit-test"
+      <button type="submit" class="btn btn-primary btn-sm rightmost" id="submit-test"
               style="width: 180px">
         Submit test
       </button>
@@ -179,10 +179,10 @@ else:
   <section id="stop-rule" style="min-height: 130px">
     <div class="flex-row">
       <label class="field-label leftmost">Stop rule</label>
-      <div class="btn-group">
-        <div class="btn btn-info" data-stop-rule="sprt" style="width: 94px">SPRT</div>
-        <div class="btn" data-stop-rule="numgames" style="width: 100px">Num games</div>
-        <div class="btn" data-stop-rule="spsa" style="width: 94px">SPSA</div>
+      <div class="btn-group btn-group-sm">
+        <div class="btn btn-info border" data-stop-rule="sprt" style="width: 94px">SPRT</div>
+        <div class="btn border" data-stop-rule="numgames" style="width: 100px">Num games</div>
+        <div class="btn border" data-stop-rule="spsa" style="width: 94px">SPSA</div>
       </div>
       <input type="hidden" name="stop_rule" id="stop_rule_field" value="sprt" />
 

--- a/server/fishtest/templates/tests_stats.mak
+++ b/server/fishtest/templates/tests_stats.mak
@@ -213,10 +213,10 @@
 <html lang="en-us">
   <head>
     <title>Raw statistics for ${run['_id']}</title>
-    <link href="https://stackpath.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css"
-          integrity="sha384-4FeI0trTH/PCsLWrGCD1mScoFu9Jf2NdknFdFoJhXZFwsvzZ3Bo5sAh7+zL8Xgnd"
-          crossorigin="anonymous"
-          rel="stylesheet">
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
+          integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
+          crossorigin="anonymous">
     <style>
       td {
         width: 20%;
@@ -228,14 +228,15 @@
   </head>
   <body>
     % if not has_spsa:
-        <div class="row-fluid">
-          <div class="span2">
-          </div>
-          <div class="span8">
-            <H3> Raw statistics for ${run['_id']}</H3>
-            <em> Unless otherwise specified, all Elo quantities below are logistic. </em>
+        <div class="row justify-content-md-center">
+          <div class="col-8">
+            <header style="margin: 12px 0">
+              <h4>Raw statistics for ${run['_id']}</h4>
+              <em>Unless otherwise specified, all Elo quantities below are logistic.</em>
+            </header>
+
             <H4> Context </H4>
-            <table class="table table-condensed">
+            <table class="table table-sm">
               <tr><td>Base TC</td><td>${run['args'].get('tc','?')}</td></tr>
               <tr><td>Test TC</td><td>${run['args'].get('new_tc',run['args'].get('tc','?'))}</td></tr>
               <tr><td>Book</td><td>${run['args'].get('book','?')}</td></tr>
@@ -245,7 +246,7 @@
             </table>
             % if has_sprt:
                 <H4> SPRT parameters</H4>
-                <table class="table table-condensed">
+                <table class="table table-sm">
                   <tr><td>Alpha</td><td>${alpha}</td></tr>
                   <tr><td>Beta</td><td>${beta}</td></tr>
                   <tr><td>Elo0 (${elo_model})</td><td>${elo0}</td></tr>
@@ -254,13 +255,13 @@
                 </table>
             % endif  ## has_sprt
             <H4>Draws</H4>
-            <table class="table table-condensed" style="margin-top:1em;">
+            <table class="table table-sm" style="margin-top:1em;">
               <tr><td>Draw ratio</td><td>${f"{draw_ratio:.5f}"}</td></tr>
               <tr><td>DrawElo (BayesElo)</td><td>${f"{drawelo:.2f}"}</td></tr>
             </table>
             % if has_sprt:
                 <H4> SPRT bounds </H4>
-                <table class="table table-condensed" style="margin-top:1em;margin-bottom:0.5em;">
+                <table class="table table-sm" style="margin-top:1em;margin-bottom:0.5em;">
                   <tr>
                   <td></td></td><td>Logistic</td><td>Normalized</td><td>BayesElo</td><td>Score</td>
                   </tr>
@@ -281,7 +282,7 @@
             % if has_pentanomial:
                 <H4> Pentanomial statistics</H4>
                 <H5> Basic statistics </H5>
-                <table class="table table-condensed">
+                <table class="table table-sm">
                   <tr><td>Elo</td><td>${f"{elo5:.4f} [{elo5_l:.4f}, {elo5_u:.4f}]"}</td></tr>
                   <tr><td>LOS(1-p)</td><td>${f"{LOS5:.5f}"}</td></tr>
                   % if has_sprt:
@@ -290,7 +291,7 @@
                 </table>
                 % if has_sprt:
                     <H5> Generalized Log Likelihood Ratio </H5>
-                    <table class="table table-condensed" style="margin-top:1em;margin-bottom:0.5em;">
+                    <table class="table table-sm" style="margin-top:1em;margin-bottom:0.5em;">
                       <tr><td>Logistic (exact)</td><td>${f"{LLR5_exact:.5f}"}</td></tr>
                       <tr><td>Logistic (alt)</td><td>${f"{LLR5_alt:.5f}"}</td></tr>
                       <tr><td>Logistic (alt2)</td><td>${f"{LLR5_alt2:.5f}"}</td></tr>
@@ -304,7 +305,7 @@
                     </em>
                 % endif ## has_sprt
                 <H5> Auxilliary statistics </H5>
-                <table class="table table-condensed">
+                <table class="table table-sm">
                   <tr><td>Games</td><td>${int(games5)}</td></tr>
                   <tr><td>Results [0-2]</td><td>${results5}</td></tr>
                   <tr><td>Distribution</td><td>${pdf5_s}</td></tr>
@@ -343,7 +344,7 @@
                 </p>
             % endif  ## has_pentanomial
             <H5> Basic statistics</H5>
-            <table class="table table-condensed">
+            <table class="table table-sm">
               <tr><td>Elo</td><td>${f"{elo3:.4f} [{elo3_l:.4f}, {elo3_u:.4f}]"}</td></tr>
               <tr><td>LOS(1-p)</td><td>${f"{LOS3:.5f}"}</td></tr>
               % if has_sprt:
@@ -352,7 +353,7 @@
             </table>
             % if has_sprt:
                 <H5>Generalized Log Likelihood Ratio</H5>
-                <table class="table table-condensed" style="margin-top:1em;margin-bottom:0.5em;">
+                <table class="table table-sm" style="margin-top:1em;margin-bottom:0.5em;">
                   <tr><td>Logistic (exact)</td><td>${f"{LLR3_exact:.5f}"}</td></tr>
                   <tr><td>Logistic (alt)</td><td>${f"{LLR3_alt:.5f}"}</td></tr>
                   <tr><td>Logistic (alt2)</td><td>${f"{LLR3_alt2:.5f}"}</td></tr>
@@ -366,7 +367,7 @@
                 </em>
             % endif  ## has_sprt
             <H5>Auxilliary statistics</H5>
-            <table class="table table-condensed">
+            <table class="table table-sm">
               <tr><td>Games</td><td>${int(games3)}</td></tr>
               <tr><td>Results [losses, draws, wins]</td><td>${results3}</td></tr>
               <tr><td>Distribution {loss ratio, draw ratio, win ratio}</td><td>${pdf3_s}</td></tr>
@@ -392,15 +393,13 @@
             </table>
             % if has_pentanomial:
                 <H4>Comparison</H4>
-                <table class="table table-condensed">
+                <table class="table table-sm">
                   <tr><td>Variance ratio (pentanomial/trinomial)</td><td>${f"{ratio:.5f}"}</td></tr>
                   <tr><td>Variance difference (trinomial-pentanomial)</td><td>${f"{var_diff:.5f}"}</td></tr>
                   <tr><td>RMS bias</td><td>${f"{RMS_bias:.5f}"}</td></tr>
                   <tr><td>RMS bias (Elo)</td><td>${f"{RMS_bias_elo:.3f}"}</td></tr>
                 </table>
             % endif  ## has_pentanomial
-          </div>
-          <div class="span2">
           </div>
         </div>
     % else:  ## not has_spsa / has_spsa

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -21,19 +21,18 @@ from fishtest.util import worker_name
 </h3>
 
 <div class="row-fluid">
-  <div style="display:inline-block;">
+  <div style="display: inline-block;">
     <%include file="elo_results.mak" args="run=run" />
   </div>
 </div>
 
-<div class="row-fluid">
-
-  <div class="span8" style="min-width: 540px">
+<div class="row row-fluid">
+  <div class="col-8" style="min-width: 540px">
     <h4>Details</h4>
 
     <%! import markupsafe %>
 
-    <table class="table table-condensed">
+    <table class="table table-sm">
       % for arg in run_args:
           % if len(arg[2]) == 0:
               <tr>
@@ -95,7 +94,7 @@ from fishtest.util import worker_name
     </table>
   </div>
 
-  <div class="span4">
+  <div class="col-4">
     <h4>Actions</h4>
     % if not run['finished']:
         <form action="/tests/stop" method="POST" style="display: inline;">
@@ -104,6 +103,7 @@ from fishtest.util import worker_name
             Stop
           </button>
         </form>
+
         % if not run.get('approved', False):
             <span>
               <form action="/tests/approve" method="POST" style="display: inline;">
@@ -124,7 +124,7 @@ from fishtest.util import worker_name
         </form>
     % endif
     <a href="/tests/run?id=${run['_id']}">
-      <button class="btn">Reschedule</button>
+      <button class="btn btn-light border">Reschedule</button>
     </a>
 
     <br>
@@ -149,19 +149,28 @@ from fishtest.util import worker_name
 
     <form class="form" action="/tests/modify" method="POST">
       <label class="control-label">Number of games:</label>
-      <input type="text" name="num-games" value="${run['args']['num_games']}">
-
+      <div class="input-group mb-3" style="width: 220px">
+        <input type="text" name="num-games" value="${run['args']['num_games']}"
+               class="form-control">
+      </div>
+  
       <label class="control-label">Adjust priority (higher is more urgent):</label>
-      <input type="text" name="priority" value="${run['args']['priority']}">
+      <div class="input-group mb-3" style="width: 220px">
+        <input type="text" name="priority" value="${run['args']['priority']}"
+               class="form-control">
+      </div>
 
       <label class="control-label">Adjust throughput (%):</label>
-      <input type="text" name="throughput" value="${run['args'].get('throughput', 1000)}">
-
+      <div class="input-group mb-3" style="width: 220px">
+        <input type="text" name="throughput" value="${run['args'].get('throughput', 1000)}"
+               class="form-control">
+      </div>
+  
       <div class="control-group">
         <label class="checkbox">
-          Auto-purge
           <input type="checkbox" name="auto_purge"
                  ${'checked' if run['args'].get('auto_purge') else ''} />
+          Auto-purge
         </label>
       </div>
 
@@ -174,7 +183,7 @@ from fishtest.util import worker_name
         <hr>
 
         <h4>Stats</h4>
-        <table class="table table-condensed">
+        <table class="table table-sm">
           <tr><td>chi^2</td><td>${f"{chi2['chi2']:.2f}"}</td></tr>
           <tr><td>dof</td><td>${chi2['dof']}</td></tr>
           <tr><td>p-value</td><td>${f"{chi2['p'] * 100:.2f}"}%</td></tr>
@@ -184,7 +193,7 @@ from fishtest.util import worker_name
     <hr>
 
     <h4>Time</h4>
-    <table class="table table-condensed">
+    <table class="table table-sm">
       <tr><td>start time</td><td>${run['start_time'].strftime("%Y-%m-%d %H:%M:%S")}</td></tr>
       <tr><td>last updated</td><td>${run['last_updated'].strftime("%Y-%m-%d %H:%M:%S")}</td></tr>
     </table>
@@ -223,7 +232,7 @@ from fishtest.util import worker_name
     Diff
     <span id="diff-num-comments" style="display: none"></span>
     <a href="${h.diff_url(run)}" class="btn btn-link" target="_blank" rel="noopener">view on Github</a>
-    <button id="diff-toggle" class="btn">Show</button>
+    <button id="diff-toggle" class="btn btn-sm btn-light border">Show</button>
     <a href="javascript:" id="copy-diff" class="btn btn-link" style="margin-left: 10px; display: none">
       <img src="/img/clipboard.png" width="20" height="20"/> Copy apply-diff command
     </a>
@@ -233,7 +242,7 @@ from fishtest.util import worker_name
 </section>
 
 <h3>Tasks ${totals}</h3>
-<table class='table table-striped table-condensed'>
+<table class='table table-striped table-sm'>
   <thead>
     <tr>
       <th>Idx</th>

--- a/server/fishtest/templates/users.mak
+++ b/server/fishtest/templates/users.mak
@@ -1,27 +1,54 @@
 <%inherit file="base.mak"/>
 <h4> </h4>
-<ul class="inline">
-  <li><dl class="dl-horizontal">
-    <dt>Testers</dt>
-    <dd>${sum(u['last_updated'] != 'Never' for u in users)}</dd>
-    <dt>Developers</dt>
-    <dd>${sum(u['tests'] > 0 for u in users)}</dd>
-  </dl></li>
-  <li><dl class="dl-horizontal">
-    <dt>Active testers</dt>
-    <dd>${sum(u['games_per_hour'] > 0 for u in users)}</dd>
-    <dt>Tests submitted</dt>
-    <dd>${sum(u['tests'] for u in users)}</dd>
-  </li></dl>
-  <li><dl class="dl-horizontal">
-    <dt>Games played</dt>
-    <dd>${sum(u['games'] for u in users)}</dd>
-    <dt>CPU time</dt>
-    <dd>${f"{sum(u['cpu_hours'] for u in users)/(24*365):.2f} years"}</dd>
-  </li></dl>
-</ul>
 
-<table class="table table-striped table-condensed">
+<div class="row" style="margin: 2em 0">
+  <div class="col-sm">
+    <div class="row">
+      <div class="col text-end"><b>Testers</b></div>
+      <div class="col text-start">
+        ${sum(u['last_updated'] != 'Never' for u in users)}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col text-end"><b>Developers</b></div>
+      <div class="col text-start">
+        ${sum(u['tests'] > 0 for u in users)}
+      </div>
+    </div>
+  </div>
+
+  <div class="col-sm">
+    <div class="row">
+      <div class="col text-end"><b>Active testers</b></div>
+      <div class="col text-start">
+        ${sum(u['games_per_hour'] > 0 for u in users)}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col text-end"><b>Tests submitted</b></div>
+      <div class="col text-start">
+        ${sum(u['tests'] for u in users)}
+      </div>
+    </div>
+  </div>
+
+  <div class="col-sm">
+    <div class="row">
+      <div class="col text-end"><b>Games played</b></div>
+      <div class="col text-start">
+        ${sum(u['games'] for u in users)}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col text-end"><b>CPU time</b></div>
+      <div class="col text-start">
+        ${f"{sum(u['cpu_hours'] for u in users)/(24*365):.2f} years"}
+      </div>
+    </div>
+  </div>
+</div>
+
+<table class="table table-striped table-sm">
   <thead>
     <tr>
       <th>Username</th>


### PR DESCRIPTION
Makes the site feel more modern since bootstrap 2.3.2 is 8+ years old (Jul 2013) and 5.1.1 was released a few weeks ago. Most of the site should still look similar.

Bootstrap 5.1 docs:
https://getbootstrap.com/docs/5.1

There will likely be issues since I didn't exhaustively check every page and don't have much test data to do so.

issues found by ppigazzini:
- [x] switch from light to dark theme is broken: clicking on the moon icon seems to switch only the icon (moon->sun->moon...)
- [x] gauge test box in light theme: lacks color (red, yellow) in homepage and in test page
- [x] test page (both themes): missing button for "Show/Hide" diff code snippet
- [x] NN stat page (both themes): missing button for "Show/Hide non default net"
- [x] test raw stats page: still to bootstrap 2.3.2
- [x] Chess SPRT Calculator page): still to bootstrap 3.4.2