### PR TITLE
Further cleanups in the db.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -168,7 +168,7 @@ class RunDb:
         # administrative flags
 
         # "finished"
-        # set in stop_run(), /api/stop_run
+        # set in stop_run(), /api/stop_run, /tests/delete
         # cleared in purge_run(), /tests/modify
         new_run["finished"] = False
 


### PR DESCRIPTION
1) We replace a `unique_key` `xxxxxxxx` by a random `unique key` depending on `worker_name`.

Making the `unique_key` equal to `xxxxxxxx` if it was missing, messes up the residual calculation for old tests.

After this replacement we can retire `unique_key` in `utils.py`.

2) We replace the fields in `run["args"]` which are "?" by "". This corresponds to the defaults in `new_run()`.

3) Set the flags `finished`, `failed`, `deleted`, `is_green`, `is_yellow`, if they are missing.

I see no issues running this against a live system. It changes the `runs` collection in place.
