### PR TITLE
Fix formula for disabling "Next" button in pager.

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1192,7 +1192,7 @@ def get_paginated_finished_runs(request):
         {
             "idx": "Next",
             "url": "?page={}".format(page_idx + 2),
-            "state": "disabled" if page_idx + 1 == len(pages) - 1 else "",
+            "state": "disabled" if page_idx >= (num_finished_runs - 1) // page_size else "",
         }
     )
 


### PR DESCRIPTION
I think the format of the pager has changed over the years. As a result the code for disabling the Next button is no longer correct.

In this PR the Next button is disabled when
```
page_idx>=(num_finished_runs - 1) // page_size
```
where `page_idx=<current page no>-1`.

Examples:
```
num_finished_runs=75, page_size=25
```
We have 3 full pages. So Next should be disabled if the current page number is 3. I.e. if `page_idx=2`. This is what the formula gives.
```
num_finished_runs=76, page_size=25
```
Now we have 4 pages, the last one containing 1 run. So Next should be disabled when `page_idx=3`, which is again what the formula gives.

Note:

Since we currently do not exclude deleted runs from our queries, but filter them out later instead, it is theoretically possible to have empty pages. This is quite unlikely however since deleted runs are very rare.