### PR TITLE
Print exception name

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -702,9 +702,9 @@ def get_exception(files):
     i = 0
     exc_type, exc_obj, tb = sys.exc_info()
     filename, lineno, name, line = traceback.extract_tb(tb)[i]
-    message = "Exception at {}:{}".format(os.path.basename(filename), lineno)
+    message = "Exception {} at {}:{}".format(exc_type.__name__, os.path.basename(filename), lineno)
     while os.path.basename(filename) in files:
-        message = "Exception at {}:{}".format(os.path.basename(filename), lineno)
+        message = "Exception {} at {}:{}".format(exc_type.__name__, os.path.basename(filename), lineno)
         i += 1
         try:
             filename, lineno, name, line = traceback.extract_tb(tb)[i]


### PR DESCRIPTION
Print the name of an unclassified exception in the event log.

Example: https://tests.stockfishchess.org/actions?count=1&before=1649400523.77