### PR TITLE
Drop the table "border-top" from dark theme

### DIFF
--- a/server/fishtest/static/css/theme.dark.css
+++ b/server/fishtest/static/css/theme.dark.css
@@ -271,7 +271,6 @@ input[type="checkbox"]:focus {
 .table th,
 .table td {
   color: var(--color-dark-1);
-  border-top: 1px solid var(--bg-dark-4);
 }
 
 .table th {


### PR DESCRIPTION
The light theme does not have this border, the table size difference is
very noticeable in a SPSA test with many parameters when switching
between the two themes.