### PR TITLE
Purge a test only if not older than 30 days

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -1036,6 +1036,9 @@ class RunDb:
         return True
 
     def purge_run(self, run):
+        now = datetime.utcnow()
+        if "start_time" not in run or (now - run["start_time"]).days > 30:
+            return False
         # Remove bad tasks
         purged = False
         chi2 = calculate_residuals(run)


### PR DESCRIPTION
After the purge a test is automatically queued to play the purged games.
An old test could lack some dictionary keys making unsafe the queueing.

Thanks to @vdbergh for reporting and debugging the problem.