### PR TITLE
Preserve the first 8 characters of the uuid across restarts and make them user settable.

### DIFF
--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -18,7 +18,11 @@ def worker_name(worker_info):
     uuid = worker_info["unique_key"]
     name = "{}-{}cores".format(username, cores)
     if len(uuid) != 0:
-        name += "-" + uuid.split("-")[0]
+        uuid_split=uuid.split("-")
+        if len(uuid_split) >= 1:
+            name += "-" + uuid_split[0]
+        if len(uuid_split) >= 2:
+            name += "-" + uuid_split[1]
     return name
 
 


### PR DESCRIPTION
Example:
    
```
$ python worker.py --uuid_prefix `hostname -s`
…
^C
$ cat uuid.txt
pl-f91e-4757-950d-392ca20856dc
```
`--uuid_prefix _hw` resets the prefix to one depending on the system (default).

