### PR TITLE
Introduce `/api/get_task/{id}/{task_id}`

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -123,6 +123,7 @@ def main(global_config, **settings):
     config.add_route("api_request_spsa", "/api/request_spsa")
     config.add_route("api_active_runs", "/api/active_runs")
     config.add_route("api_get_run", "/api/get_run/{id}")
+    config.add_route("api_get_task", "/api/get_task/{id}/{task_id}")
     config.add_route("api_upload_pgn", "/api/upload_pgn")
     config.add_route("api_download_pgn", "/api/pgn/{id}")
     config.add_route("api_download_pgn_100", "/api/pgn_100/{skip}")

--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -75,11 +75,11 @@ def validate_request(request):
 def strip_run(run):
     run = copy.deepcopy(run)
     if "tasks" in run:
-        del run["tasks"]
+        run["tasks"] = []
     if "bad_tasks" in run:
-        del run["bad_tasks"]
+        run["bad_tasks"] = []
     if "spsa" in run["args"] and "param_history" in run["args"]["spsa"]:
-        del run["args"]["spsa"]["param_history"]
+        run["args"]["spsa"]["param_history"] = []
     run["_id"] = str(run["_id"])
     run["start_time"] = str(run["start_time"])
     run["last_updated"] = str(run["last_updated"])
@@ -287,11 +287,46 @@ class ApiView(object):
     @view_config(route_name="api_get_run")
     def get_run(self):
         run = self.request.rundb.get_run(self.request.matchdict["id"])
+        if run is None:
+            raise exception_response(404)
         return strip_run(run)
+
+    @view_config(route_name="api_get_task")
+    def get_task(self):
+        try:
+            run = self.request.rundb.get_run(self.request.matchdict["id"])
+            task_id = self.request.matchdict["task_id"]
+            if task_id.endswith("bad"):
+                task_id = int(task_id[:-3])
+                task = copy.deepcopy(run["bad_tasks"][task_id])
+            else:
+                task_id = int(task_id)
+                task = copy.deepcopy(run["tasks"][task_id])
+        except:
+            raise exception_response(404)
+        if "worker_info" in task:
+            worker_info = task["worker_info"]
+            # Do not reveal the unique_key.
+            if "unique_key" in worker_info:
+                unique_key = worker_info["unique_key"]
+                worker_info["unique_key"] = unique_key[0:8] + "..."
+            # Do not reveal remote_addr.
+            if "remote_addr" in worker_info:
+                worker_info["remote_addr"] = "?.?.?.?"
+        if "last_updated" in task:
+            # json does not know about datetime
+            task["last_updated"] = str(task["last_updated"])
+        if "residual" in task:
+            # json does not know about infinity
+            if task["residual"] == float("inf"):
+                task["residual"] = "inf"
+        return task
 
     @view_config(route_name="api_get_elo")
     def get_elo(self):
         run = self.request.rundb.get_run(self.request.matchdict["id"])
+        if run is None:
+            raise exception_response(404)
         results = run["results"]
         if "sprt" not in run["args"]:
             return {}


### PR DESCRIPTION
This makes it convenient to inspect tasks from long ago before the current db schema crystallized. It's another step towards db conversion.

Tweaks in the returned task.

- The `unique_key` is truncated to 8 characters.
- The remote address is replaced by "?.?.?.?".
- If `"task_id"` ends with `"bad"` then the api call returns the corresponding element from `run["bad_tasks"]`.
- `task["last_updated"]` is replaced by a string since json does not know about `datetime`.
- If `task["residual"]` is infinite then it is replaced by the string `"inf"` since JSON does not know about infinity. 