### PR TITLE
Compute sri hashes of worker files and compare with master

### DIFF
--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,0 +1,1 @@
+{"__version": 181, "updater.py": "maP3sPA0/SXZ/2HYLkaaDXrNPALUOtsWHMdfzOSR+jI49iWywEbLcRB7lw/HjZGO", "worker.py": "H54ZC6E44bKco8IsNRqxrRcOYfDYco+L09W0knm3+4TeqJvkiyKTqEIH9AzCH5tT", "games.py": "7VnR+r0ZWFBbT/M0SuZ/Ftb6P3J5W2Y9tEZrT4tmkOVvEECKx5cz5qQSbNRlvVva"}

--- a/worker/test_worker.py
+++ b/worker/test_worker.py
@@ -61,6 +61,9 @@ class workerTest(unittest.TestCase):
         print(file_list)
         self.assertTrue("worker.py" in file_list)
 
+    def test_sri(self):
+        self.assertTrue(worker.verify_sri("."))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The sri hashes of the current worker files are stored in a file `sri.txt`. This file is updated each time the worker runs, and it can also be updated manually with
```    
    python worker.py --only_config
```    
CI is used to enforce that the file `sri.txt` matches the worker files during pushes or pull requests.
    
The worker will also download the master `sri.txt` (currently not existing) 

https://raw.githubusercontent.com/glinscott/fishtest/master/worker/sri.txt
    
and check if the hashes in that file coincide with the sri hashes of the current worker. If not then a message is printed on the terminal. A tainted worker is not stopped but the flag `worker_info['modified']` is set to `True`. In a subsequent PR the server will use this information in the event log messages (for debugging purposes).
    
In order to fix the race condition between the update of the master worker on GitHub and the update of the Fishtest server (which pulls its code from GitHub), the file `sri.txt` contains the version number of the worker. We ignore the master `sri.txt` if its version is higher than the version of the running worker.
