### PR TITLE
[Wip] More sane residual(s)

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -1045,7 +1045,10 @@ class RunDb:
         if "bad_tasks" not in run:
             run["bad_tasks"] = []
         for task in run["tasks"]:
-            if unique_key_(task["worker_info"]) in chi2["bad_users"]:
+            if (
+                "worker_info" in task
+                and unique_key_(task["worker_info"]) in chi2["bad_users"]
+            ):
                 purged = True
                 task["bad"] = True
                 run["bad_tasks"].append(task)

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -311,12 +311,12 @@ from fishtest.util import worker_name
 
           % if 'spsa' not in run['args']:
               % if 'residual' in task and task['residual']['res_draw']!=float("inf"):
-                  <td style="background-color:${task['residual_color']['res_draw']}">${f"{task['residual']['res_draw']:.3f}"}</td>
+                  <td data-diff=${abs(task['residual']['res_draw'])} style="background-color:${task['residual_color']['res_draw']}">${f"{task['residual']['res_draw']:.3f}"}</td>
               % else:
                   <td>-</td>
               % endif
               % if 'residual' in task and task['residual']['res_elo']!=float("inf"):
-                  <td style="background-color:${task['residual_color']['res_elo']}">${f"{task['residual']['res_elo']:.3f}"}</td>
+                  <td data-diff=${abs(task['residual']['res_elo'])} style="background-color:${task['residual_color']['res_elo']}">${f"{task['residual']['res_elo']:.3f}"}</td>
               % else:
                   <td>-</td>
               % endif

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -251,9 +251,10 @@ from fishtest.util import worker_name
       <th>Crashes</th>
       <th>Time</th>
 
-      % if 'spsa' not in run['args']:
-          <th>Residual</th>
-      % endif
+      % if 'spsa' not in run['args']: 
+          <th>Residual (draws)</th>
+          <th>Residual (Elo)</th>
+     % endif
     </tr>
   </thead>
   <tbody>
@@ -309,8 +310,13 @@ from fishtest.util import worker_name
           <td>${stats.get('time_losses', '-')}</td>
 
           % if 'spsa' not in run['args']:
-              % if 'residual' in task and task['residual']!=float("inf"):
-                  <td style="background-color:${task['residual_color']}">${f"{task['residual']:.3f}"}</td>
+              % if 'residual' in task and task['residual']['res_draw']!=float("inf"):
+                  <td style="background-color:${task['residual_color']['res_draw']}">${f"{task['residual']['res_draw']:.3f}"}</td>
+              % else:
+                  <td>-</td>
+              % endif
+              % if 'residual' in task and task['residual']['res_elo']!=float("inf"):
+                  <td style="background-color:${task['residual_color']['res_elo']}">${f"{task['residual']['res_elo']:.3f}"}</td>
               % else:
                   <td>-</td>
               % endif

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -155,9 +155,10 @@ def calculate_residuals(run):
                     task["residual_color"][res] = "#FF6A6A"
 
             if chi2["p"] < 0.05 or abs(task["residual"]["res_elo"]) > 3.0:
