### PR TITLE
Fix toggling individual spsa parameters dropdown

### DIFF
--- a/server/fishtest/static/js/spsa.js
+++ b/server/fishtest/static/js/spsa.js
@@ -161,7 +161,7 @@ $(document).ready(function(){
       }
 
       for (j = 0; j < spsa_params.length; j++) { 
-        $("#dropdown_individual").append("<li><a param_id=\"" + (j+1) + "\" >" + spsa_params[j].name + "</a></li>");
+        $("#dropdown_individual").append("<li><a class=\"dropdown-item\" href=\"javascript:\" param_id=\"" + (j+1) + "\" >" + spsa_params[j].name + "</a></li>");
       }
 
       $("#dropdown_individual").find('a').on('click', function() {

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -216,7 +216,7 @@ from fishtest.util import worker_name
       </div>
 
       <div class="btn-group">
-        <button id="btn_view_individual" type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+        <button id="btn_view_individual" type="button" class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown">
           View Individual Parameter<span class="caret"></span>
         </button>
         <ul class="dropdown-menu" role="menu" id="dropdown_individual"></ul>


### PR DESCRIPTION
The problem was newer bootstrap uses a new `data-bs-toggle` attribute to mark a button as a dropdown toggle.

Fixes https://github.com/glinscott/fishtest/pull/1044#issuecomment-927500322