### PR TITLE
Do more validation of api arguments in api.py.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -4,15 +4,63 @@ from datetime import datetime
 
 import requests
 from fishtest.stats.stat_util import SPRT_elo
-from fishtest.util import worker_name
+from fishtest.util import optional_key, validate, worker_name
 from fishtest.views import del_tasks
-from pyramid.httpexceptions import HTTPFound, HTTPUnauthorized, exception_response
+from pyramid.httpexceptions import (
+    HTTPBadRequest,
+    HTTPFound,
+    HTTPUnauthorized,
+    exception_response,
+)
 from pyramid.response import Response
 from pyramid.view import exception_view_config, view_config, view_defaults
 
 WORKER_VERSION = 131
 
 flag_cache = {}
+
+def validate_request(request):
+    schema = {
+        "password" : str,
+        optional_key("username") : str,
+        optional_key("run_id") : str,
+        optional_key("task_id") : int,
+        optional_key("unique_key") : str,
+        optional_key("pgn") : str,
+        optional_key("message") : str,
+        optional_key("ARCH") : str,
+        optional_key("nps") : float,
+        optional_key("worker_info") : {
+            "uname": str,
+            "architecture": [str, str],
+            "concurrency": int,
+            "max_memory": int,
+            "min_threads": int,
+            "username": str,
+            "version": str,
+            "gcc_version": str,
+            "unique_key": str,
+            "rate": {'limit': int, 'remaining': int}
+        },
+        optional_key("spsa") : {
+            "wins" : int,
+            "losses" : int,
+            "draws" : int,
+            "num_games" : int,
+        },
+        optional_key("stats") : {
+            "wins" : int,
+            "losses" : int,
+            "draws" : int,
+            "crashes" : int,
+            "time_losses" : int,
+            "pentanomial" : [int, int, int, int, int],
+        },
+    }
+    error = validate(schema, request, "request")
+    if error != "":
+        print(error, flush=True)
+        raise HTTPBadRequest({"error": error})
 
 
 def strip_run(run):
@@ -36,6 +84,13 @@ def authentication_failed(error, request):
     return response
 
 
+@exception_view_config(HTTPBadRequest)
+def badrequest_failed(error, request):
+    response = Response(json_body=error.detail)
+    response.status_int = 400
+    return response
+
+
 @view_defaults(renderer="json")
 class ApiView(object):
     """All API endpoints that require authentication are used by workers"""
@@ -50,15 +105,52 @@ class ApiView(object):
         if "error" in token:
             raise HTTPUnauthorized(token)
 
+    def validate_request(self):
+        try:
+            request = self.request.json_body
+        except:
+            raise HTTPBadRequest({"error": "request is not json encoded"})
+        validate_request(request)
+
     def get_username(self):
-        if "username" in self.request.json_body:
-            return self.request.json_body["username"]
-        return self.request.json_body["worker_info"]["username"]
+        try:
+            return self.__username
+        except:
+            pass
+        try:
+            if "username" in self.request.json_body:
+                username = str(self.request.json_body["username"])
+            else:
+                username = str(self.request.json_body["worker_info"]["username"])
+        except:
+            error = "No username"
+            print(error, flush=True)
+            raise HTTPBadRequest({"error": error})
+        self.__username = username
+        return username
 
     def get_unique_key(self):
-        if "unique_key" in self.request.json_body:
-            return self.request.json_body["unique_key"]
-        return self.request.json_body["worker_info"]["unique_key"]
+        try:
+            return self.__unique_key
+        except:
+            pass
+        try:
+            if "unique_key" in self.request.json_body:
+                unique_key = str(self.request.json_body["unique_key"])
+            else:
+                unique_key = str(self.request.json_body["worker_info"]["unique_key"])
+        except:
+            error = "No unique key"
+            print(error, flush=True)
+            raise HTTPBadRequest({"error": error})
+
+        task = self.task()
+        if unique_key != task["worker_info"]["unique_key"]:
+            error = "Invalid unique key: {}".format(unique_key)
+            print(error, flush=True)
+            raise HTTPBadRequest({"error": error})
+        self.__unique_key = unique_key
+        return unique_key
 
     def get_flag(self):
         ip = self.request.remote_addr
