### PR TITLE
Adjust network timeouts

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -63,7 +63,7 @@ def is_64bit():
     return "64" in platform.architecture()[0]
 
 
-HTTP_TIMEOUT = 15.0
+HTTP_TIMEOUT = 30.0
 
 REPO_URL = "https://github.com/official-stockfish/books"
 EXE_SUFFIX = ".exe" if IS_WINDOWS else ""

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -43,8 +43,8 @@ from games import (
 from updater import update
 
 WORKER_VERSION = 139
-HTTP_TIMEOUT = 15.0
-MAX_RETRY_TIME = 14400.0  # four hours
+HTTP_TIMEOUT = 30.0
+MAX_RETRY_TIME = 900.0  # 15 minutes
 IS_WINDOWS = "windows" in platform.system().lower()
 CONFIGFILE = "fishtest.cfg"
 


### PR DESCRIPTION
MAX_RETRY_TIME: speedup recovery time after longer fishtest outages.
HTTP_TIMEOUT: allow a little more time for longer downloads