### PR TITLE
Limit SPSA Parameter dropdown

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -121,6 +121,11 @@
   border: none;
 }
 
+.dropdown-menu {
+  max-height: 10em;
+  overflow: auto;
+}
+
 a {
   color: #008002;
   text-decoration: none;

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -229,7 +229,7 @@ if 'spsa' in run['args']:
         <button id="btn_view_individual" type="button" class="btn btn-default dropdown-toggle" data-bs-toggle="dropdown">
           View Individual Parameter<span class="caret"></span>
         </button>
-  <ul class="dropdown-menu" style="z-index: 1030" role="menu" id="dropdown_individual"></ul>
+        <ul class="dropdown-menu" role="menu" id="dropdown_individual"></ul>
       </div>
 
       <button id="btn_view_all" class="btn">View All</button>


### PR DESCRIPTION
This changes the amount of parameteres that are shown for the SPSA dropdown before the user has to scroll down.

With this change the SPSA dropdown should look like this:
![image](https://user-images.githubusercontent.com/45608332/178706575-2c680239-79c8-4254-b2cb-f9b1c2404038.png)

Before it was:
![image](https://user-images.githubusercontent.com/45608332/178706738-053f0460-4406-487c-b038-2f515fc15f43.png)

