### PR TITLE
Stop the run if the server sends invalid SPSA options.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -721,6 +721,12 @@ def parse_cutechess_output(
             raise RunException(message)
 
         # Parse line like this:
+        # Warning: Invalid value for option P: -354
+        if "Warning:" in line and "Invalid value" in line:
+            message = r'Cutechess-cli says: "{}"'.format(line)
+            raise RunException(message)
+
+        # Parse line like this:
         # Finished game 1 (stockfish vs base): 0-1 {White disconnects}
         if "disconnects" in line or "connection stalls" in line:
             result["stats"]["crashes"] += 1


### PR DESCRIPTION
Tested with 

https://dfts-0.pigazzini.it/tests/view/61a550c37347b974ba95a02f

In this case the intervals when setting up the test were declared to be `[-1024,1024]` whereas the intervals used by this branch of SF were `[-128,128]`.

See https://github.com/glinscott/fishtest/pull/1170#issuecomment-982294779 .