### PR TITLE
Automatically set dark.theme.css sha256 during server init

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -51,16 +51,17 @@ $(() => {
 
     // Click the sun/moon icons to change the color theme of the site
     // SRI hash for "fishtest/server/fishtest/static/css/theme.dark.css":
-    // sha256sum theme.dark.css | head -c 96 | xxd -r -p | base64
+    // openssl dgst -sha256 -binary theme.dark.css | openssl base64 -A
     let theme = $.cookie('theme') || 'light';
     $("#change-color-theme").click(function() {
       if (theme === 'light') {
+        const darkThemeSha256 = $("meta[name='dark-theme-sha256']").attr("content");
         $("#sun").show();
         $("#moon").hide();
         $("<link>")
-          .attr("href", "/css/theme.dark.css")
+          .attr("href", "/css/theme.dark.css?v=" + darkThemeSha256)
           .attr("rel", "stylesheet")
-          .attr("integrity", "sha256-MWSktvLLEzZq1ATtOtXXDNVQ+DrHHBgb55uXy9GByoo=")
+          .attr("integrity", "sha256-" + darkThemeSha256)
           .appendTo($("head"));
         theme = 'dark';
       } else {

--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -3,6 +3,7 @@
   <head>
     <title>Stockfish Testing Framework</title>
     <meta name="csrf-token" content="${request.session.get_csrf_token()}" />
+    <meta name="dark-theme-sha256" content="${cache_busters['css/theme.dark.css']}" />
 
     <link rel="stylesheet"
           href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"


### PR DESCRIPTION
This makes edits to `dark.theme.css` more convenient, since we'll no longer have to manually calculate the sha256sum and update `application.js` to fix the dark/light toggle.

The expected behavior is now:
- make `dark.theme.css` changes
- restart the server, and the toggle will automatically work