### PR TITLE
Many small cosmetic fixes.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -15,6 +15,18 @@ from pyramid.httpexceptions import (
 from pyramid.response import Response
 from pyramid.view import exception_view_config, view_config, view_defaults
 
+"""
+Important note
+==============
+
+All apis that are relying on get_run() should be served from a single
+Fishtest instance.
+
+If other instances need information about runs they should query the
+db directly. However this information may be slightly outdated, depending
+on how frequently the main instance flushes its run cache.
+"""
+
 WORKER_VERSION = 133
 
 flag_cache = {}
@@ -39,7 +51,7 @@ def validate_request(request):
             "version": str,
             "gcc_version": str,
             "unique_key": str,
-            optional_key("rate"): {"limit": int, "remaining": int},
+            "rate": {"limit": int, "remaining": int},
         },
         optional_key("spsa"): {
             "wins": int,
@@ -56,10 +68,7 @@ def validate_request(request):
             "pentanomial": [int, int, int, int, int],
         },
     }
-    error = validate(schema, request, "request")
-    if error != "":
-        print(error, flush=True)
-        raise HTTPBadRequest({"error": error})
+    return validate(schema, request, "request")
 
 
 def strip_run(run):
@@ -76,17 +85,17 @@ def strip_run(run):
     return run
 
 
-@exception_view_config(HTTPUnauthorized)
-def authentication_failed(error, request):
-    response = Response(json_body=error.detail)
-    response.status_int = 401
-    return response
-
-
 @exception_view_config(HTTPBadRequest)
 def badrequest_failed(error, request):
     response = Response(json_body=error.detail)
     response.status_int = 400
+    return response
+
+
+@exception_view_config(HTTPUnauthorized)
+def authentication_failed(error, request):
+    response = Response(json_body=error.detail)
+    response.status_int = 401
     return response
 
 
@@ -97,72 +106,77 @@ class ApiView(object):
     def __init__(self, request):
         self.request = request
 
-    def validate_request(self, api):
-        error = ""
-        exception = HTTPBadRequest
-        for _ in range(1):  # trick to be able to use break
-            # is the request valid json?
-            try:
-                self.request_body = self.request.json_body
-            except:
-                error = "request is not json encoded"
-                break
-
-            # Is the request syntactically correct?
-            # Raises HTTPBadRequest() in case of error.
-            validate_request(self.request_body)
-
-            # is the supplied password correct?
-            token = self.request.userdb.authenticate(
-                self.request_body["worker_info"]["username"],
-                self.request_body["password"],
-            )
-            if "error" in token:
-                error = "Invalid password for user: {}".format(
-                    self.request_body["worker_info"]["username"],
-                )
-                exception = HTTPUnauthorized
-                break
-
-            # is a supplied run_id correct?
-            self.__run = None
-            if "run_id" in self.request_body:
-                run_id = self.request_body["run_id"]
-                run = self.request.rundb.get_run(run_id)
-                if run is None:
-                    error = "Invalid run_id: {}".format(run_id)
-                    break
-
-                self.__run = run
-
-            # if a task_id is present then there should be a run_id, and
-            # the unique_key should correspond to the unique_key of the
-            # task
-            self.__task = None
-            if "task_id" in self.request_body:
-                task_id = self.request_body["task_id"]
-                if "run_id" not in self.request_body:
-                    error = "The request has a task_id but no run_id"
-                    break
-
-                if task_id < 0 or task_id >= len(run["tasks"]):
-                    error = "Invalid task_id {} for run_id {}".format(task_id, run_id)
-                    break
-
-                task = run["tasks"][task_id]
-                unique_key = self.request_body["worker_info"]["unique_key"]
-                if unique_key != task["worker_info"]["unique_key"]:
-                    error = "Invalid unique key {} for task_id {} for run_id {}".format(
-                        unique_key, task_id, run_id
-                    )
-                    break
-
-                self.__task = task
-
+    def handle_error(self, error, exception=HTTPBadRequest):
         if error != "":
