### PR TITLE
Only LTC task to Windows high concurrency worker

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -697,11 +697,17 @@ class RunDb:
 
             # To avoid time losses in the case of large concurrency and short TC,
             # probably due to cutechess-cli as discussed in issue #822,
-            # assign those workers to LTC or multi-threaded jobs.
+            # assign linux workers to LTC or multi-threaded jobs
+            # and windows workers only to LTC jobs
             if max_threads >= 32:
-                short_tc = estimate_game_duration(run["args"]["tc"]) * run["args"][
-                    "threads"
-                ] <= estimate_game_duration("30+0.3")
+                if "windows" in worker_info["uname"].lower():
+                    short_tc = estimate_game_duration(
+                        run["args"]["tc"]
+                    ) <= estimate_game_duration("55+0.5")
+                else:
+                    short_tc = estimate_game_duration(run["args"]["tc"]) * run["args"][
+                        "threads"
+                    ] <= estimate_game_duration("30+0.3")
                 if short_tc:
                     continue
 


### PR DESCRIPTION
A Windows 10 worker running with a modern CPU (it should be a 36 cores + HT)
had many time losses with concurrency 64 or 71 in SMPT test at 8 threads 20+0.2
With the same configuration the worker ran without problems all his LTC task.
The Windows 10 Pro seems to be suboptimal for high count threads, see
https://www.anandtech.com/show/15483/amd-threadripper-3990x-review/3

Thanks to: @Vizvezdenec (bug report) @vondele (fix idea)