### PR TITLE
[WIP] Retire `idx_hint`. It doesn't work.

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1162,13 +1162,14 @@ def get_paginated_finished_runs(request):
 
     page_idx = max(0, int(request.params.get("page", 1)) - 1)
     page_size = 25
-    finished_runs, num_finished_runs = request.rundb.get_finished_runs(
+    finished_runs, num_finished_runs = request.rundb.get_runs(
         username=username,
         success_only=success_only,
         yellow_only=yellow_only,
         ltc_only=ltc_only,
         skip=page_idx * page_size,
         limit=page_size,
+        finished=True,
     )
 
     pages = [

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -189,7 +189,7 @@ class CreateRunDBTest(unittest.TestCase):
         self.rundb.buffer(run, True)
 
     def test_40_list_LTC(self):
-        finished_runs = self.rundb.get_finished_runs(limit=3, ltc_only=True)[0]
+        finished_runs = self.rundb.get_runs(limit=3, ltc_only=True)[0]
         for run in finished_runs:
             print(run["args"]["tc"])
 


### PR DESCRIPTION
Also: replace `get_finished_runs()` by the more generic `get_runs()` which can also return unfinished runs. Currently this possibility is not used.

Quick fix for #1224 .