### PR TITLE
Adjust remaining hours estimate

### DIFF
--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -327,7 +327,7 @@ def remaining_hours(run):
     r = run["results"]
     if "sprt" in run["args"]:
         # current average number of games. Regularly update / have server guess?
-        expected_games = 53000
+        expected_games = 58000
         # checking randomly, half the expected games needs still to be done
         remaining_games = expected_games / 2
     else:


### PR DESCRIPTION
as discussed in the issue, our estimate is probably relatively accurate.

It might 'feel' wrong, as it reports the time needed to empty fishtest
assuming no further patches are submitted.

This updates one of the parameters to the current measured value.

fixes https://github.com/glinscott/fishtest/issues/879