@@ -91,14 +183,114 @@ class ApiView(object):
             print("Failed GeoIP check for {}".format(ip))
             return None
 
-    def run_id(self):
-        return str(self.request.json_body["run_id"])
+    def __run_(self):
+        try:
+            return self.__run_id, self.__run
+        except:
+            pass
 
-    def task_id(self):
-        tid = self.request.json_body.get("task_id", None)
-        if tid is not None:
-            return int(tid)
-        return tid
+        run_id = self.request.json_body["run_id"]
+        if run_id is None:
+            error = "No run_id"
+            print(error, flush=True)
+            raise HTTPBadRequest({"error": error})
+        run = self.request.rundb.get_run(run_id)
+        if run is None:
+            error = "Invalid run_id: {}".format(run_id)
+            print(error, flush=True)
+            raise HTTPBadRequest({"error": error})
+        self.__run_id, self.__run = run_id, run
+        return run_id, run
+
+    def run(self):
+        return self.__run_()[1]
+
+    def run_id(self):
+        return self.__run_()[0]
+
+    def __task_(self):
+        try:
+            return self.__task_id, self.__task
+        except:
+            pass
+        task_id = self.request.json_body.get("task_id")
+        if task_id is None:
+            error = "No task_id"
+            print(error, flush=True)
+            raise HTTPBadRequest({"error": error})
+
+        run = self.run()
+        if task_id < 0 or task_id >= len(run["tasks"]):
+            error = "Invalid task_id: {}".format(task_id)
+            print(error, flush=True)
+            raise HTTPBadRequest({"error": error})
+
+        task = run["tasks"][task_id]
+
+        self.__task_id, self.__task = task_id, task
+        return task_id, task
+
+    def task(self):
+        return self.__task_()[1]
+
+    def task_id(self, allow_none=False):
+        return self.__task_()[0]
+
+    def worker_info(self, allow_server=False):
+        try:
+            return self.__worker_info
+        except:
+            pass
+        if "worker_info" in self.request.json_body:
+            worker_info = self.request.json_body["worker_info"]
+            worker_info["remote_addr"] = self.request.remote_addr
+            flag = self.get_flag()
+            if flag:
+                worker_info["country_code"] = flag
+            self.__worker_info = worker_info
+        elif allow_server:
+            worker_info = self.task().get("worker_info")
+        else:
+            error = "No worker_info"
+            print(error, flush=True)
+            raise HTTPBadRequest({"error": error})
+
+        return worker_info
+
+    def worker_name(self):
+        try:
+            return self.__worker_name
+        except:
+            pass
+        worker_info = self.worker_info(allow_server=True)
+        try:
+            worker_name_ = worker_name(worker_info)
+        except:
+            error = "Unable to construct worker name"
+            print(error, flush=True)
+            raise HTTPBadRequest({"error": error})
+        self.__worker_name = worker_name_
+        return worker_name_
+
+    def cpu_hours(self):
+        username = self.get_username()
+        user = self.request.userdb.user_cache.find_one({"username": username})
+        if not user:
+            return -1
+        else:
+            return user["cpu_hours"]
+
+    def message(self):
+        message = str(self.request.json_body.get("message"))
+        return message
+
+    def stats(self):
+        stats=self.request.json_body.get("stats", {})
+        return stats
+
+    def spsa(self):
+        spsa = self.request.json_body.get("spsa", {})
+        return spsa
 
     @view_config(route_name="api_active_runs")
     def active_runs(self):
@@ -114,7 +306,7 @@ class ApiView(object):
 
     @view_config(route_name="api_get_elo")
     def get_elo(self):
-        run = self.request.rundb.get_run(self.request.matchdict["id"]).copy()
+        run = self.request.rundb.get_run(self.request.matchdict["id"])
         results = run["results"]
         if "sprt" not in run["args"]:
             return {}
