### PR TITLE
Further fix #active behaves differently from other tabs due to width not set.

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -70,6 +70,10 @@ body {
   display: inline-table;
 }
 
+#active {
+  width: max-content; 
+}
+
 .contentbase main > h2 {
   top: 0;
   background: var(--bs-body-bg);


### PR DESCRIPTION
in smaller screens, width for #active is not calculated per percentages properly because there is no set width.