### PR TITLE
Enable using dynamic cachebusters for static files

### DIFF
--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -9,9 +9,9 @@
           integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
           crossorigin="anonymous">
 
-    <link href="/css/application.css?v=3" rel="stylesheet">
+    <link href="/css/application.css?v=${cache_busters['css/application.css']}" rel="stylesheet">
     % if request.cookies.get('theme') == 'dark':
-        <link href="/css/theme.dark.css" rel="stylesheet">
+        <link href="/css/theme.dark.css?v=${cache_busters['css/theme.dark.css']}" rel="stylesheet">
     % endif
 
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"
@@ -23,7 +23,7 @@
             crossorigin="anonymous"></script>
 
     <script src="/js/jquery.cookie.js" defer></script>
-    <script src="/js/application.js?v=6" defer></script>
+    <script src="/js/application.js?v=${cache_busters['js/application.js']}" defer></script>
 
     <%block name="head"/>
   </head>


### PR DESCRIPTION
This enables auto-updating cache buster query params when static files change. The goal is to:
- not require users to manually hard refresh the page when css/js files change
- not require devs to manually update cache buster query params when css/js files change

This implementation:
- calculates the md5sum of the listed static files when the server starts
- uses the md5sum of the static file as a query param when serving the file

Prompted by https://github.com/glinscott/fishtest/pull/1044#issuecomment-927375281