### PR TITLE
Do not make dead tasks visible by default in the events log.

### DIFF
--- a/server/fishtest/actiondb.py
+++ b/server/fishtest/actiondb.py
@@ -13,7 +13,7 @@ class ActionDb:
         if action:
             q["action"] = action
         else:
-            q["action"] = {"$ne": "update_stats"}
+            q["action"] = {"$nin": ["update_stats", "dead_task"]}
         if username:
             q["username"] = username
         if before:

--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -473,3 +473,7 @@ td {
 .pagination > li:last-child a {
   border-radius: 0 .25rem .25rem 0
 }
+
+option.grayedoutoption {
+    background-color: LightGray;
+}

--- a/server/fishtest/static/css/theme.dark.css
+++ b/server/fishtest/static/css/theme.dark.css
@@ -326,3 +326,7 @@ pre[style*="border-color:Pink"] {
   background: rgb(68, 68, 68);
   color: rgb(177, 173, 167);
 }
+
+option.grayedoutoption {
+    background-color: Gray;
+}

--- a/server/fishtest/templates/actions.mak
+++ b/server/fishtest/templates/actions.mak
@@ -22,10 +22,10 @@ function timestamp(){
     <option value="delete_run">Delete Run</option>
     <option value="purge_run">Purge Run</option>
     <option value="block_user">Block/Unblock User</option>
-    <option value="update_stats">System Events</option>
     <option value="upload_nn">Upload NN file</option>
-    <option value="failed_task">Failed Task</option>
-    <option value="dead_task">Dead Task</option>
+    <option value="failed_task">Failed Tasks</option>
+    <option class=grayedoutoption value="dead_task">Dead Tasks</option>
+    <option class=grayedoutoption value="update_stats">System Events</option>
   </select>
   &nbsp;From user:
   <input id="user" type="text" name="user" class="submit_on_enter">


### PR DESCRIPTION
This is similar to system events.

A dead task may for example be caused by a user closing their laptop. Or a colab worker being disconnected.

Dead tasks do not carry a lot of information (they have no associated message) and there are a lot of them.

But the fact that a task was declared dead can explain why a pgn file was not uploaded. So it might still be useful to have a record of them.