@@ -135,14 +327,9 @@ class ApiView(object):
 
     @view_config(route_name="api_request_task")
     def request_task(self):
+        self.validate_request()
         self.require_authentication()
-
-        worker_info = self.request.json_body["worker_info"]
-        worker_info["remote_addr"] = self.request.remote_addr
-        flag = self.get_flag()
-        if flag:
-            worker_info["country_code"] = flag
-
+        worker_info = self.worker_info()
         result = self.request.rundb.request_task(worker_info)
         if "task_waiting" in result:
             return result
@@ -169,28 +356,31 @@ class ApiView(object):
 
     @view_config(route_name="api_update_task")
     def update_task(self):
+        self.validate_request()
         self.require_authentication()
         return self.request.rundb.update_task(
             run_id=self.run_id(),
             task_id=self.task_id(),
-            stats=self.request.json_body["stats"],
+            stats=self.stats(),
             nps=self.request.json_body.get("nps", 0),
             ARCH=self.request.json_body.get("ARCH", "?"),
-            spsa=self.request.json_body.get("spsa", {}),
+            spsa=self.spsa(),
             username=self.get_username(),
             unique_key=self.get_unique_key(),
         )
 
     @view_config(route_name="api_failed_task")
     def failed_task(self):
+        self.validate_request()
         self.require_authentication()
-        message = self.request.json_body.get("message", "Unknown reason")
+        self.get_unique_key()  # validation
         return self.request.rundb.failed_task(
-            self.run_id(), self.task_id(), self.get_unique_key(), message
+            self.run_id(), self.task_id(), self.message()
         )
 
     @view_config(route_name="api_upload_pgn")
     def upload_pgn(self):
