### PR TITLE
Drop the final gzip for mongodb backup

### DIFF
--- a/server/utils/backup.sh
+++ b/server/utils/backup.sh
@@ -4,7 +4,7 @@
 # List available backups with:
 # ${VENV}/bin/aws s3 ls s3://fishtest/backup/archive/
 # Download a backup with:
-# ${VENV}/bin/aws s3 cp s3://fishtest/backup/archive/<YYYYMMDD>/dump.tar.gz dump.tar.gz
+# ${VENV}/bin/aws s3 cp s3://fishtest/backup/archive/<YYYYMMDD>/dump.tar dump.tar
 
 # Load the variables with the AWS keys, cron uses a limited environment
 . ${HOME}/.profile
@@ -13,9 +13,9 @@ cd ${HOME}/backup
 for db_name in "fishtest_new" "admin" "fishtest" "fishtest_testing"; do
   mongodump --db=${db_name} --numParallelCollections=1 --excludeCollection="pgns" --gzip
 done
-tar -cv dump | gzip -1 > dump.tar.gz
+tar -cvf dump.tar dump
 rm -rf dump
 
 date_utc=$(date +%Y%m%d --utc)
 ${VENV}/bin/aws configure set default.s3.max_concurrent_requests 1
-${VENV}/bin/aws s3 cp dump.tar.gz s3://fishtest/backup/archive/${date_utc}/dump.tar.gz
+${VENV}/bin/aws s3 cp dump.tar s3://fishtest/backup/archive/${date_utc}/dump.tar


### PR DESCRIPTION
The new version of mongodump exports the collections with a higher level
of gzip compression, so the second gzip compression can be safely dropped:
-rw-rw-r--  1 fishtest fishtest 1851822080 Jan 26 14:58 dump.tar
-rw-rw-r--  1 fishtest fishtest 1809900535 Jan 26 12:20 dump.tar.gz