### PR TITLE
clickable username in liveElo page

### DIFF
--- a/server/fishtest/static/js/live_elo.js
+++ b/server/fishtest/static/js/live_elo.js
@@ -156,9 +156,8 @@ function display_data(items) {
     " (" +
     escapeHtml(items.args.msg_new) +
     ")</a>";
-  document.getElementById("username").innerHTML = escapeHtml(
-    items.args.username
-  );
+  document.getElementById("username").innerHTML = 
+    `<a href="/tests/user/${escapeHtml(items.args.username)}">${escapeHtml(items.args.username)}</a>`;
   document.getElementById("tc").innerHTML = escapeHtml(items.args.tc);
   document.getElementById("info").innerHTML = escapeHtml(items.args.info);
   document.getElementById("sprt").innerHTML =


### PR DESCRIPTION
So that we can jump directly from the LiveElo pages to the page with all the tests of the user.