### PR TITLE
Untested try at rejecting workers submitting bad data

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -912,6 +912,13 @@ class RunDb:
                 error = "Update_task: the number of games received for task {}/{} is incompatible with the SPRT batch size".format(
                     run_id, task_id
                 )
+        elif    ("stats" in task
+            and ((task["stats"]["time_losses"] + task["stats"]["crashes"])*100 > num_games)
+            # Allow workers at most 1% bad data, however patches which break TM need special handling (TODO?)
+            and error == ""):
+            error = "Update task: task {}/{} has too many crashes+timelosses ({}+{})".format(
+                run_id, task_id, task["stats"]["crashes"], task["stats"]["time_losses"]
+            )
 
         if error != "":
             print(error, flush=True)

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -912,13 +912,13 @@ class RunDb:
                 error = "Update_task: the number of games received for task {}/{} is incompatible with the SPRT batch size".format(
                     run_id, task_id
                 )
-        elif    ("stats" in task
-            and ((task["stats"]["time_losses"] + task["stats"]["crashes"])*100 > num_games)
+        elif "stats" in task and error == "":
+            crashes, time_losses = task["stats"].get("crashes", 0), task["stats"].get("time_losses", 0)
             # Allow workers at most 1% bad data, however patches which break TM need special handling (TODO?)
-            and error == ""):
-            error = "Update task: task {}/{} has too many crashes+timelosses ({}+{})".format(
-                run_id, task_id, task["stats"]["crashes"], task["stats"]["time_losses"]
-            )
+            if (crashes + time_losses) * 100 > num_games:
+                error = "Update task: task {}/{} has too many crashes+timelosses ({}+{})".format(
+                    run_id, task_id, crashes, time_losses
+                )
 
         if error != "":
             print(error, flush=True)


### PR DESCRIPTION
Marked as draft because it needs review/testing but in principle, it should be merged as soon as possible.

This addresses server-side filtering of problematic tasks caused by #1393. Obviously we should also prevent this worker-side problem in the first place, but in the short run this should at least prevent fishtests from being polluted by garbage as they currently are