### PR TITLE
support apple-silicon when COMP=gcc

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -610,6 +610,11 @@ def find_arch():
             and "x86-64-sse3-popcnt" in targets
         ):
             arch = "x86-64-sse3-popcnt"
+        elif (
+            IS_MACOS and
+            props["arch"] == "armv8-a"
+        ):
+            arch = "apple-silicon"
         else:
             if props["arch"] in targets:
                 arch = props["arch"]


### PR DESCRIPTION
Tested on Mac with M1 and gcc 11.2.0.

   IS_MACOS and props["arch"].startswith("armv8") 

would be a bit speculative but is worth to be considered.