### PR TITLE
Make implicit exceptions (of the type filename:fileno) fatal.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -290,9 +290,9 @@ def get_exception(files):
     i = 0
     exc_type, exc_obj, tb = sys.exc_info()
     filename, lineno, name, line = traceback.extract_tb(tb)[i]
-    message = "Exception at {}: {}".format(os.path.basename(filename), lineno)
+    message = "Exception at {}:{}".format(os.path.basename(filename), lineno)
     while os.path.basename(filename) in files:
-        message = "Exception at {}: {}".format(os.path.basename(filename), lineno)
+        message = "Exception at {}:{}".format(os.path.basename(filename), lineno)
         i += 1
         try:
             filename, lineno, name, line = traceback.extract_tb(tb)[i]
@@ -413,8 +413,9 @@ def fetch_and_handle_task(worker_info, password, remote, current_state):
         message = str(e)
         server_message = message
     except Exception as e:
-        message = str(e)
         server_message = get_exception(["worker.py", "games.py"])
+        message = "{} ({})".format(server_message,str(e))
+        current_state["alive"] = False
 
     current_state["task_id"] = None
     current_state["run"] = None


### PR DESCRIPTION
This is again to prevent flooding. Such exceptions are likely to be unrecoverable.