-            error = "{}: {}".format(api, error)
+            error = "{}: {}".format(self.__api, error)
             print(error, flush=True)
             raise exception({"error": error})
+
+    def validate_username_password(self, api):
+        self.__api = api
+        # is the request valid json?
+        try:
+            self.request_body = self.request.json_body
+        except:
+            self.handle_error("request is not json encoded")
+
+        # Is the request syntactically correct?
+        schema = {"password": str, "worker_info": {"username": str}}
+        self.handle_error(validate(schema, self.request_body, "request"))
+
+        # is the supplied password correct?
+        token = self.request.userdb.authenticate(
+            self.request_body["worker_info"]["username"],
+            self.request_body["password"],
+        )
+        if "error" in token:
+            self.handle_error(
+                "Invalid password for user: {}".format(
+                    self.request_body["worker_info"]["username"],
+                ),
+                exception=HTTPUnauthorized,
+            )
+
+    def validate_request(self, api):
+        self.__run = None
+        self.__task = None
+
+        # Preliminary validation.
+        self.validate_username_password(api)
+            
+        # Is the request syntactically correct?
+        self.handle_error(validate_request(self.request_body))
+
+        # is a supplied run_id correct?
+        if "run_id" in self.request_body:
+            run_id = self.request_body["run_id"]
+            run = self.request.rundb.get_run(run_id)
+            if run is None:
+                self.handle_error("Invalid run_id: {}".format(run_id))
+            self.__run = run
+
+        # if a task_id is present then there should be a run_id, and
+        # the unique_key should correspond to the unique_key of the
+        # task
+        if "task_id" in self.request_body:
+            task_id = self.request_body["task_id"]
+            if "run_id" not in self.request_body:
+                self.handle_error("The request has a task_id but no run_id")
+
+            if task_id < 0 or task_id >= len(run["tasks"]):
+                self.handle_error(
+                    "Invalid task_id {} for run_id {}".format(task_id, run_id)
+                )
+
+            task = run["tasks"][task_id]
+            unique_key = self.request_body["worker_info"]["unique_key"]
+            if unique_key != task["worker_info"]["unique_key"]:
+                self.handle_error(
+                    "Invalid unique key {} for task_id {} for run_id {}".format(
+                        unique_key, task_id, run_id
+                    )
+                )
+            self.__task = task
 
     def get_username(self):
         return self.request_body["worker_info"]["username"]
@@ -174,33 +188,31 @@ class ApiView(object):
         if self.__run is not None:
             return self.__run
 
-        error = "Missing run_id"
-        print(error, flush=True)
-        raise HTTPBadRequest({"error": error})
+        self.handle_error("Missing run_id")
 
     def run_id(self):
         if "run_id" in self.request_body:
             return self.request_body["run_id"]
 
-        error = "Missing run_id"
-        print(error, flush=True)
-        raise HTTPBadRequest({"error": error})
+        self.handle_error("Missing run_id")
 
     def task(self):
         if self.__task is not None:
             return self.__task
 
-        error = "Missing task_id"
-        print(error, flush=True)
-        raise HTTPBadRequest({"error": error})
+        self.handle_error("Missing task_id")
 
     def task_id(self):
         if "task_id" in self.request_body:
             return self.request_body["task_id"]
 
-        error = "Missing task_id"
-        print(error, flush=True)
-        raise HTTPBadRequest({"error": error})
+        self.handle_error("Missing task_id")
+
+    def pgn(self):
+        if "pgn" in self.request_body:
+            return self.request_body["pgn"]
+
+        self.handle_error("Missing pgn content")
 
     def worker_info(self):
         worker_info = self.request_body["worker_info"]
@@ -225,12 +237,10 @@ class ApiView(object):
         return self.request_body.get("message", "")
 
     def stats(self):
-        stats = self.request.json_body.get("stats", {})
-        return stats
+        return self.request_body.get("stats", {})
 
     def spsa(self):
-        spsa = self.request_body.get("spsa", {})
-        return spsa
+        return self.request_body.get("spsa", {})
 
     def get_flag(self):
         ip = self.request.remote_addr
