### PR TITLE
Run cutechess-cli with the option "-recover".

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -1164,6 +1164,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
         cmd = (
             [
                 cutechess,
+                "-recover",
                 "-repeat",
                 "-games",
                 str(int(games_to_play)),


### PR DESCRIPTION
In that way crashes should be recorded correctly and matches should finish cleanly.