### PR TITLE
Fix events pagination

### DIFF
--- a/server/fishtest/actiondb.py
+++ b/server/fishtest/actiondb.py
@@ -27,10 +27,11 @@ class ActionDb:
         if utc_before:
             q["time"] = {"$lte": utc_before}
 
-        count = self.actions.count_documents(q)
         if max_actions:
+            count = self.actions.count_documents(q, limit=max_actions)
             limit = min(limit, max_actions - skip)
-            count = min(count, max_actions)
+        else:
+            count = self.actions.count_documents(q)
 
         actions_list = self.actions.find(q, limit=limit, skip=skip, sort=[("_id", DESCENDING)])
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -358,7 +358,7 @@ def actions(request):
         if search_action:
             page["url"] += "&action={}".format(search_action)
         if max_actions:
-            page["url"] += "&max_actions={}".format(max_actions)
+            page["url"] += "&max_actions={}".format(num_actions)
         if before:
             page["url"] += "&before={}".format(before)
 


### PR DESCRIPTION
Limit the count if max_actions is used (credits to @ppigazzini)
Correct value in url in case user uses a max_actions value larger than count