### PR TITLE
Raise HTTP_TIMEOUT for neural network upload

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -127,7 +127,9 @@ def sync_upload(request):
         with open(os.path.expanduser("~/fishtest.upload"), "r") as f:
             upload_server = f.read().replace("\n", "")
             upload_server = upload_server + "/" + filename
-            response = requests.post(upload_server, data=network, timeout=HTTP_TIMEOUT)
+            response = requests.post(
+                upload_server, data=network, timeout=HTTP_TIMEOUT * 20
+            )
             if response.status_code != 200:
                 print("Network upload failed: " + str(response.status_code))
                 request.session.flash(


### PR DESCRIPTION
The neural network server has often a low uploading bandwidth, stopping
the upload process with a timeout error.
The issue is solved:
 - raising the HTTP_TIMEOUT with this PR, and
 - caching the upload request with Cloudflare ("fishtest.upload" server
configuration)