### PR TITLE
Set the SF15 reference Nps using SF11 as base

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -27,7 +27,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 164
+WORKER_VERSION = 165
 
 flag_cache = {}
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1238,7 +1238,7 @@ def homepage_results(request):
         machine["last_updated"] = delta_date(diff)
         if machine["nps"] != 0:
             games_per_minute += (
-                (machine["nps"] / 1280000.0)
+                (machine["nps"] / 1328000.0)
                 * (60.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
                 * (
                     int(machine["concurrency"])

--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -69,7 +69,7 @@ def process_run(run, info, deltas=None):
 def build_users(machines, info):
     for machine in machines:
         games_per_hour = (
-            (machine["nps"] / 1280000.0)
+            (machine["nps"] / 1328000.0)
             * (3600.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
             * (int(machine["concurrency"]) // machine["run"]["args"].get("threads", 1))
         )

--- a/worker/games.py
+++ b/worker/games.py
@@ -1300,16 +1300,14 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
         games_concurrency * threads,
     )
 
-    if base_nps < 500000 / (1 + math.tanh((worker_concurrency - 1) / 8)):
+    if base_nps < 540000 / (1 + math.tanh((worker_concurrency - 1) / 8)):
         raise FatalException(
             "This machine is too slow ({} nps / thread) to run fishtest effectively - sorry!".format(
                 base_nps
             )
         )
-
-    factor = (
-        1280000 / base_nps
-    )  # 1280000 nps is the reference core, also used in fishtest views.
+    # 1328000 nps is the reference core, also set in views.py and delta_update_users.py
+    factor = 1328000 / base_nps
 
     # Adjust CPU scaling.
     scaled_tc, tc_limit = adjust_tc(run["args"]["tc"], factor)

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -46,7 +46,7 @@ from games import (
 )
 from updater import update
 
-WORKER_VERSION = 164
+WORKER_VERSION = 165
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
 THREAD_JOIN_TIMEOUT = 15.0


### PR DESCRIPTION
Fishtest with Stockfish 11 had 1.6MNps as reference Nps and 0.7MNps as
threshold for the slow worker.
Set the new reference Nps according to the average 17% slowdown.
Set the new threshold for slow worker according to the 21% slowdown.

- arch=bmi2 (Dual Xeon workstation)
```
sf_base =  1517458 +/- 9427
sf_test =  1259909 +/- 10794
diff    =  -257549 +/- 9477
speedup = -0.169724
```
- arch=modern (core i7 3770k)
```
sf_base =  1864275 +/- 20969
sf_test =  1466315 +/- 7262
diff    =  -397959 +/- 14643
speedup = -0.213466
```

The speedups are nearly the same measured after the switch to the new net arch
https://github.com/official-stockfish/Stockfish/pull/3927

- arch=bmi2 (Dual Xeon workstation)
```
sf_base =  1566536 +/- 6407
sf_test =  1308257 +/- 5827
diff    =  -258279 +/- 4440
speedup = -0.164873
```
- arch=modern (core i7 3770k)
```
sf_base =  1946273 +/- 22064
sf_test =  1518906 +/- 11325
diff    =  -427366 +/- 11006
speedup = -0.219582
```