@@ -350,7 +360,7 @@ class ApiView(object):
         self.validate_request("/api/upload_pgn")
         return self.request.rundb.upload_pgn(
             run_id="{}-{}".format(self.run_id(), self.task_id()),
-            pgn_zip=base64.b64decode(self.request_body["pgn"]),
+            pgn_zip=base64.b64decode(self.pgn()),
         )
 
     @view_config(route_name="api_download_pgn", renderer="string")
@@ -410,15 +420,14 @@ class ApiView(object):
                 task["active"] = False
                 self.request.rundb.buffer(run, True)
 
-        if error != "":
-            error = "{}: {}".format(api, error)
-            print(error, flush=True)
-            return {"error": error}
+        self.handle_error(error, exception=HTTPUnauthorized)
         return {}
 
     @view_config(route_name="api_request_version")
     def request_version(self):
-        self.validate_request("/api/request_version")
+        # By being mor lax here we can be more strict
+        # elsewhere since the worker will upgrade.
+        self.validate_username_password("/api/request_version")
         return {"version": WORKER_VERSION}
 
     @view_config(route_name="api_beat")
@@ -428,7 +437,7 @@ class ApiView(object):
         task = self.task()
         task["last_updated"] = datetime.utcnow()
         self.request.rundb.buffer(run, False)
-        return self.worker_name()
+        return {}
 
     @view_config(route_name="api_request_spsa")
     def request_spsa(self):

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -10,46 +10,58 @@ from pyramid.testing import DummyRequest
 from util import get_rundb
 
 
+def new_run(self, add_tasks=0):
+    num_tasks = 4
+    num_games = num_tasks * self.rundb.chunk_size
+    run_id = self.rundb.new_run(
+        "master",
+        "master",
+        num_games,
+        "10+0.01",
+        "10+0.01",
+        "book",
+        10,
+        1,
+        "",
+        "",
+        username="travis",
+        tests_repo="travis",
+        start_time=datetime.datetime.utcnow(),
+    )
+    run = self.rundb.get_run(run_id)
+    run["approved"] = True
+    if add_tasks > 0:
+        run["cores"] = 0
+        for i in range(add_tasks):
+            task = {
+                "num_games": self.rundb.chunk_size,
+                "stats": {"wins": 0, "draws": 0, "losses": 0, "crashes": 0},
+                "active": True,
+                "worker_info": self.worker_info,
+            }
+            run["cores"] += self.worker_info["concurrency"]
+            run["tasks"].append(task)
+    self.rundb.buffer(run, True)
+    return str(run_id)
+
+
+def stop_all_runs(self):
+    runs = self.rundb.runs.find({})
+    stopped = []
+    for run in runs:
+        run_ = self.rundb.get_run(str(run["_id"]))
+        run_["finished"] = True
+        for task in run_["tasks"]:
+            task["active"] = False
+        stopped.append(str(run_["_id"]))
+        self.rundb.buffer(run_, True)
+    return stopped
+
+
 class TestApi(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.rundb = get_rundb()
-
-        # Set up a run
-        num_tasks = 4
-        num_games = num_tasks * self.rundb.chunk_size
-        run_id = self.rundb.new_run(
-            "master",
-            "master",
-            num_games,
-            "10+0.01",
-            "10+0.01",
-            "book",
-            10,
-            1,
-            "",
-            "",
-            username="travis",
-            tests_repo="travis",
-            start_time=datetime.datetime.utcnow(),
-        )
-        self.run_id = str(run_id)
-        run = self.rundb.get_run(self.run_id)
-        run["approved"] = True
-
-        # Set up a task
-        self.task_id = 0
-
-        task = {
-            "num_games": self.rundb.chunk_size,
-            "stats": {"wins": 0, "draws": 0, "losses": 0, "crashes": 0},
-            "active": True,
-        }
-
-        run["tasks"].append(task)
-
-        self.rundb.buffer(run, True)
-
         # Set up an API user (a worker)
         self.username = "JoeUserWorker"
         self.password = "secret"
@@ -74,7 +86,6 @@ class TestApi(unittest.TestCase):
             "unique_key": "unique key",
             "rate": {"limit": 5000, "remaining": 5000},
         }
