### PR TITLE
add_clang_and_m1_support

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -518,6 +518,7 @@ def gcc_version():
         bufsize=1,
         close_fds=not IS_WINDOWS,
     ) as p:
+        clang_major = "None"
         for line in iter(p.stdout.readline, ""):
             if "__GNUC__" in line:
                 major = line.split()[2]
@@ -525,15 +526,26 @@ def gcc_version():
                 minor = line.split()[2]
             if "__GNUC_PATCHLEVEL__" in line:
                 patchlevel = line.split()[2]
+            if "__clang_major__" in line:
+                clang_major = line.split()[2]
+            if "__clang_minor__" in line:
+                clang_minor = line.split()[2]
+            if "__clang_patchlevel__" in line:
+                clang_patchlevel = line.split()[2]
 
     if p.returncode != 0:
         print("g++ version query failed with return code {}".format(p.returncode))
         return None
 
     try:
-        major = int(major)
-        minor = int(minor)
-        patchlevel = int(patchlevel)
+        if clang_major == "None":
+            major = int(major)
+            minor = int(minor)
+            patchlevel = int(patchlevel)
+        else:
+            major = int(clang_major)
+            minor = int(clang_minor)
+            patchlevel = int(clang_patchlevel)
     except:
         print("Failed to parse g++ version.")
         return None


### PR DESCRIPTION
Additions to support clang and apple-silicon (which is far more efficient on a M1 hardware (factor 1.7 vs. x86-64 arch)).

Tested on Mac with Intel and M1 cpu and on Windows 10 with Intel 64-bit cpu.

In order to make things perfect for Mac users a cutechess-cli with static linked qt5 would be fine. I can provide you with a binary that runs on Intel and M1 macs. If you upload it I can make the changes in games.py to check and download it to the testing dir if it is missing. Please drop me a note.