### PR TITLE
Fixes for busybox.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -944,7 +944,8 @@ def pid_valid(pid, name):
         else:
             p = stack.enter_context(
                 subprocess.Popen(
-                    ["ps", "-f", "-p", str(pid)],
+                    # for busybox these options are undocumented...
+                    ["ps", "-f", "-a"],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.DEVNULL,
                     universal_newlines=True,
@@ -953,7 +954,7 @@ def pid_valid(pid, name):
                 )
             )
         for line in iter(p.stdout.readline, ""):
-            if name in line:
+            if name in line and str(pid) in line:
                 return True
     return False
 


### PR DESCRIPTION
See #1364 

Tested by replacing "ps" by "busybox", "ps" in the Popen statements and running the script
```sh
python worker.py &
python worker.py &
sleep 1
killall python g++ make
```

EDIT: It also works with the docker image
```
vdbergh@pl2:~/fishtest-docker$ sudo docker run -it  --pid=host -v worker-dir:/opt/fishtest/worker -e concurrency=1 fishtest

______ _     _     _            _                        _
|  ___(_)   | |   | |          | |                      | |
| |_   _ ___| |__ | |_ ___  ___| |_  __      _____  _ __| | _____ _ __
|  _| | / __| '_ \| __/ _ \/ __| __| \ \ /\ / / _ \| '__| |/ / _ \ '__|
| |   | \__ \ | | | ||  __/\__ \ |_   \ V  V / (_) | |  |   <  __/ |
\_|   |_|___/_| |_|\__\___||___/\__|   \_/\_/ \___/|_|  |_|\_\___|_|

Worker started in /opt/fishtest/worker ... (PID=273258)
ps failed. It seems we are running busybox

*** Worker (PID=273258) stopped! ***
Another worker (PID=272865) is already running in this directory, using the lock file:
/opt/fishtest/worker/worker.lock
vdbergh@pl2:~/fishtest-docker$ 
```
