### PR TITLE
Little clean up

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -343,9 +343,7 @@ def actions(request):
                     action["data"].get("failure_reason", "Unknown reason")
                 )
             if action["action"] == "dead_task":
-                item["description"] += ": {}".format(
-                    action["data"].get("dead_task")
-                )
+                item["description"] += ": {}".format(action["data"].get("dead_task"))
             if action["action"] == "stop_run":
                 item["description"] += ": {}".format(
                     action["data"].get("stop_reason", "User stop")

--- a/worker/games.py
+++ b/worker/games.py
@@ -1,9 +1,11 @@
 import copy
+import ctypes
 import datetime
 import glob
 import hashlib
 import json
 import math
+import multiprocessing
 import os
 import platform
 import re
@@ -23,9 +25,6 @@ from zipfile import ZipFile
 import requests
 
 IS_WINDOWS = "windows" in platform.system().lower()
-if IS_WINDOWS:
-    import ctypes
-    from multiprocessing import Process
 
 ARCH = "?"
 
@@ -100,7 +99,7 @@ def send_ctrl_c(pid):
 def send_sigint(p):
     if IS_WINDOWS:
         if p.poll() is None:
-            proc = Process(target=send_ctrl_c, args=(p.pid,))
+            proc = multiprocessing.Process(target=send_ctrl_c, args=(p.pid,))
             proc.start()
             proc.join()
     else:


### PR DESCRIPTION
- drop deprecated `Threads.setDaemon()`
- drop unused `json` library
- drop `from os import path` for the already used `os.path()`
- simplify import for `multiprocessing` and `ctypes`
- fix the print of old gcc version
- improve CPU count code
- run black and isort