### PR TITLE
No placeholder for the username field in the event log

### DIFF
--- a/server/fishtest/templates/actions.mak
+++ b/server/fishtest/templates/actions.mak
@@ -30,7 +30,7 @@
   </div>
   <div class="col-12 col-md-auto mb-3">
     <label for="user" class="form-label">From user</label>
-    <input id="user" type="text" name="user" class="form-control" placeholder="username" value="${request.GET.get('user') if request.GET.get('user') != None else ''}">
+    <input id="user" type="text" name="user" class="form-control" value="${request.GET.get('user') if request.GET.get('user') != None else ''}">
   </div>
 
   <div class="col-12 col-md-auto mb-3 d-flex align-items-end">


### PR DESCRIPTION
The placeholder causes annoying behaviour in some browsers that think that this is a login field: e.g. Safari on iPad.