### PR TITLE
Simplify the machines table code

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -99,7 +99,6 @@ def main(global_config, **settings):
     config.add_route("nns", "/nns")
 
     config.add_route("tests", "/tests")
-    config.add_route("tests_machines", "/tests/machines")
     config.add_route("tests_finished", "/tests/finished")
     config.add_route("tests_run", "/tests/run")
     config.add_route("tests_view", "/tests/view/{id}")

--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -27,22 +27,16 @@ $(() => {
             .forEach(tr => body.appendChild(tr));
     });
 
-
     $("#non_default-button").click(function() {
-        var active = $(this).text().trim().substring(0, 4) === 'Hide';
+        const active = $(this).text().trim().substring(0, 4) === 'Hide';
         $(this).text(active ? 'Show non default nets' : 'Hide non default nets');
         $.cookie('non_default_state', active ? 'Hide' : 'Show', {expires: 3650});
         window.location.reload();
     });
 
-    let fetchingMachines = false;
     $("#machines-button").click(function() {
         const active = $(this).text().trim() === 'Hide';
         $(this).text(active ? 'Show' : 'Hide');
-        if (!active && !$("#machines table")[0] && !fetchingMachines) {
-            fetchingMachines = true;
-            $.get("/tests/machines", (html) => $("#machines").append(html));
-        }
         $("#machines").slideToggle(150);
         $.cookie('machines_state', $(this).text().trim(), {expires: 3650});
     });

--- a/server/fishtest/templates/tests.mak
+++ b/server/fishtest/templates/tests.mak
@@ -19,11 +19,9 @@
     </h4>
 
     <div id="machines"
-          class="overflow-auto"
-          style="${'' if machines_shown else 'display: none;'}">
-      % if machines_shown:
-          <%include file="machines_table.mak" args="machines=machines"/>
-      % endif
+         class="overflow-auto"
+         style="${'' if machines_shown else 'display: none;'}">
+      <%include file="machines_table.mak"/>
     </div>
 % endif
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -987,15 +987,6 @@ def tests_stats(request):
     return {"run": run}
 
 
-@view_config(route_name="tests_machines", renderer="machines_table.mak")
-def tests_machines(request):
-    machines = request.rundb.get_machines()
-    for machine in machines:
-        diff = diff_date(machine["last_updated"])
-        machine["last_updated"] = delta_date(diff)
-    return {"machines": machines}
-
-
 @view_config(route_name="tests_view", renderer="tests_view.mak")
 def tests_view(request):
     run = request.rundb.get_run(request.matchdict["id"])
@@ -1301,6 +1292,7 @@ def tests(request):
             finally:
                 last_time = time.time()
                 building.release()
+
     return {
         **last_tests,
         "machines_shown": request.cookies.get("machines_state") == "Hide",


### PR DESCRIPTION
The old code refreshed the machines table content using a dedicated view
to avoid the costly reload of the whole home page.
However the code had some problems:
- the smart refresh worked only for the first click over the "Show" button
- the refresh of an open machines table required anyway the reload
of the whole home page
- the control logic was spreaded in a couple of views,
in a couple of mako templates and in one js script