### PR TITLE
Use github actions to add md5sums to branch

### DIFF
--- a/.github/workflows/compute_md5sums.py
+++ b/.github/workflows/compute_md5sums.py
@@ -1,0 +1,15 @@
+import hashlib
+import json
+from pathlib import Path
+
+worker_dir = Path(__file__).parent.parent.parent / "worker"
+
+FILE_LIST = ["updater.py", "worker.py", "games.py"]
+md5dict = {}
+for file in FILE_LIST:
+    item = worker_dir / file
+    bytes = item.read_bytes()
+    md5 = hashlib.md5(bytes).hexdigest()
+    md5dict[file] = md5
+
+(worker_dir / "md5sums").write_text(json.dumps(md5dict) + "\n")

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # Use MongoDb
       - name: Start MongoDB
@@ -32,6 +34,20 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+
+      # Add md5sums to repository
+      - name: Compute md5sums
+        run: python .github/workflows/compute_md5sums.py
+      - name: Add md5sums file
+        run: git add worker/md5sums
+      - name: Configure username/email
+        run: |
+            git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+            git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+      - name: Commit
+        run: git commit --amend --no-edit
+      - name: Force push changes
+        run: git push -f || true
 
       # And run the tests
       - name: Install setuptools

--- a/worker/md5sums
+++ b/worker/md5sums
@@ -1,0 +1,1 @@
+{"updater.py": "47487cbb29a11ca7eedddfc8b31ea779", "worker.py": "2d5d8b2fe8fe1221b7960067af8edd9f", "games.py": "400cb6402c1a2f6b395a62a252bb2547"}


### PR DESCRIPTION
For every push or pull request or push this PR adds a commit (via github actions) with the md5sums of the worker files. By downloading this file from the master branch at github the worker can check if it has been changed locally. If the worker has been changed it can communicate this information to the server which can suitably annotate event log messages.

This is to aid in debugging. See e.g. https://github.com/glinscott/fishtest/issues/1360#issuecomment-1294506544 .

The worker/server changes are not included yet since I first would like to know if this PR is acceptable.