### PR TITLE
Use again a generic message in the action log if a get request fails.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -71,7 +71,14 @@ def requests_get(remote, *args, **kw):
         result = requests.get(remote, *args, **kw)
         result.raise_for_status()  # also catch return codes >= 400
     except Exception as e:
-        raise WorkerException("Get request failed. Reason: {}".format(e), e=e)
+        print(
+            "Exception in requests.get():\n",
+            e,
+            sep="",
+            file=sys.stderr,
+        )
+        raise WorkerException("Get request to {} failed".format(remote), e=e)
+
 
     return result
 


### PR DESCRIPTION
The current long messages don't look very nice and they don't really give useful information.