### PR TITLE
Open graph meta tags

### DIFF
--- a/server/fishtest/static/css/theme.dark.css
+++ b/server/fishtest/static/css/theme.dark.css
@@ -262,7 +262,7 @@ td[style*="background-color:#FF6A6A"] {
 }
 
 /* Darken white box */
-pre[style*="white-space:nowrap"] {
+.elo-results {
   background: var(--bg-dark-3) !important;
   color: var(--color-dark-1) !important;
 }

--- a/server/fishtest/templates/actions.mak
+++ b/server/fishtest/templates/actions.mak
@@ -4,10 +4,18 @@
   import datetime
 %>
 
+<%!
+  title = "Events Log | Stockfish Testing"
+%>
+
+<%block name="head">
+  <meta property="og:title" content="${title}" />
+</%block>
+
 <h2>Events Log</h2>
 
 <script>
-  document.title = 'Events Log | Stockfish Testing';
+  document.title = '${title}';
 </script>
 
 <form class="row mb-3">

--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -5,6 +5,7 @@ monitoring = request.rundb.conn["admin"].command("getFreeMonitoringStatus")
 <html lang="en">
   <head>
     <title>Stockfish Testing Framework</title>
+    <meta property="og:site_name" content="Fishtest" />
     <meta name="csrf-token" content="${request.session.get_csrf_token()}" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 

--- a/server/fishtest/templates/login.mak
+++ b/server/fishtest/templates/login.mak
@@ -1,7 +1,15 @@
 <%inherit file="base.mak"/>
 
+<%!
+  title = "Login | Stockfish Testing"
+%>
+
+<%block name="head">
+  <meta property="og:title" content="${title}" />
+</%block>
+
 <script>
-  document.title = 'Login | Stockfish Testing';
+  document.title = '${title}';
 </script>
 
 <div class="col-limited-size">

--- a/server/fishtest/templates/nn_upload.mak
+++ b/server/fishtest/templates/nn_upload.mak
@@ -1,7 +1,15 @@
 <%inherit file="base.mak"/>
 
+<%!
+  title = "Neural Network Upload | Stockfish Testing"
+%>
+
+<%block name="head">
+  <meta property="og:title" content="${title}" />
+</%block>
+
 <script>
-  document.title = 'Neural Network Upload | Stockfish Testing';
+  document.title = '${title}';
 </script>
 
 <div class="col-limited-size">

--- a/server/fishtest/templates/nns.mak
+++ b/server/fishtest/templates/nns.mak
@@ -1,7 +1,15 @@
 <%inherit file="base.mak"/>
 
+<%!
+  title = "Neural Network Repository | Stockfish Testing"
+%>
+
+<%block name="head">
+  <meta property="og:title" content="${title}" />
+</%block>
+
 <script>
-  document.title = 'Neural Network Repository | Stockfish Testing';
+  document.title = '${title}';
 </script>
 
 <h2>Neural Network Repository</h2>

--- a/server/fishtest/templates/pending.mak
+++ b/server/fishtest/templates/pending.mak
@@ -1,7 +1,15 @@
 <%inherit file="base.mak"/>
 
+<%!
+  title = "Users - Pending & Idle | Stockfish Testing"
+%>
+
+<%block name="head">
+  <meta property="og:title" content="${title}" />
+</%block>
+
 <script>
-  document.title = 'Users - Pending & Idle | Stockfish Testing';
+  document.title = '${title}';
 </script>
 
 <h2>Users - Pending & Idle</h2>

--- a/server/fishtest/templates/signup.mak
+++ b/server/fishtest/templates/signup.mak
@@ -1,10 +1,15 @@
 <%inherit file="base.mak"/>
 
+<%!
+  title = "Register | Stockfish Testing"
+%>
+
 <script>
-  document.title = 'Register | Stockfish Testing';
+  document.title = '${title}';
 </script>
 
 <%block name="head">
+  <meta property="og:title" content="${title}" />
   <script src='https://www.google.com/recaptcha/api.js'></script>
 </%block>
 

--- a/server/fishtest/templates/sprt_calc.mak
+++ b/server/fishtest/templates/sprt_calc.mak
@@ -1,5 +1,17 @@
 <%inherit file="base.mak"/>
 
+<%!
+  title = "Chess SPRT Calculator | Stockfish Testing"
+%>
+
+<%block name="head">
+  <meta property="og:title" content="${title}" />
+</%block>
+
+<script>
+  document.title = '${title}';
+</script>
+
 <style>
   @media (min-width: 768px) {
     .form-control.number {
@@ -16,10 +28,6 @@
     word-break: break-word;
   }
 </style>
-
-<script>
-  document.title = 'Chess SPRT Calculator | Stockfish Testing';
-</script>
 
 <h2>Chess SPRT Calculator</h2>
 

--- a/server/fishtest/templates/tests.mak
+++ b/server/fishtest/templates/tests.mak
@@ -1,5 +1,9 @@
 <%inherit file="base.mak"/>
 
+<%block name="head">
+  <meta property="og:title" content="Stockfish Testing Framework" />
+</%block>
+
 <link rel="stylesheet"
       href="/css/flags.css?v=${cache_busters['css/flags.css']}"
       integrity="sha384-${cache_busters['css/flags.css']}"

--- a/server/fishtest/templates/tests_finished.mak
+++ b/server/fishtest/templates/tests_finished.mak
@@ -2,31 +2,35 @@
 <%
   title = ""
   if "ltc_only" in request.url:
-      title += " - LTC"
+      title += " LTC"
   if "success_only" in request.url:
-      title += " - Greens"
+      title += " Greens"
   if "yellow_only" in request.url:
-      title += " - Yellows"
+      title += " Yellows"
 %>
 
+<%!
+  title = "Finished Tests | Stockfish Testing"
+%>
+
+<%block name="head">
+  <meta property="og:title" content="${title}" />
+  <meta property="og:description" content="Finished - ${num_finished_runs} tests" />
+</%block>
+
 <script>
-  document.title =  'Finishes Test${title} | Stockfish Testing';
+  document.title =  '${title}';
 </script>
 
-<h2>
-  Finished Tests
-  % if 'success_only' in request.url:
-      - Greens
-  % elif 'yellow_only' in request.url:
-      - Yellows
-  % elif 'ltc_only' in request.url:
-      - LTC
-  % endif
-</h2>
+% if 'success_only' in request.url and 'yellow_only' in request.url:
+  <div class="alert alert-danger">Invalid parameters</div>
+% else:
+  <h2>Finished Tests -${title}</h2>
 
-<%include file="run_table.mak" args="runs=finished_runs,
-                                     header='Finished',
-                                     count=num_finished_runs,
-                                     pages=finished_runs_pages,
-                     title=title"
-/>
+  <%include file="run_table.mak" args="runs=finished_runs,
+                                       header='Finished',
+                                       count=num_finished_runs,
+                                       pages=finished_runs_pages,
+                                       title=title"
+  />
+% endif

--- a/server/fishtest/templates/tests_live_elo.mak
+++ b/server/fishtest/templates/tests_live_elo.mak
@@ -1,7 +1,13 @@
 <%inherit file="base.mak"/>
 
+<%def name="title_tests_live_elo()">Live Elo - ${page_title} | Stockfish Testing</%def>
+
+<%block name="head">
+  <meta property="og:title" content="${title_tests_live_elo()}" />
+</%block>
+
 <script>
-  document.title = 'Live Elo - ${page_title} | Stockfish Testing';
+  document.title = '${title_tests_live_elo()}';
   const test_id = "${str(run['_id'])}";
 </script>
 

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -26,9 +26,18 @@
     is_odds = False
 %>
 
+<%!
+  title = "Create New Test | Stockfish Testing"
+%>
+
+<%block name="head">
+  <meta property="og:title" content="${title}" />
+</%block>
+
 <script>
-  document.title = 'Create New Test | Stockfish Testing';
+  document.title = '${title}';
 </script>
+
 
 <header style="text-align: center; padding-top: 7px">
   <h2>Create New Test</h2>

--- a/server/fishtest/templates/tests_stats.mak
+++ b/server/fishtest/templates/tests_stats.mak
@@ -213,8 +213,14 @@
           elo5_u = elo5 + elo95_5
 %>
 
+<%def name="title_tests_stats()">Statistics - ${page_title} | Stockfish Testing</%def>
+
+<%block name="head">
+  <meta property="og:title" content="${title_tests_stats()}" />
+</%block>
+
 <script>
-  document.title = 'Statistics - ${page_title} | Stockfish Testing';
+  document.title = '${title_tests_stats()}';
 </script>
 
 <style>td {width: 20%;}</style>

--- a/server/fishtest/templates/tests_user.mak
+++ b/server/fishtest/templates/tests_user.mak
@@ -1,8 +1,15 @@
 <%inherit file="base.mak"/>
+
+<%def name="title_tests_user()">${username} | Stockfish Testing</%def>
+
+<%block name="head">
+  <meta property="og:title" content="${title_tests_user()}" />
+</%block>
+
 <h2>${username} - Info</h2>
 
 <script>
-  document.title = '${username} | Stockfish Testing';
+  document.title = '${title_tests_user()}';
 </script>
 
 <%include file="run_tables.mak"/>

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -1,5 +1,19 @@
 <%inherit file="base.mak"/>
 
+<%def name="list_info(run)">
+  % for i in range(len(run['results_info']['info'])):
+      ${run['results_info']['info'][i]}
+  % endfor
+</%def>
+
+<%def name="title_tests_view()">${page_title} | Stockfish Testing</%def>
+
+<%block name="head">
+  <meta property="og:title" content="${title_tests_view()}" />
+  <meta property="og:description" content="${list_info(run)}">
+  <meta name="theme-color" content="${'#FFFF00' if run['results_info']['style'] == 'yellow' else run['results_info']['style']}">
+</%block>
+
 <%
 from fishtest.util import worker_name
 
@@ -434,7 +448,7 @@ if 'spsa' in run['args']:
 </script>
 
 <script>
-  document.title = "${page_title} | Stockfish Testing";
+  document.title = '${title_tests_view()}';
 
   document.addEventListener("DOMContentLoaded", function () {
     let copyDiffBtn = document.querySelector("#copy-diff");

--- a/server/fishtest/templates/user.mak
+++ b/server/fishtest/templates/user.mak
@@ -1,7 +1,15 @@
 <%inherit file="base.mak"/>
 
+<%!
+  title = "User Administration | Stockfish Testing"
+%>
+
+<%block name="head">
+  <meta property="og:title" content="${title}" />
+</%block>
+
 <script>
-  document.title = 'User Administration | Stockfish Testing';
+  document.title = '${title}';
 </script>
 
 <div class="col-limited-size">

--- a/server/fishtest/templates/users.mak
+++ b/server/fishtest/templates/users.mak
@@ -1,7 +1,13 @@
 <%inherit file="base.mak"/>
 
+<%def name="title_users()">Users${" - Top Month" if "monthly" in request.url else ""} | Stockfish Testing</%def>
+
+<%block name="head">
+  <meta property="og:title" content="${title_users()}" />
+</%block>
+
 <script>
-  document.title = 'Users${" - Top Month" if "monthly" in request.url else ""} | Stockfish Testing';
+  document.title = '${title_users()}';
 </script>
 
 <h2>


### PR DESCRIPTION
This PR aims to add open graph meta tags for a better integration with external websites such as Discord
![image](https://user-images.githubusercontent.com/63931154/178841869-c4f76e7a-79b0-41f3-ba49-7334abf17566.png)

I also added a condition in `tests_finished.mak` in case someone tries to search for green and yellow tests at the same time

I'm not entirely familiar with mako templates so if there is a cleaner way of doing things please tell me