+        self.validate_request()
         self.require_authentication()
         return self.request.rundb.upload_pgn(
             run_id="{}-{}".format(self.run_id(), self.task_id()),
@@ -228,77 +418,57 @@ class ApiView(object):
 
     @view_config(route_name="api_stop_run")
     def stop_run(self):
+        self.validate_request()
         self.require_authentication()
-        for _ in range(1):  # trick to allow break after errors
-            error = ""
-            if self.task_id() is None:
-                error = "api_stop_run: no task_id"
-                break
-            username = self.get_username()
-            user = self.request.userdb.user_cache.find_one({"username": username})
-            authorized = True
-            if not user:
-                error = "api_stop_run: Warning: user {} is not in the db 'user_cache'".format(
-                    username
-                )
-                authorized = False
-            elif user["cpu_hours"] < 1000:
-                error = "api_stop_run: User {} has too few games to stop a run".format(
-                    username
-                )
-                authorized = False
-            with self.request.rundb.active_run_lock(self.run_id()):
-                run = self.request.rundb.get_run(self.run_id())
-                if run is None:
-                    error = "api_stop_run: run_id {} does not exist".format(
-                        self.run_id()
-                    )
-                    break
-                if self.task_id() >= len(run["tasks"]) or self.task_id() < 0:
-                    error = "api_stop_run: invalid task_id: {}".format(self.task_id())
-                    break
-                task = run["tasks"][self.task_id()]
-                message = self.request.json_body.get("message", "API request")
-                run["stop_reason"] = "task_id: {}, worker: {}, reason: '{}' {}".format(
-                    self.task_id(),
-                    worker_name(task["worker_info"]),
-                    message[:1024],
-                    " (not authorized)" if not authorized else "",
-                )
-                run_ = del_tasks(run)
-                self.request.actiondb.stop_run(username, run_)
-                if authorized:
-                    run["finished"] = True
-                    run["failed"] = True
-                    self.request.rundb.stop_run(self.run_id())
-                else:
-                    # TODO: invoke "failed_task()"
-                    task["active"] = False
-                    self.request.rundb.buffer(run, True)
+        self.get_unique_key()  # validation
+        error = ""
+        if self.cpu_hours() < 1000:
+            error = "api_stop_run: User {} has too few games to stop a run".format(
+                self.get_username()
+            )
+        with self.request.rundb.active_run_lock(self.run_id()):
+            run = self.run()
+            run["stop_reason"] = "task_id: {}, worker: {}, reason: '{}' {}".format(
+                self.task_id(),
+                self.worker_name(),
+                self.message()[:1024],
+                " (not authorized)" if error != "" else "",
+            )
+            run_ = del_tasks(run)
+            self.request.actiondb.stop_run(self.get_username(), run_)
+            if error == "":
+                run["finished"] = True
+                run["failed"] = True
+                self.request.rundb.stop_run(self.run_id())
+            else:
+                task = self.task()
+                task["active"] = False
+                self.request.rundb.buffer(run, True)
 
         if error != "":
             print(error, flush=True)
             return {"error": error}
-        else:
-            return {}
+        return {}
 
     @view_config(route_name="api_request_version")
     def request_version(self):
+        self.validate_request()
         self.require_authentication()
         return {"version": WORKER_VERSION}
 
     @view_config(route_name="api_beat")
     def beat(self):
+        self.validate_request()
         self.require_authentication()
-        if self.task_id() is not None:
-            run = self.request.rundb.get_run(self.run_id())
-            task = run["tasks"][self.task_id()]
-            task["last_updated"] = datetime.utcnow()
-            self.request.rundb.buffer(run, False)
-            return worker_name(task["worker_info"])
-        return "Pleased to hear from you..."
+        run = self.run()
+        task = self.task()
+        task["last_updated"] = datetime.utcnow()
+        self.request.rundb.buffer(run, False)
+        return self.worker_name()
 
     @view_config(route_name="api_request_spsa")
     def request_spsa(self):
+        self.validate_request()
         self.require_authentication()
+        self.get_unique_key()  # validation
         return self.request.rundb.request_spsa(self.run_id(), self.task_id())

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -411,3 +411,45 @@ def password_strength(password, *args):
             return False, suggestions + " " + warning
     else:
         return False, "Non-empty password required"
+
+
+class optional_key:
+    def __init__(self,key):
+        self.key = key
+
+
+def validate(schema, object, name):
+    if isinstance(schema, type):
+        if not isinstance(object, schema):
+            return "{} is not of type {}".format(name, schema)
+        else:
+            return ""
+    if type(schema) != type(object):
+        return "{} is not of type {}".format(name, type(schema))
+    elif isinstance(schema, list) or isinstance(schema, tuple):
+        l = len(object)
+        for i in range(len(schema)):
+            name_ = "{}[{}]".format(name, i)
+            if i >= l:
+                return "{} does not exist".format(name_)
+            else:
+                ret = validate(schema[i], object[i], name_)
+                if ret != "":
+                    return ret
+        return ""
+    elif isinstance(schema, dict):
+        for k in schema:
+            k_ = k
+            if isinstance(k, optional_key):
+                k_ = k.key
+                if k_ not in object:
+                    continue
+            name_ = "{}['{}']".format(name, k_)
+            if k_ not in object:
+                return "{} is missing".format(name_)
+            else:
+                ret = validate(schema[k], object[k_], name_)
+                if ret != "":
+                    return ret
+        return ""
+    return "Type {} is not supported".format(type(schema))

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -102,24 +102,5 @@ class Create90APITest(unittest.TestCase):
         self.rundb.stop()
         testing.tearDown()
 
-    def test_stop_run(self):
-        request = testing.DummyRequest(
-            rundb=self.rundb,
-            userdb=self.rundb.userdb,
-            actiondb=self.rundb.actiondb,
-            method="POST",
-            json_body={
-                "username": "JoeUser",
-                "password": "secret",
-                "run_id": self.run_id,
-                "message": "travis",
-            },
-        )
-        response = ApiView(request).stop_run()
-        self.assertTrue("error" in response)
-        run = request.rundb.get_run(request.json_body["run_id"])
-        self.assertTrue("stop_reason" not in run)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/worker/games.py
+++ b/worker/games.py
@@ -866,7 +866,7 @@ def launch_cutechess(
         + cmd[idx + 1 :]
     )
 
-    print(cmd)
+#    print(cmd)
     with subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
@@ -1150,7 +1150,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
         scaled_new_tc, new_tc_limit = adjust_tc(run["args"]["new_tc"], factor)
         tc_limit = (tc_limit + new_tc_limit) / 2
 
-    result["nps"] = base_nps
+    result["nps"] = float(base_nps)
     result["ARCH"] = ARCH
 
     print("Running {} vs {}".format(run["args"]["new_tag"], run["args"]["base_tag"]))

--- a/worker/games.py
+++ b/worker/games.py
@@ -609,10 +609,6 @@ def enqueue_output(out, queue):
         queue.put(line)
 
 
-w_params = None
-b_params = None
-
-
 def update_pentanomial(line, rounds):
     def result_to_score(_result):
         if _result == "1-0":
@@ -843,7 +839,6 @@ def launch_cutechess(
             )
         )
 
