### PR TITLE
Adapt to new MDN standard with explicit SameSite

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -75,7 +75,7 @@ document.addEventListener("DOMContentLoaded", () => {
         ?.remove();
     }
     // Remember the theme for 30 days
-    document.cookie = `theme=${theme};path=/;max-age=${30 * 24 * 60 * 60}`;
+    document.cookie = `theme=${theme};path=/;max-age=${30 * 24 * 60 * 60};SameSite=Lax;`;
   };
 
   const getPreferredTheme = () => {

--- a/server/fishtest/templates/nns.mak
+++ b/server/fishtest/templates/nns.mak
@@ -20,7 +20,7 @@ The recommended net for a given Stockfish executable can be found as the default
     const active = button.innerText.trim().substring(0, 4) === "Hide";
     button.innerText = active ? "Show non default nets" : "Hide non default nets";
     document.cookie =
-      "non_default_state=" + (active ? "Hide" : "Show") + ";max-age=315360000";
+      "non_default_state=" + (active ? "Hide" : "Show") + ";max-age=315360000;SameSite=Lax;";
     window.location.reload();
   }
 </script>

--- a/server/fishtest/templates/run_table.mak
+++ b/server/fishtest/templates/run_table.mak
@@ -40,7 +40,7 @@
     const active = button.innerText.trim() === "Hide";
     button.innerText = active ? "Show" : "Hide";
     document.cookie =
-      "${cookie_name}" + "=" + button.innerText.trim() + ";max-age=315360000";
+      "${cookie_name}" + "=" + button.innerText.trim() + ";max-age=315360000;SameSite=Lax;";
   }
 </script>
 % endif

--- a/server/fishtest/templates/tests.mak
+++ b/server/fishtest/templates/tests.mak
@@ -52,7 +52,7 @@
         const active = button.innerText.trim() === "Hide";
         button.innerText = active ? "Show" : "Hide";
         document.cookie =
-          "machines_state" + "=" + button.innerText.trim() + ";max-age=315360000";
+          "machines_state" + "=" + button.innerText.trim() + ";max-age=315360000;SameSite=Lax;";
       }
     </script>
     

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -257,7 +257,7 @@ if 'spsa' in run['args']:
       const div = document.querySelector("#tasks");
       const active = button.innerText.trim() === 'Hide';
       button.innerText = active ? 'Show' : 'Hide';
-      document.cookie = 'tasks_state' + '=' + button.innerText.trim() + ";max-age=315360000";
+      document.cookie = 'tasks_state' + '=' + button.innerText.trim() + ";max-age=315360000;SameSite=Lax;";
     }
 </script>
 


### PR DESCRIPTION
Explicitly set SameSite to Lax to treat FireFox warning (in the browser console) of new Cookie standard when clicking on the "finished button"

- Lax is the default we already have but setting it explicitly to make cookies standardized for most browsers and treat the warning
- Lax option allows HTTP cookie transmission which is what we have for buttons state and is convenient for Dev purposes in testing on other devices in the same network
- Note that any sensitive cookies introduced in the future should be flagged as secured and not Lax but these button-states are not sensitive data and we don't provide them to third parties after dropping google analytics 

For any new use of cookies in sensitive data,
see the options available at: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie

Warning Screenshot:
![Capture](https://user-images.githubusercontent.com/41402573/189519780-acfd1931-fd1a-4b31-9297-90310c3e0a48.PNG)
