### PR TITLE
Sort the table rows for dotted version header

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -1,7 +1,14 @@
+// https://stackoverflow.com/questions/14267781/sorting-html-table-with-javascript
+// https://stackoverflow.com/questions/40201533/sort-version-dotted-number-strings-in-javascript
 const getCellValue = (tr, idx) => tr.children[idx].dataset.diff || tr.children[idx].innerText || tr.children[idx].textContent;
+const padDotVersion = (dn) => dn.split('.').map(n => +n+1000).join('')
 
 const comparer = (idx, asc) => (a, b) => ((v1, v2) =>
-    v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2) ? v1 - v2 : v1.toString().localeCompare(v2)
+    v1 !== '' && v2 !== '' && !isNaN(v1) && !isNaN(v2)
+    ? v1 - v2
+    : v1 !== '' && v2 !== '' && !isNaN(padDotVersion(v1)) && !isNaN(padDotVersion(v2))
+    ? padDotVersion(v1) - padDotVersion(v2)
+    : v1.toString().localeCompare(v2)
 )(getCellValue(asc ? a : b, idx), getCellValue(asc ? b : a, idx));
 
 $(() => {


### PR DESCRIPTION
The original table sorting code (first reference) sorts for:
 - numerical order: for strings that are a number
 - lexygraphical order: for other strings

Using the second reference add also:
 - numerical order: for strings that are a dotted version (eg 3.10.12)

Also add a comment with the references.

https://stackoverflow.com/questions/14267781/sorting-html-table-with-javascript
https://stackoverflow.com/questions/40201533/sort-version-dotted-number-strings-in-javascript