### PR TITLE
Some tweaks around option handling.

### DIFF
--- a/worker/test_worker.py
+++ b/worker/test_worker.py
@@ -25,8 +25,11 @@ class workerTest(unittest.TestCase):
             pass
 
     def test_config_setup(self):
-        sys.argv = [sys.argv[0], "user", "pass"]
-        worker.setup_parameters("foo.txt")
+        sys.argv = [sys.argv[0], "user", "pass", "--validate", "false"]
+        if os.path.exists("foo.txt"):
+            os.remove("foo.txt")
+        worker.CONFIGFILE = "foo.txt"
+        worker.setup_parameters(".")
         from configparser import ConfigParser
 
         config = ConfigParser()
@@ -40,7 +43,11 @@ class workerTest(unittest.TestCase):
         self.assertTrue(config.has_option("parameters", "concurrency"))
 
     def test_worker_script_with_no_args(self):
-        with subprocess.Popen(["python", "worker.py"]) as p:
+        assert not os.path.exists("fishtest.cfg")
+        with subprocess.Popen(
+            ["python", "worker.py"],
+            stdin=subprocess.PIPE,
+        ) as p:
             p.communicate()
             self.assertEqual(p.returncode, 1)
 


### PR DESCRIPTION
1) We try to fix
    
https://github.com/glinscott/fishtest/issues/1184
    
The semantics of `--use_all_cores` is now as follows:
    
 `--use_all_cores True`
    
(1) allows the use of all cores;
(2) makes the default concurrency equal to the number of cores.
    
The default can be overridden by supplying an explicit `--concurrency` option.
    
 `--use_all_cores False` disallows the use of all cores.
    
2) We validate config file entries and command line parameters.
    
In particular we make sure that in the option object returned by setup_parameters() all attributes have the expected type. This makes the downstream code simpler.
    
3) We switch from optparse to argparse. optparse is deprecated.
