### PR TITLE
Give server feedback for failed tasks.

### DIFF
--- a/server/fishtest/actiondb.py
+++ b/server/fishtest/actiondb.py
@@ -45,6 +45,9 @@ class ActionDb:
     def block_user(self, username, data):
         self._new_action(username, "block_user", data)
 
+    def failed_task(self, username, run):
+        self._new_action(username,"failed_task", run)
+
     def _new_action(self, username, action, data):
         self.actions.insert_one(
             {

--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import requests
 from fishtest.stats.stat_util import SPRT_elo
 from fishtest.util import worker_name
+from fishtest.views import del_tasks
 from pyramid.httpexceptions import HTTPFound, HTTPUnauthorized, exception_response
 from pyramid.response import Response
 from pyramid.view import exception_view_config, view_config, view_defaults
@@ -183,8 +184,9 @@ class ApiView(object):
     @view_config(route_name="api_failed_task")
     def failed_task(self):
         self.require_authentication()
+        message = self.request.json_body.get("message", "Unknown reason")
         return self.request.rundb.failed_task(
-            self.run_id(), self.task_id(), self.get_unique_key()
+            self.run_id(), self.task_id(), self.get_unique_key(), message
         )
 
     @view_config(route_name="api_upload_pgn")
@@ -236,6 +238,7 @@ class ApiView(object):
             run["finished"] = True
             run["failed"] = True
             run["stop_reason"] = self.request.json_body.get("message", "API request")
+            run = del_tasks(run)
             self.request.actiondb.stop_run(username, run)
             self.request.rundb.stop_run(self.run_id())
         return {}

--- a/server/fishtest/templates/actions.mak
+++ b/server/fishtest/templates/actions.mak
@@ -14,6 +14,7 @@
     <option value="block_user">Block/Unblock User</option>
     <option value="update_stats">System Events</option>
     <option value="upload_nn">Upload NN file</option>
+    <option value="failed_task">Failed Task</option>
   </select>
   &nbsp;From user:
   <input id="user" type="text" name="user" class="submit_on_enter">

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -303,6 +303,10 @@ def actions(request):
             item["run"] = action["data"]["args"]["new_tag"]
             item["_id"] = action["data"]["_id"]
             item["description"] = " ".join(action["action"].split("_"))
+            if action["action"] == "failed_task":
+                item["description"] += ": {}".format(
+                    action["data"].get("failure_reason", "Unknown reason")
+                )
             if action["action"] == "stop_run":
                 item["description"] += ": {}".format(
                     action["data"].get("stop_reason", "User stop")

--- a/worker/test_worker.py
+++ b/worker/test_worker.py
@@ -1,12 +1,11 @@
 import os
 import os.path
-import sys
 import subprocess
+import sys
 import unittest
 
 import games
 import updater
-
 import worker
 
 
@@ -25,9 +24,10 @@ class workerTest(unittest.TestCase):
             pass
 
     def test_config_setup(self):
-        sys.argv = [sys.argv[0], 'user', 'pass']
+        sys.argv = [sys.argv[0], "user", "pass"]
         worker.setup_parameters("foo.txt")
         from configparser import ConfigParser
+
         config = ConfigParser()
         config.read("foo.txt")
         self.assertTrue(config.has_section("login"))


### PR DESCRIPTION
Post a message in the server log.
    
Post a message in the actiondb.
    
Introduce "WorkerException" for standard exceptions.
    
One does not want to record all exceptions on the server since this would include things like syntax errors, potentially even leading to privacy issues.
    
If one raises WorkerException(reason) in run_games() then the reason will be recorded on the server using the "failed_task" api. Exceptions caused by syntax errors etc... are of course not of the type WorkerException. Such exceptions will be recorded on the server with the file name and the line number where the exception occurred.
    
Also: fix a bug in pgn uploading created by the last commit.
