### PR TITLE
Limit the scope of no-storing the response to run_table instead of t…

### DIFF
--- a/server/fishtest/templates/run_table.mak
+++ b/server/fishtest/templates/run_table.mak
@@ -12,6 +12,12 @@
   from fishtest.util import get_cookie
   if toggle:
     cookie_name = toggle+"_state"
+    request.response.headerlist.extend(
+        (
+            ("Cache-Control", "no-store"),
+            ("Expires", "0"),
+        )
+    )
 %>
 
 % if toggle:

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1281,12 +1281,6 @@ def tests_finished(request):
 
 @view_config(route_name="tests_user", renderer="tests_user.mak")
 def tests_user(request):
-    request.response.headerlist.extend(
-        (
-            ("Cache-Control", "no-store"),
-            ("Expires", "0"),
-        )
-    )
     username = request.matchdict.get("username", "")
     response = {**get_paginated_finished_runs(request), "username": username}
     if int(request.params.get("page", 1)) == 1:
@@ -1335,12 +1329,6 @@ building = threading.Semaphore()
 
 @view_config(route_name="tests", renderer="tests.mak")
 def tests(request):
-    request.response.headerlist.extend(
-        (
-            ("Cache-Control", "no-store"),
-            ("Expires", "0"),
-        )
-    )
     if int(request.params.get("page", 1)) > 1:
         # page 2 and beyond only show finished test results
         return get_paginated_finished_runs(request)


### PR DESCRIPTION
…he whole home page

this limits the scope of demanding a no-store response only to be applied on the run tables instead of the tests page,
should result in some page loading speedup of `tests` and `tests\user` pages while still solving the "back" button issue of mismatched behavior between browsers.

DEV testing and PROD testing are needed to confirm if any speed-up which loading time can be measured by dev-tools network tab