-        run["tasks"][0]["worker_info"] = self.worker_info
         self.rundb.userdb.create_user(self.username, self.password, "email@email.email")
         user = self.rundb.userdb.get_user(self.username)
         user["blocked"] = False
@@ -90,7 +101,7 @@ class TestApi(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
-        self.rundb.runs.delete_one({"_id": self.run_id})
+        self.rundb.runs.delete_many({})
         self.rundb.userdb.users.delete_many({"username": self.username})
         self.rundb.userdb.user_cache.delete_many({"username": self.username})
         self.rundb.userdb.flag_cache.delete_many({"ip": self.remote_addr})
@@ -124,75 +135,66 @@ class TestApi(unittest.TestCase):
         )
 
     def test_get_active_runs(self):
+        run_id = new_run(self)
         request = DummyRequest(rundb=self.rundb)
         response = ApiView(request).active_runs()
-        self.assertTrue(self.run_id in response)
+        self.assertTrue(run_id in response)
 
     def test_get_run(self):
-        request = DummyRequest(rundb=self.rundb, matchdict={"id": self.run_id})
+        run_id = new_run(self)
+        request = DummyRequest(rundb=self.rundb, matchdict={"id": run_id})
         response = ApiView(request).get_run()
-        self.assertEqual(self.run_id, response["_id"])
+        self.assertEqual(run_id, response["_id"])
 
     def test_get_elo(self):
-        request = DummyRequest(rundb=self.rundb, matchdict={"id": self.run_id})
+        run_id = new_run(self)
+        request = DummyRequest(rundb=self.rundb, matchdict={"id": run_id})
         response = ApiView(request).get_elo()
-        self.assertTrue(not response)
+        # /api/get_elo only works for SPRT
+        self.assertFalse(response)
 
     def test_request_task(self):
+        stop_all_runs(self)
+
+        runs = [new_run(self), new_run(self), new_run(self)]
+
+        request = self.invalid_password_request()
         with self.assertRaises(HTTPUnauthorized):
-            response = ApiView(self.invalid_password_request()).update_task()
+            response = ApiView(request).request_task()
             self.assertTrue("error" in response)
+            print(response["error"])
 
-        run = self.rundb.get_run(self.run_id)
-        self.assertEqual(run.get("cores"), None)
-
-        run["tasks"][self.task_id] = {
-            "num_games": self.rundb.chunk_size,
-            "stats": {"wins": 0, "draws": 0, "losses": 0, "crashes": 0},
-            "active": False,
-        }
-        self.rundb.buffer(run, True)
         request = self.correct_password_request()
         response = ApiView(request).request_task()
-        self.assertEqual(self.run_id, response["run"]["_id"])
-        self.assertNotEqual(self.task_id, response["task_id"])
 
-        run = self.rundb.get_run(self.run_id)
+        run = response["run"]
+        run_id = str(run["_id"])
+        task_id = response["task_id"]
+
+        self.assertTrue(run_id in runs)
+
+        run = self.rundb.get_run(run_id)
+        self.assertEqual(len(run["tasks"]), 1)
         self.assertEqual(run["cores"], self.concurrency)
-        task = run["tasks"][response["task_id"]]
+        task = run["tasks"][task_id]
         self.assertTrue(task["active"])
 
     def test_update_task(self):
-        self.assertFalse(self.rundb.get_run(self.run_id)["results_stale"])
+        run_id = new_run(self, add_tasks=1)
+        run = self.rundb.get_run(run_id)
+        self.assertFalse(run["results_stale"])
 
         # Request fails if username/password is invalid
         with self.assertRaises(HTTPUnauthorized):
             response = ApiView(self.invalid_password_request()).update_task()
             self.assertTrue("error" in response)
