### PR TITLE
Save the uuid in the configfile and recycle it.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -92,6 +92,7 @@ def setup_parameters(config_file):
         ("parameters", "min_threads", "1"),
         ("parameters", "fleet", "False"),
         ("parameters", "use_all_cores", "False"),
+        ("parameters", "unique_key", str(uuid.uuid4())),
     ]
 
     for v in defaults:
@@ -156,6 +157,8 @@ def setup_parameters(config_file):
 
     options.username = username
     options.password = password
+
+    options.unique_key = config.get("parameters", "unique_key")
 
     # Step 4: fix inconsistencies in the config options.
     protocol = options.protocol.lower()
@@ -520,7 +523,7 @@ def worker():
             sys.version_info.minor,
             sys.version_info.micro,
         ),
-        "unique_key": str(uuid.uuid4()),
+        "unique_key": options.unique_key,
     }
     print("UUID:", worker_info["unique_key"])
     with open(path.join(worker_dir, "uuid.txt"), "w") as f:


### PR DESCRIPTION
If two workers connect from the same directory then they will have the same uuid. The server will detect the dual connection and send back an error to one of the workers.

My first idea was to quit the worker in that case. However this might be too drastic in case of network errors. 

