### PR TITLE
Fix broken SPSA's diff if the repo is too old

### DIFF
--- a/server/fishtest/helpers.py
+++ b/server/fishtest/helpers.py
@@ -5,7 +5,8 @@ def tests_repo(run):
 
 
 def master_diff_url(run):
-    return "https://github.com/official-stockfish/Stockfish/compare/master...{}".format(
+    return "{}/compare/master...{}".format(
+        tests_repo(run),
         run["args"]["resolved_base"][:10]
     )
 


### PR DESCRIPTION
Bug reported by locutus2 (as well as the bugfix):
https://discord.com/channels/435943710472011776/900771437177094156/991994320464908418