-        global w_params, b_params
         w_params = req["w_params"]
         b_params = req["b_params"]
 

--- a/worker/games.py
+++ b/worker/games.py
@@ -831,7 +831,7 @@ def parse_cutechess_output(
 def launch_cutechess(
     cmd, remote, result, spsa_tuning, games_to_play, batch_size, tc_limit
 ):
-    spsa = {"w_params": [], "b_params": [], "num_games": games_to_play}
+    spsa = {"num_games": games_to_play}
 
     if spsa_tuning:
         # Request parameters for next game.

--- a/worker/games.py
+++ b/worker/games.py
@@ -682,7 +682,7 @@ def validate_pentanomial(wld, rounds):
 
 
 def parse_cutechess_output(
-    p, remote, result, spsa, spsa_tuning, games_to_play, batch_size, tc_limit
+    p, remote, result, spsa_tuning, games_to_play, batch_size, tc_limit
 ):
     saved_stats = copy.deepcopy(result["stats"])
     rounds = {}
@@ -758,6 +758,7 @@ def parse_cutechess_output(
             result["stats"]["draws"] = wld_pairs["draws"] + saved_stats["draws"]
 
             if spsa_tuning:
+                spsa = result["spsa"]
                 spsa["wins"] = wld_pairs["wins"]
                 spsa["losses"] = wld_pairs["losses"]
                 spsa["draws"] = wld_pairs["draws"]
@@ -827,9 +828,9 @@ def parse_cutechess_output(
 def launch_cutechess(
     cmd, remote, result, spsa_tuning, games_to_play, batch_size, tc_limit
 ):
-    spsa = {"num_games": games_to_play}
 
     if spsa_tuning:
+
         # Request parameters for next game.
         t0 = datetime.datetime.utcnow()
         req = send_api_post_request(remote + "/api/request_spsa", result).json()
@@ -839,10 +840,11 @@ def launch_cutechess(
             )
         )
 
+        result["spsa"] = {"num_games": games_to_play}
+
         w_params = req["w_params"]
         b_params = req["b_params"]
 
-        result["spsa"] = spsa
     else:
         w_params = []
         b_params = []
@@ -875,7 +877,6 @@ def launch_cutechess(
                 p,
                 remote,
                 result,
-                spsa,
                 spsa_tuning,
                 games_to_play,
                 batch_size,


### PR DESCRIPTION
This allows for simplification of downstream code. Notably `failed_task()`, `update_task()` and `request_spsa()`.

We do the validation when parsing the arguments. For example `self.task_id()` will throw a `HTTPBadRequest()` exception if it does not succeed in returning a `task_id` corresponding to an existing task. So downstream code may assume that a `task_id` argument is valid.

The same mechanism has allowed us to simplify `api_stop_run` which had recently ballooned because of argument validation.

To check that the api arguments are syntactically correct we provide a rudimentary, but generic, "schema" implementation in `utils.py:validate()`.
