### PR TITLE
Make "g++ target query failed" a FatalException.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -331,7 +331,7 @@ def gcc_props():
                 arch = line.split()[1]
 
     if p.returncode != 0:
-        raise WorkerException(
+        raise FatalException(
             "g++ target query failed with return code {}".format(p.returncode)
         )
 


### PR DESCRIPTION
Not urgent but inspired by the current tribulations of tolkki963.