### PR TITLE
Refill base branch/signature when page is shown

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -395,11 +395,17 @@ else:
 
 <script>
   let form_submitted = false;
+  // when pressing the 'back'/'forward' button to get back to this page
   window.onpageshow = function() {
-    // If pressing the 'back' button to get back to this page, make sure
-    // the submit test button is enabled again.
+    // if the run was not a Reschedule
+    // make sure the base branch and base signiture are refilled again
+    % if not is_rerun:
+        document.querySelector("#base-branch").value = "${args.get('base_tag', 'master')}";
+        document.querySelector("#base-signature").value = "${args.get('base_signature', bench)}";
+    % endif
     // make sure form_submitted is set back to false
     form_submitted = false;
+    // make sure the submit test button is enabled again.
     document.querySelector('#submit-test').removeAttribute('disabled');
     document.querySelector('#submit-test').innerText = 'Submit test';
     // Also make sure that the odds TC fields have the right visibility.


### PR DESCRIPTION
When the run test page is reached with 'back'/'forward' button and the test is not a reschedule, Make sure that the base branch and base signature are refilled if the last stop rule has set their value to an empty string (e.g. last stop rule chosen is SPSA)

I'm expecting this to be tested first in DEV