### PR TITLE
Fix table header overlapping the dropdown menu

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -219,7 +219,7 @@ from fishtest.util import worker_name
         <button id="btn_view_individual" type="button" class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown">
           View Individual Parameter<span class="caret"></span>
         </button>
-        <ul class="dropdown-menu" role="menu" id="dropdown_individual"></ul>
+	<ul class="dropdown-menu" style="z-index: 1030" role="menu" id="dropdown_individual"></ul>
       </div>
 
       <button id="btn_view_all" class="btn">View All</button>


### PR DESCRIPTION
In Boostrap the sticky style has "z-index: 1020" and the dropdown style
has "z-index: 1000", so one of the SPSA parameters from the dropdown menu
cannot be selected because it is overlapped by the sticky table header.
Raise the z-index for the dropdown menu to set the proper stacking order.

https://getbootstrap.com/docs/5.0/layout/z-index/