### PR TITLE
Imply use_all_cores=False if lowering concurrency.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -217,6 +217,12 @@ def setup_parameters(config_file):
     elif protocol == "https" and options.port == "80":
         # Rewrite old port 80 to 443
         options.port = "443"
+    # If we are not going to use all cores, then unset that option.
+    # Note that if we used that option previously, we'd have set
+    # concurrency to the maximum value in the config file, so this will
+    # (only) apply when overruling concurrency via the command line.
+    if cpu_count < multiprocessing.cpu_count():
+        options.use_all_cores = "False"
 
     try:
         if options.use_all_cores == "True":


### PR DESCRIPTION
Currently, if you launch the client once with use_all_cores, it
will save this in the configuration. If you then relaunch it with
a lower --concurrency, that will get ignored because the saved
use_all_cores=True overrules it.

The cleanest fix (that is still backwards compatible and avoids
introducing new flags) appears to be to make a concurrency that's
less than maximum imply use_all_cores=False.

Fixes #1184.