### PR TITLE
Skip profiled build for Apple silicon

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -27,7 +27,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 170
+WORKER_VERSION = 171
 
 flag_cache = {}
 

--- a/worker/games.py
+++ b/worker/games.py
@@ -662,7 +662,10 @@ def setup_engine(
         elif compiler == "clang++":
             comp = "clang"
 
-        cmd = "make -j {} profile-build ARCH={} COMP={}".format(concurrency, arch, comp)
+        # skip temporary the profiled build for apple silicon, see
+        # https://stackoverflow.com/questions/71580631/how-can-i-get-code-coverage-with-clang-13-0-1-on-mac
+        make_cmd = "build" if arch == "apple-silicon" else "profile-build"
+        cmd = "make -j {} {} ARCH={} COMP={}".format(concurrency, make_cmd, arch, comp)
 
         env = dict(os.environ, CXXFLAGS="-DNNUE_EMBEDDING_OFF")
         with subprocess.Popen(

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -48,7 +48,7 @@ from games import (
 )
 from updater import update
 
-WORKER_VERSION = 170
+WORKER_VERSION = 171
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
 THREAD_JOIN_TIMEOUT = 15.0


### PR DESCRIPTION
Skip profiled build for Apple silicon
Workers with Apple silicon stopped building stockfish:
```
reason: 'Executing make -j 4 profile-build ARCH=apple-silicon COMP=clang failed.
Error: ['warning: default.profraw: Unsupported instrumentation profile format version\n', 'error: No profiles could be merged.\n', 'make[1]: *** [clang-profile-use] Error 1\n', 'make: *** [profile-build] Error 2\n']'
```
See https://stackoverflow.com/questions/71580631/how-can-i-get-code-coverage-with-clang-13-0-1-on-mac

A MacOS worker is running fine with clang, so at the moment
skip the profiled build only for Apple silicon.

Also raise worker version.