### PR TITLE
Expand the vertical range of data in SPSA chart

### DIFF
--- a/server/fishtest/static/js/spsa.js
+++ b/server/fishtest/static/js/spsa.js
@@ -76,7 +76,7 @@
     "#743411",
   ];
 
-  var chart_invisible_color = "#CCCCCC";
+  var chart_invisible_color = "#cccccc";
 
   var chart_options = {
     curveType: "function",
@@ -90,6 +90,9 @@
     height: 500,
     hAxis: {
       format: "percent",
+    },
+    vAxis: {
+      viewWindowMode: "maximized",
     },
     legend: {
       position: "right",


### PR DESCRIPTION
The default vAxis setting often compresses the range of negative data
in order to insert the x-axis in the chart.
https://developers.google.com/chart/interactive/docs/gallery/linechart#configuration-options