### PR TITLE
Restrict uuid_prefixes to alphanumeric _ascii_ strings.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -140,7 +140,7 @@ def _alpha_numeric(x):
     if len(x) <= 1:
         print("The prefix {} is too short".format(x))
         raise ValueError(x)
-    if not x.isalnum():
+    if not all(ord(c) < 128 for c in x) or not x.isalnum():
         raise ValueError(x)
     return x[:8]
 


### PR DESCRIPTION
Currently "Štockfish" is allowed.