-
-        # Prepare a pending task that will be updated
-        run = self.rundb.get_run(self.run_id)
-        run["tasks"][self.task_id] = {
-            "num_games": self.rundb.chunk_size,
-            "active": True,
-        }
-        run["finished"] = False
-        run["tasks"][self.task_id]["worker_info"] = self.worker_info
-
-        if run["args"].get("spsa"):
-            del run["args"]["spsa"]
-        self.rundb.buffer(run, True)
-
-        # Calling /api/request_task assigns this task to the worker
-        request = self.correct_password_request()
-        response = ApiView(request).request_task()
-        self.assertEqual(response["run"]["_id"], str(run["_id"]))
+            print(response["error"])
 
         # Task is active after calling /api/update_task with the first set of results
         request = self.correct_password_request(
             {
-                "run_id": self.run_id,
-                "task_id": self.task_id,
+                "run_id": run_id,
+                "task_id": 0,
                 "stats": {
                     "wins": 2,
                     "draws": 0,
@@ -205,7 +207,7 @@ class TestApi(unittest.TestCase):
         )
         response = ApiView(request).update_task()
         self.assertTrue(response["task_alive"])
-        self.assertFalse(self.rundb.get_run(self.run_id)["results_stale"])
+        self.assertFalse(self.rundb.get_run(run_id)["results_stale"])
 
         # Task is still active
         cs = self.rundb.chunk_size
@@ -220,7 +222,7 @@ class TestApi(unittest.TestCase):
         }
         response = ApiView(request).update_task()
         self.assertTrue(response["task_alive"])
-        self.assertFalse(self.rundb.get_run(self.run_id)["results_stale"])
+        self.assertFalse(self.rundb.get_run(run_id)["results_stale"])
 
         # Task is still active. Odd update.
         request.json_body["stats"] = {
@@ -244,8 +246,13 @@ class TestApi(unittest.TestCase):
         }
         response = ApiView(request).update_task()
         self.assertFalse(response["task_alive"])
+
+        response = ApiView(request).update_task()
+        self.assertTrue("info" in response)
+        print(response["info"])
+
         # revive the task
-        run["tasks"][self.task_id]["active"] = True
+        run["tasks"][0]["active"] = True
         self.rundb.buffer(run, True)
 
         request.json_body["stats"] = {
@@ -271,12 +278,12 @@ class TestApi(unittest.TestCase):
         self.assertFalse(response["task_alive"])
 
         # revive the task
-        run["tasks"][self.task_id]["active"] = True
+        run["tasks"][0]["active"] = True
         self.rundb.buffer(run, True)
 
         # Task is finished when calling /api/update_task with results where the number of
         # games played is the same as the number of games in the task
-        task_num_games = run["tasks"][self.task_id]["num_games"]
+        task_num_games = run["tasks"][0]["num_games"]
         request.json_body["stats"] = {
             "wins": task_num_games,
             "draws": 0,
@@ -286,88 +293,96 @@ class TestApi(unittest.TestCase):
             "pentanomial": [0, 0, 0, 0, task_num_games // 2],
         }
         response = ApiView(request).update_task()
-        self.assertFalse(self.rundb.get_run(self.run_id)["results_stale"])
+        self.assertFalse(self.rundb.get_run(run_id)["results_stale"])
         self.assertFalse(response["task_alive"])
-        run = self.rundb.get_run(self.run_id)
-        task = run["tasks"][self.task_id]
+        run = self.rundb.get_run(run_id)
+        task = run["tasks"][0]
         self.assertFalse(task["active"])
 
     def test_failed_task(self):
-        request = self.correct_password_request({"run_id": self.run_id, "task_id": 0})
-        response = ApiView(request).failed_task()
-        self.assertTrue(not response)
+        run_id = new_run(self, add_tasks=1)
+        run = self.rundb.get_run(run_id)
+        # Request fails if username/password is invalid
+        request = self.invalid_password_request()
+        with self.assertRaises(HTTPUnauthorized):
+            response = ApiView(self.invalid_password_request()).update_task()
+            self.assertTrue("error" in response)
+            print(response["error"])
 
-        run = self.rundb.get_run(self.run_id)
-        run["tasks"][self.task_id]["active"] = True
-        run["tasks"][self.task_id]["worker_info"] = self.worker_info
+        self.assertTrue(run["tasks"][0]["active"])
+        message = "Sorry but I can't run this"
+        request = self.correct_password_request({"run_id": run_id, "task_id": 0, "message": message})
+        response = ApiView(request).failed_task()
+        self.assertEqual(response, {})
+        self.assertFalse(run["tasks"][0]["active"])
+
+        request = self.correct_password_request({"run_id": run_id, "task_id": 0})
+        response = ApiView(request).failed_task()
+        self.assertTrue("info" in response)
+        print(response["info"])
+        self.assertFalse(run["tasks"][0]["active"])
+
+        # revive task
+        run["tasks"][0]["active"] = True
         self.rundb.buffer(run, True)
-        run = self.rundb.get_run(self.run_id)
-        self.assertTrue(run["tasks"][self.task_id]["active"])
-
-        request = self.correct_password_request(
-            {"run_id": self.run_id, "task_id": self.task_id}
-        )
+        request = self.correct_password_request({"run_id": run_id, "task_id": 0, "message": message})
         response = ApiView(request).failed_task()
-        self.assertTrue(not response)
-        self.assertFalse(run["tasks"][self.task_id]["active"])
+        self.assertTrue(response == {})
+        self.assertFalse(run["tasks"][0]["active"])
 
     def test_stop_run(self):
+        run_id = new_run(self, add_tasks=1)
         with self.assertRaises(HTTPUnauthorized):
             response = ApiView(self.invalid_password_request()).stop_run()
             self.assertTrue("error" in response)
+            print(response["error"])
 
-        run = self.rundb.get_run(self.run_id)
+        run = self.rundb.get_run(run_id)
         self.assertFalse(run["finished"])
-        run["tasks"][self.task_id]["worker_info"] = self.worker_info
-        self.rundb.buffer(run, True)
 
+        message = "/api/stop_run request"
         request = self.correct_password_request(
-            {"run_id": self.run_id, "task_id": self.task_id, "message": "API request"}
+            {"run_id": run_id, "task_id": 0, "message": message}
         )
-        response = ApiView(request).stop_run()
-        self.assertTrue("error" in response)
+        with self.assertRaises(HTTPUnauthorized):
+            response = ApiView(request).stop_run()
+            self.assertTrue(error in response)
+            sefl.assertFalse(run["tasks"][0]["active"])
 
         self.rundb.userdb.user_cache.update_one(
             {"username": self.username}, {"$set": {"cpu_hours": 10000}}
         )
-        user = self.rundb.userdb.user_cache.find_one({"username": self.username})
-        self.assertTrue(user["cpu_hours"] == 10000)
 
         response = ApiView(request).stop_run()
-        self.assertTrue(not response)
+        self.assertTrue(response == {})
 
-        run = self.rundb.get_run(self.run_id)
+        #        run = self.rundb.get_run(run_id)
         self.assertTrue(run["finished"])
-        self.assertEqual(run["stop_reason"][-13:-2], "API request")
-
-        run["finished"] = False
-        self.rundb.buffer(run, True)
+        self.assertTrue(message in run["stop_reason"])
 
     def test_upload_pgn(self):
+        run_id = new_run(self, add_tasks=1)
         pgn_text = "1. e4 e5 2. d4 d5"
         request = self.correct_password_request(
             {
-                "run_id": self.run_id,
-                "task_id": self.task_id,
+                "run_id": run_id,
+                "task_id": 0,
                 "pgn": base64.b64encode(
                     zlib.compress(pgn_text.encode("utf-8"))
                 ).decode(),
             }
         )
         response = ApiView(request).upload_pgn()
-        self.assertTrue(not response)
+        self.assertTrue(response == {})
 
-        pgn_filename_prefix = "{}-{}".format(self.run_id, self.task_id)
+        pgn_filename_prefix = "{}-{}".format(run_id, 0)
         pgn = self.rundb.get_pgn(pgn_filename_prefix)
         self.assertEqual(pgn, pgn_text)
         self.rundb.pgndb.delete_one({"run_id": pgn_filename_prefix})
 
     def test_request_spsa(self):
-        request = self.correct_password_request({"run_id": self.run_id, "task_id": 0})
-        response = ApiView(request).request_spsa()
-        self.assertFalse(response["task_alive"])
-
-        run = self.rundb.get_run(self.run_id)
+        run_id = new_run(self, add_tasks=1)
+        run = self.rundb.get_run(run_id)
         run["args"]["spsa"] = {
             "iter": 1,
             "num_iter": 10,
@@ -378,11 +393,7 @@ class TestApi(unittest.TestCase):
                 {"name": "param name", "a": 1, "c": 1, "theta": 1, "min": 0, "max": 100}
             ],
         }
-        run["tasks"][self.task_id]["active"] = True
-        self.rundb.buffer(run, True)
-        request = self.correct_password_request(
-            {"run_id": self.run_id, "task_id": self.task_id}
-        )
+        request = self.correct_password_request({"run_id": run_id, "task_id": 0})
         response = ApiView(request).request_spsa()
         self.assertTrue(response["task_alive"])
         self.assertTrue(response["w_params"] is not None)
@@ -392,57 +403,35 @@ class TestApi(unittest.TestCase):
         with self.assertRaises(HTTPUnauthorized):
             response = ApiView(self.invalid_password_request()).request_version()
             self.assertTrue("error" in response)
+            print(response["error"])
 
         response = ApiView(self.correct_password_request()).request_version()
         self.assertEqual(WORKER_VERSION, response["version"])
 
     def test_beat(self):
+        run_id = new_run(self, add_tasks=1)
+
         with self.assertRaises(HTTPUnauthorized):
             response = ApiView(self.invalid_password_request()).beat()
             self.assertTrue("error" in response)
+            print(response["error"])
 
-        request = self.correct_password_request(
-            {
-                "run_id": self.run_id,
-                "task_id": self.task_id,
-            }
-        )
+        request = self.correct_password_request({"run_id": run_id, "task_id": 0})
         response = ApiView(request).beat()
-        print(response)
-        self.assertEqual("JoeUserWorker-7cores-unique key", response)
+        self.assertEqual(response, {})
 
 
 class TestRunFinished(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.rundb = get_rundb()
-
-        # Set up a run with 2 tasks
-        num_games = 2 * self.rundb.chunk_size
-        run_id = self.rundb.new_run(
-            "master",
-            "master",
-            num_games,
-            "10+0.01",
-            "10+0.01",
-            "book",
-            10,
-            1,
-            "",
-            "",
-            username="travis",
-            tests_repo="travis",
-            start_time=datetime.datetime.utcnow(),
-        )
-        self.run_id = str(run_id)
-        run = self.rundb.get_run(self.run_id)
-        run["approved"] = True
-
-        # Set up a user
-        self.username = "JoeUserWorker2"
+        # Set up an API user (a worker)
+        self.username = "JoeUserWorker"
         self.password = "secret"
+        self.unique_key = "unique key"
         self.remote_addr = "127.0.0.1"
         self.concurrency = 7
+
         self.worker_info = {
             "uname": "Linux 5.11.0-40-generic",
             "architecture": ["64bit", "ELF"],
@@ -460,12 +449,12 @@ class TestRunFinished(unittest.TestCase):
             "unique_key": "unique key",
             "rate": {"limit": 5000, "remaining": 5000},
         }
-
         self.rundb.userdb.create_user(self.username, self.password, "email@email.email")
         user = self.rundb.userdb.get_user(self.username)
         user["blocked"] = False
         user["machine_limit"] = 50
         self.rundb.userdb.save_user(user)
+
         self.rundb.userdb.user_cache.insert_one(
             {"username": self.username, "cpu_hours": 0}
         )
@@ -495,7 +484,9 @@ class TestRunFinished(unittest.TestCase):
         )
 
     def test_auto_purge_runs(self):
-        run = self.rundb.get_run(self.run_id)
+        stop_all_runs(self)
+        run_id = new_run(self)
+        run = self.rundb.get_run(run_id)
         num_games = 600
         run["args"]["num_games"] = num_games
         self.rundb.buffer(run, True)
@@ -505,7 +496,7 @@ class TestRunFinished(unittest.TestCase):
         response = ApiView(request).request_task()
         self.assertEqual(response["run"]["_id"], str(run["_id"]))
         self.assertEqual(response["task_id"], 0)
-        task1 = self.rundb.get_run(self.run_id)["tasks"][0]
+        task1 = self.rundb.get_run(run_id)["tasks"][0]
         task_size1 = task1["num_games"]
 
         # Request task 2 of 2
@@ -513,7 +504,7 @@ class TestRunFinished(unittest.TestCase):
         response = ApiView(request).request_task()
         self.assertEqual(response["run"]["_id"], str(run["_id"]))
         self.assertEqual(response["task_id"], 1)
-        task2 = self.rundb.get_run(self.run_id)["tasks"][1]
+        task2 = self.rundb.get_run(run_id)["tasks"][1]
         task_size2 = task2["num_games"]
         task_start2 = task2["start"]
 
@@ -526,7 +517,7 @@ class TestRunFinished(unittest.TestCase):
 
         request = self.correct_password_request(
             {
-                "run_id": self.run_id,
+                "run_id": run_id,
                 "task_id": 0,
                 "stats": {
                     "wins": n_wins,
@@ -540,7 +531,7 @@ class TestRunFinished(unittest.TestCase):
         )
         response = ApiView(request).update_task()
         self.assertFalse(response["task_alive"])
-        run = self.rundb.get_run(self.run_id)
+        run = self.rundb.get_run(run_id)
         self.assertFalse(run["finished"])
 
         # Finish task 2 of 2
@@ -550,7 +541,7 @@ class TestRunFinished(unittest.TestCase):
 
         request = self.correct_password_request(
             {
-                "run_id": self.run_id,
+                "run_id": run_id,
                 "task_id": 1,
                 "stats": {
                     "wins": n_wins,
@@ -566,7 +557,7 @@ class TestRunFinished(unittest.TestCase):
         self.assertFalse(response["task_alive"])
 
         # The run should be marked as finished after the last task completes
-        run = self.rundb.get_run(self.run_id)
+        run = self.rundb.get_run(run_id)
         self.assertTrue(run["finished"])
         self.assertFalse(run["results_stale"])
         self.assertTrue(all([not t["active"] for t in run["tasks"]]))

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -118,7 +118,8 @@ class CreateRunDBTest(unittest.TestCase):
             "worker2",
             "travis",
         )
-        self.assertEqual(run, {"task_alive": False})
+        self.assertFalse(run["task_alive"])
+        self.assertTrue("error" in run)
         run = self.rundb.update_task(
             run_id,
             0,
@@ -135,7 +136,8 @@ class CreateRunDBTest(unittest.TestCase):
             "worker1",
             "travis2",
         )
-        self.assertEqual(run, {"task_alive": False})
+        self.assertFalse(run["task_alive"])
+        self.assertTrue("info" in run)
         # revive task
         run_ = self.rundb.get_run(run_id)
         run_["tasks"][0]["active"] = True


### PR DESCRIPTION
More generic error handling in `api.py`. In particular the error message will now always include `/api/****`.

The worker now uses `send_api_post_request()` for all POST api requests.

A comment in `api.py` about fishtest instances.

Adapt `test_api.py` to dynamic tasks.

`HTTPUnauthorized` exception when `stop_run()` fails.

Make the beat api the same as the other apis.

Create an "info" field in api when the worker tries to do something with an inactive task.

Make the heartbeat thread a daemon thread.

Get rid of the many "Error from remote" messages in the worker. Print the error message in `send_api_post_request()` instead. As a bonus we also print info messages now.
    
Only check username/password for /api/request_version. By being less strict here we can be more strict elsewhere since the worker will upgrade.
    
Make `upload_pgn` a bit more robust.

