### PR TITLE
Retire uuid.txt.

### DIFF
--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1381,8 +1381,6 @@ def worker():
     }
 
     print("UUID:", worker_info["unique_key"])
-    with open(os.path.join(worker_dir, "uuid.txt"), "w") as f:
-        f.write(worker_info["unique_key"])
 
     # Start heartbeat thread as a daemon (not strictly necessary, but there might be bugs)
     heartbeat_thread = threading.Thread(


### PR DESCRIPTION
The first (constant) part of the UUID is now written as a comment in the config file. This is sufficient to identify the worker.