### PR TITLE
Increase the number of games per tasks dynamically

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -566,7 +566,10 @@ class RunDb:
         game_time = estimate_game_duration(run["args"]["tc"])
         concurrency = worker_info["concurrency"] // run["args"]["threads"]
         assert concurrency >= 1
-        games = self.task_duration / game_time * concurrency
+        # as we have more tasks done (>1000), make them longer to avoid
+        # having many tasks in long running tests
+        scale_duration = 1 + (len(run["tasks"]) // 1000) ** 2
+        games = self.task_duration * scale_duration / game_time * concurrency
         if "sprt" in run["args"]:
             batch_size = 2 * run["args"]["sprt"].get("batch_size", 1)
             games = max(batch_size, batch_size * int(games / batch_size + 1 / 2))


### PR DESCRIPTION
as we have more tasks increases the games per task.
tests with many games at VLTC can result in 1000s of tasks/test.
This increases the number of games per batch as the number of tasks increases.

partially solves  https://github.com/glinscott/fishtest/issues/1299