### PR TITLE
Fix a problem with Ctrl-C during /api/update_task.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -869,6 +869,8 @@ def parse_cutechess_output(
                             sep="",
                             file=sys.stderr,
                         )
+                        if isinstance(e, FatalException): # signal
+                            raise e
                     else:
                         if not response["task_alive"]:
                             # This task is no longer necessary

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -488,7 +488,7 @@ def setup_parameters(worker_dir):
 
 def on_sigint(current_state, signal, frame):
     current_state["alive"] = False
-    raise WorkerException("Terminated by signal {}".format(str_signal(signal)))
+    raise FatalException("Terminated by signal {}".format(str_signal(signal)))
 
 
 def get_rate():


### PR DESCRIPTION
If Ctrl-C happens during `/api/update_task` then this leads to a "Finished match uncleanly" and moreover it takes `15s` before the worker quits. This PR should fix this.