### PR TITLE
Delete the old "requests" package

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -9,7 +9,7 @@ from pyramid.httpexceptions import HTTPFound, HTTPUnauthorized, exception_respon
 from pyramid.response import Response
 from pyramid.view import exception_view_config, view_config, view_defaults
 
-WORKER_VERSION = 108
+WORKER_VERSION = 109
 
 flag_cache = {}
 

--- a/worker/updater.py
+++ b/worker/updater.py
@@ -88,6 +88,20 @@ def update(restart=True, test=False):
                 except:
                     print("Failed to remove the old backup folder " + str(old_bkp_dir))
 
+    # to be dropped when all workers will use the new requests packages
+    requests_dir = os.path.join(worker_dir, "requests")
+    requests_bkp = os.path.join(worker_dir, "_requests")
+    if os.path.exists(requests_bkp):
+        try:
+            shutil.rmtree(requests_bkp)
+        except:
+            print("Failed to delete the old requests folder " + str(requests_bkp))
+    if os.path.exists(requests_dir):
+        try:
+            shutil.move(requests_dir, requests_bkp)
+        except:
+            print("Failed to rename the old requests folder " + str(requests_dir))
+
     print("start_dir: " + start_dir)
     if restart:
         do_restart()

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -41,7 +41,7 @@ except ImportError:
 from games import run_games
 from updater import update
 
-WORKER_VERSION = 108
+WORKER_VERSION = 109
 ALIVE = True
 HTTP_TIMEOUT = 15.0
 


### PR DESCRIPTION
The old "requests" packages is incompatible with python 3.10 and lacks the
updated list of root certificates to work with Let’s Encrypt, see:
https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/

Add temporary code to delete the old "requests" package:
1. at the next worker update: rename the "requests" directory to "_requests"
   to have a backup in case of problems for some users
2. at the successive worker update: delete the "_request" directory