### PR TITLE
Ignore the master sri if it has a different version number

### DIFF
--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 183, "updater.py": "maP3sPA0/SXZ/2HYLkaaDXrNPALUOtsWHMdfzOSR+jI49iWywEbLcRB7lw/HjZGO", "worker.py": "hLKzqUFSr+ka769iC9vC+KXYDHwTwkdsRzlZRPsbu8gk2ijcHkXaPXLSJU+zJAk3", "games.py": "7VnR+r0ZWFBbT/M0SuZ/Ftb6P3J5W2Y9tEZrT4tmkOVvEECKx5cz5qQSbNRlvVva"}
+{"__version": 183, "updater.py": "maP3sPA0/SXZ/2HYLkaaDXrNPALUOtsWHMdfzOSR+jI49iWywEbLcRB7lw/HjZGO", "worker.py": "5eD5FH7xEKUWpWKd0BT1PCAYKZz5Ksy87ZG0T+rcljvIJ4Gk/rvHyM/88+4NKjQD", "games.py": "7VnR+r0ZWFBbT/M0SuZ/Ftb6P3J5W2Y9tEZrT4tmkOVvEECKx5cz5qQSbNRlvVva"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -288,8 +288,8 @@ def verify_remote_sri(install_dir):
     if sri_ is None:
         return None
     version = sri_.get("__version", -1)
-    if version > WORKER_VERSION:
-        print("The master sri file has a later version. Ignoring!")
+    if version != WORKER_VERSION:
+        print("The master sri file has a different version number. Ignoring!")
         return True
     tainted = False
     for k, v in sri_.items():
@@ -1443,8 +1443,8 @@ def worker():
         return 1
 
     # Check if we are running an unmodified worker
-    un_modified = verify_remote_sri(worker_dir)
-    if un_modified is None:
+    unmodified = verify_remote_sri(worker_dir)
+    if unmodified is None:
         return 1
 
     # Assemble the config/options data as well as some other data in a
@@ -1475,7 +1475,7 @@ def worker():
         ),
         "compiler": compiler,
         "unique_key": get_uuid(options),
-        "modified": not un_modified,
+        "modified": not unmodified,
         "ARCH": "?",
         "nps": 0.0,
     }


### PR DESCRIPTION
This is to handle another race condition. Namely the fact  that it takes some time for https://raw.githubusercontent.com to update after a push. See
    
https://github.com/glinscott/fishtest/pull/1445#issuecomment-1304848578
