### PR TITLE
Send a SIGINT to cutechess-cli to give it a chance to exit nicely (Linux only).

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -82,6 +82,14 @@ def format_return_code(r):
         return str(r)
 
 
+def send_sigint(p):
+    if IS_WINDOWS:
+        # patches welcome...
+        pass
+    else:
+        p.send_signal(signal.SIGINT)
+
+
 # See https://stackoverflow.com/questions/16511337/correct-way-to-try-except-using-python-requests-module
 # for background.
 # It may be useful to introduce more refined http exception handling in the future.
@@ -897,6 +905,9 @@ def launch_cutechess(
                 tc_limit,
             )
         finally:
+            # We nicely ask cutechess-cli to stop.
+            # Unfortunately this only works under Linux right now.
+            send_sigint(p)
             print("\nWaiting for cutechess-cli to finish ... ", end="", flush=True)
             try:
                 p.wait(timeout=HTTP_TIMEOUT)


### PR DESCRIPTION
If the server finishes a SPRT test then it takes a long time before the worker actually kills cutechess-cli.
We try to fix this by sending a SIGINT first. This works correctly on Linux. cutechess-cli will write the pgn and then quit.

I cannot test if it works correctly on Windows since I don't have windows.