### PR TITLE
Set SPSA A proportional to the total iterations

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -242,10 +242,10 @@ else:
 
     <div class="flex-row input-group input-group-sm stop_rule spsa"
          style="${args.get('spsa') or 'display: none'}">
-      <label class="field-label leftmost">SPSA A</label>
-      <input type="number" min="0" step="500" name="spsa_A"
+      <label class="field-label leftmost">SPSA A ratio</label>
+      <input type="number" min="0" max="1" step="0.001" name="spsa_A"
              class="third-size no-arrows form-control"
-             value="${args.get('spsa', {'A': '3000'})['A']}" />
+             value="${args.get('spsa', {'A': '0.1'})['A']}" />
 
       <label class="field-label rightmost">SPSA Alpha</label>
       <input type="number" min="0" step="0.001" name="spsa_alpha"

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -722,7 +722,7 @@ def validate_form(request):
             raise Exception("Number of games must be >= 0")
 
         data["spsa"] = {
-            "A": int(request.POST["spsa_A"]),
+            "A": int(float(request.POST["spsa_A"]) * data["num_games"] / 2),
             "alpha": float(request.POST["spsa_alpha"]),
             "gamma": float(request.POST["spsa_gamma"]),
             "raw_params": request.POST["spsa_raw_params"],
@@ -811,7 +811,12 @@ def tests_run(request):
 
     run_args = {}
     if "id" in request.params:
-        run_args = request.rundb.get_run(request.params["id"])["args"]
+        run_args = copy.deepcopy(request.rundb.get_run(request.params["id"])["args"])
+        if "spsa" in run_args:
+            # needs deepcopy
+            run_args["spsa"]["A"] = (
+                round(1000 * 2 * run_args["spsa"]["A"] / run_args["num_games"]) / 1000
+            )
 
     username = request.authenticated_userid
     u = request.userdb.get_user(username)


### PR DESCRIPTION
The A parameter avoids instability in early SPSA iterations,
the seminal paper suggests to set it at 10% of the total iterations.
fishtest used the default A=3000 (10% of the default 30000 iterations)
that is too small for SPSA ran with 250-500k iterations.

- Ask for the "A_ratio", decimal in range [0; 1], in the new SPSA test
form.
- Set as default value the 10% of total iterations.
- Compute the "A_ratio" when rescheduling a SPSA.
- Backward compatibility saving in the DB "A = A_ratio * iterations"