### PR TITLE
Refine memory estimate

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -718,8 +718,8 @@ class RunDb:
             need_tt += get_hash(run["args"]["new_options"])
             need_tt += get_hash(run["args"]["base_options"])
             need_tt *= max_threads // run["args"]["threads"]
-            # estime another 70MB per process for net (40) and other things besides hash
-            need_base = 2 * 70 * (max_threads // run["args"]["threads"])
+            # estime another 10MB per process, 30MB per thread, and 40MB for net as a base memory need besides hash
+            need_base = 2 * (max_threads // run["args"]["threads"]) * (10 + 40 + 30 * run["args"]["threads"])
 
             if need_base + need_tt > max_memory:
                 continue


### PR DESCRIPTION
Might fix some of the crashes we currently see of fishtest for a test with 8 threads and 512MB hash.