### PR TITLE
Update the entry_points for setuptools 60.9.0

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -37,8 +37,9 @@ setup(
     install_requires=requires,
     tests_require=requires,
     test_suite="run_all_tests.server_test_suite",
-    entry_points="""\
-      [paste.app_factory]
-      main=fishtest:main
-      """,
+    entry_points={
+        'paste.app_factory': [
+            'main = fishtest:main',
+        ],
+    },
 )


### PR DESCRIPTION
Update the entry_points format in setup.py according to the Pyramid
instructions to work with the latest setuptools version 60.9.0

https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/project.html

The fishtest Pyramid project files are still a bit outdated with respect
to the latest version created with cookiecutter.