### PR TITLE
For a failed get_request use the exception in the error message.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -51,18 +51,17 @@ EXE_SUFFIX = ".exe" if IS_WINDOWS else ""
 MAKE_CMD = "make COMP=mingw " if IS_WINDOWS else "make COMP=gcc "
 
 
+# See https://stackoverflow.com/questions/16511337/correct-way-to-try-except-using-python-requests-module
+# for background.
+# It may be useful to introduce more refined http exception handling in the future.
+
 def requests_get(remote, *args, **kw):
     # A lightweight wrapper around requests.get()
     try:
         result = requests.get(remote, *args, **kw)
+        result.raise_for_status()  # also catch return codes >= 400
     except Exception as e:
-        print(
-            "Exception in requests.get():\n",
-            e,
-            sep="",
-            file=sys.stderr,
-        )
-        raise WorkerException("Get request to {} failed".format(remote))
+        raise WorkerException("Get request failed. Reason: {}".format(e))
 
     return result
 
@@ -71,6 +70,7 @@ def requests_post(remote, *args, **kw):
     # A lightweight wrapper around requests.post()
     try:
         result = requests.post(remote, *args, **kw)
+        result.raise_for_status()  # also catch return codes >= 400
     except Exception as e:
         print(
             "Exception in requests.post():\n",


### PR DESCRIPTION
For a failed get_request use the exception in the error message.
    
I don't want to do this for post requests since I am afraid it may expose passwords. Even if it does not now it may do so in future versions of the requests module.
    
Raise an exception on http status codes >= 400.
    
This is apparently not done by default by the requests module. See
    
    https://stackoverflow.com/questions/16511337/correct-way-to-try-except-using-python-requests-module
    
for background.
    
See https://en.wikipedia.org/wiki/List_of_HTTP_status_codes for http status codes.