-                if (
-                    len(worst_user) == 0
-                    or abs(task["residual"]["res_elo"]) > abs(worst_user["residual"]["res_elo"])
+                if len(worst_user) == 0 or (
+                    abs(task["residual"]["res_elo"])
+                    > abs(worst_user["residual"]["res_elo"])
+                    and task["residual"]["res_elo"] != float("inf")
                 ):
                     worst_user["unique_key"] = unique_key(task["worker_info"])
                     worst_user["residual"] = task["residual"]

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -154,10 +154,10 @@ def calculate_residuals(run):
                 else:
                     task["residual_color"][res] = "#FF6A6A"
 
-            if chi2["p"] < 0.001 or task["residual"]["res_elo"] > 7.0:
+            if chi2["p"] < 0.001 or abs(task["residual"]["res_elo"]) > 7.0:
                 if (
                     len(worst_user) == 0
-                    or task["residual"]["res_elo"] > worst_user["residual"]["res_elo"]
+                    or abs(task["residual"]["res_elo"]) > abs(worst_user["residual"]["res_elo"])
                 ):
                     worst_user["unique_key"] = unique_key(task["worker_info"])
                     worst_user["residual"] = task["residual"]

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -121,6 +121,26 @@ def get_chi2(tasks, bad_users):
 
 
 def calculate_residuals(run):
+    # This function does multiple things:
+    # (1) It calculates residuals and puts them in
+    #     the list run["tasks"]. These are displayed on
+    #     the main test page.
+    # (2) It computes at most one "bad_user" (=bad_task), i.e.
+    #     subject to some other restrictions, the user
+    #     with the worst residual.
+    # (3) It returns chi2 and residuals recomputed _after
+    #     excluding bad_user_. So the returned residuals
+    #     do not have to agree with those already in run["tasks"].
+    #     OTOH: the returned "cleaned" chi2 value is the one displayed
+    #     on the main test page.
+    #
+    # Note: when a run is purged (in rundb.py:purge_run()),
+    # the bad_users are moved to another list run["bad_tasks"].
+    #
+    # Maybe it would be better if identifying bad_users and recomputing
+    # would be moved to purge_run() instead of including it in this
+    # function.
+
     bad_users = set()
     chi2 = get_chi2(run["tasks"], bad_users)
     residuals = chi2["residual"]
@@ -155,10 +175,10 @@ def calculate_residuals(run):
                     task["residual_color"][res] = "#FF6A6A"
 
             if chi2["p"] < 0.05 or abs(task["residual"]["res_draw"]) > 3.0:
-                if len(worst_user) == 0 or (
-                    abs(task["residual"]["res_draw"])
+                if task["residual"]["res_draw"] != float("inf") and (
+                    len(worst_user) == 0
+                    or abs(task["residual"]["res_draw"])
                     > abs(worst_user["residual"]["res_draw"])
-                    and task["residual"]["res_draw"] != float("inf")
                 ):
                     worst_user["unique_key"] = unique_key(task["worker_info"])
                     worst_user["residual"] = task["residual"]

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -174,11 +174,13 @@ def calculate_residuals(run):
                 else:
                     task["residual_color"][res] = "#FF6A6A"
 
-            if chi2["p"] < 0.05 or abs(task["residual"]["res_draw"]) > 3.0:
-                if task["residual"]["res_draw"] != float("inf") and (
+            def abs_res(res):
+                return max(abs(res["res_draw"]), abs(res["res_elo"]))
+
+            if chi2["p"] < 0.05 or abs_res(task["residual"]) > 3.0:
+                if abs_res(task["residual"]) != float("inf") and (
                     len(worst_user) == 0
-                    or abs(task["residual"]["res_draw"])
-                    > abs(worst_user["residual"]["res_draw"])
+                    or abs_res(task["residual"]) > abs_res(worst_user["residual"])
                 ):
                     worst_user["unique_key"] = unique_key(task["worker_info"])
                     worst_user["residual"] = task["residual"]

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -111,8 +111,8 @@ def get_chi2(tasks, bad_users):
     # Finally we also compute for each qualifying worker two residuals
     # indicating how badly it deviates from the norm.
 
-    res_draw = fishtest.stats.stat_util.residuals(numpy.array([0, 1, 0]), observed)
-    res_elo = fishtest.stats.stat_util.residuals(numpy.array([-1, 0, 1]), observed)
+    res_draw = fishtest.stats.stat_util.residuals(numpy.array([0, 0, 1]), observed)
+    res_elo = fishtest.stats.stat_util.residuals(numpy.array([1, -1, 0]), observed)
 
     for idx in range(len(keys)):
         users[keys[idx]] = {"res_draw": res_draw[idx], "res_elo": res_elo[idx]}

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -154,11 +154,11 @@ def calculate_residuals(run):
                 else:
                     task["residual_color"][res] = "#FF6A6A"
 
-            if chi2["p"] < 0.05 or abs(task["residual"]["res_elo"]) > 3.0:
+            if chi2["p"] < 0.05 or abs(task["residual"]["res_draw"]) > 3.0:
                 if len(worst_user) == 0 or (
-                    abs(task["residual"]["res_elo"])
-                    > abs(worst_user["residual"]["res_elo"])
-                    and task["residual"]["res_elo"] != float("inf")
+                    abs(task["residual"]["res_draw"])
+                    > abs(worst_user["residual"]["res_draw"])
+                    and task["residual"]["res_draw"] != float("inf")
                 ):
                     worst_user["unique_key"] = unique_key(task["worker_info"])
                     worst_user["residual"] = task["residual"]

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -154,7 +154,7 @@ def calculate_residuals(run):
                 else:
                     task["residual_color"][res] = "#FF6A6A"
 
-            if chi2["p"] < 0.001 or abs(task["residual"]["res_elo"]) > 7.0:
+            if chi2["p"] < 0.05 or abs(task["residual"]["res_elo"]) > 3.0:
                 if (
                     len(worst_user) == 0
                     or abs(task["residual"]["res_elo"]) > abs(worst_user["residual"]["res_elo"])


### PR DESCRIPTION
We compute for each worker two residuals. One sensitive to the draw ratio and one sensitive to Elo. Both are standard normal under the null hypothesis that all workers are equal.

I suspect that the many  cores servers are more noisy which may lead to a lower draw ratio. This should be picked up by the first residual. However a lower draw ratio does not necessarily have to distort the Elo contribution. Distortions which affect Elo are indicated in the second residual.