### PR TITLE
Fix book depth input not showing

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -429,10 +429,11 @@ else:
   }
 
   function update_book_depth_visibility(book) {
-    if (book.match('\.pgn$')) {
-      document.querySelector('.book-depth').style.display = "";
+    const bookDepth = document.querySelectorAll(".book-depth");
+    if (book.match("\\.pgn$")) {
+      bookDepth.forEach((el) => (el.style.display = ""));
     } else {
-      document.querySelector('.book-depth').style.display = "none";
+      bookDepth.forEach((el) => (el.style.display = "none"));
     }
   }
 


### PR DESCRIPTION
.book-depth has more than one element to be shown/hidden,
this is basically a miss on my recent PR of Replacing jQuery with JavaScript

as jQuery selector $('.<class-name>') operates on all elements with that selector,
which was simplified when needed for selectors with only one element
not to have unnecessary loops over a length of 1
and this was carried out by mistake with correct simplifications of other cases