### PR TITLE
Add a toggle button for the tasks table

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -47,6 +47,13 @@ $(() => {
         $.cookie('machines_state', $(this).text().trim(), {expires: 3650});
     });
 
+    $("#tasks-button").click(function() {
+        const active = $(this).text().trim() === 'Hide';
+        $(this).text(active ? 'Show' : 'Hide');
+        $("#tasks").slideToggle(150);
+        $.cookie('tasks_state', $(this).text().trim(), {expires: 3650});
+    });
+
     // Click the sun/moon icons to change the color theme of the site
     // SRI hash for "fishtest/server/fishtest/static/css/theme.dark.css":
     // openssl dgst -sha256 -binary theme.dark.css | openssl base64 -A

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -234,18 +234,25 @@ if 'spsa' in run['args']:
 
 <section id="diff-section" style="display: none">
   <h3>
+    <button id="diff-toggle" class="btn btn-sm btn-light border">Show</button>
     Diff
     <span id="diff-num-comments" style="display: none"></span>
     <a href="${h.diff_url(run)}" class="btn btn-link" target="_blank" rel="noopener">View on Github</a>
-    <button id="diff-toggle" class="btn btn-sm btn-light border">Show</button>
     <a href="javascript:" id="copy-diff" class="btn btn-link" style="margin-left: 10px; display: none">Copy apply-diff command</a>
     <div class="btn btn-link copied" style="color: green; display: none">Copied command!</div>
   </h3>
   <pre id="diff-contents"><code class="diff"></code></pre>
 </section>
 
-<h3>Tasks ${totals}</h3>
-<div id="tasks" class="overflow-auto">
+<h3>
+  <button id="tasks-button" class="btn btn-sm btn-light border">
+    ${'Hide' if tasks_shown else 'Show'}
+  </button>
+  Tasks ${totals}
+</h3>
+<div id="tasks"
+     class="overflow-auto"
+     style="${'' if tasks_shown else 'display: none;'}">
   <table class='table table-striped table-sm'>
     <thead class="sticky-top">
       <tr>

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1140,6 +1140,7 @@ def tests_view(request):
         "totals": "({} active worker{} with {} core{})".format(
             active, ("s" if active != 1 else ""), cores, ("s" if cores != 1 else "")
         ),
+        "tasks_shown": request.cookies.get("tasks_state") == "Hide",
     }
 
 


### PR DESCRIPTION
The test page loads faster (and uses less RAM) with the tasks table
closed, very useful to open a test with many tasks, see https://github.com/glinscott/fishtest/issues/1299.
Use a cookie to remember the state of the toggle.