### PR TITLE
Make `failed_task()` less expensive.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -362,12 +362,11 @@ class RunDb:
                     ),
                     flush=True,
                 )
-                with self.active_run_lock(str(run_id)):
-                    run["dead_task"] = "task_id: {}, worker: {}".format(
-                        task_id, worker_name(task["worker_info"])
-                    )
-                    run = del_tasks(run)
-                    self.actiondb.dead_task(task["worker_info"]["username"], run)
+                run = del_tasks(run)
+                run["dead_task"] = "task_id: {}, worker: {}".format(
+                    task_id, worker_name(task["worker_info"])
+                )
+                self.actiondb.dead_task(task["worker_info"]["username"], run)
         return dead_task
 
     def get_unfinished_runs_id(self):
@@ -968,7 +967,7 @@ class RunDb:
             return {"task_alive": False, "info": info}
         # Mark the task as inactive.
         task["active"] = False
-        self.buffer(run, True)
+        self.buffer(run, False)
         print(
             "Failed_task: failure for: https://tests.stockfishchess.org/tests/view/{}, "
             "task_id: {}, worker: {}, reason: '{}'".format(
@@ -976,12 +975,11 @@ class RunDb:
             ),
             flush=True,
         )
-        with self.active_run_lock(str(run_id)):
-            run["failure_reason"] = "task_id: {}, worker: {}, reason: '{}'".format(
-                task_id, worker_name(task["worker_info"]), message[:1024]
-            )
-            run = del_tasks(run)
-            self.actiondb.failed_task(task["worker_info"]["username"], run)
+        run = del_tasks(run)
+        run["failure_reason"] = "task_id: {}, worker: {}, reason: '{}'".format(
+            task_id, worker_name(task["worker_info"]), message[:1024]
+        )
+        self.actiondb.failed_task(task["worker_info"]["username"], run)
         return {}
 
     def stop_run(self, run_id, run=None):

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -754,9 +754,9 @@ def validate_form(request):
 
 
 def del_tasks(run):
-    if "tasks" in run:
-        run = copy.deepcopy(run)
-        del run["tasks"]
+    run = copy.copy(run)
+    run.pop("tasks", None)
+    run = copy.deepcopy(run)
     return run
 
 


### PR DESCRIPTION
(1) Avoid making a copy of the task list in `del_tasks()`.
(2) Use `buffer(run,False)`.
(3) Do not grab the active run lock (there seems to be no point).