### PR TITLE
Refactoring `purge_run` - again.

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -940,9 +940,9 @@ def tests_purge(request):
         return HTTPFound(location=request.route_url("tests"))
 
     # More relaxed conditions than with auto purge.
-    purged = request.rundb.purge_run(run, p=0.01, res=4.5)
-    if not purged:
-        request.session.flash("No bad workers!")
+    message = request.rundb.purge_run(run, p=0.01, res=4.5)
+    if message != "":
+        request.session.flash(message)
         return HTTPFound(location=request.route_url("tests"))
 
     run = del_tasks(run)


### PR DESCRIPTION
This is an attempt to fix #1247 by reordering `stop_run()` and enhancing `purge_run()`.

We now let `stop_run()` completely stop the run and _then_ we invoke `purge_run()`, if `auto_purge` is enabled. `purge_run()`, which can now only be invoked on a finished run, will usually revive the run, _except_ when the test is an sprt test and after purging the LLR is outside the bounds (this part is new).

This PR is almost completely untested.
