### PR TITLE
Detect a common clang misconfiguration (missing llvm-profdata).

### DIFF
--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 188, "updater.py": "iN1p2Qba0tK78vGLA5iEAkX/IMSYkcaS5StImgla6QDPo0lTv1wxuN3pvxl84aOe", "worker.py": "2r4VEtWzyR+hsNZf15JRWUyFd8nvVzVHTiXNQkPSR7iQkXzOqiiifkKZZ7/Sc/D6", "games.py": "5h/Vo+50Xh07L4wVVg/wZ0Nkz1eglnnTsCiv+JbpsN3pQupKpI8xh2Pu6jjToJrY"}
+{"__version": 188, "updater.py": "iN1p2Qba0tK78vGLA5iEAkX/IMSYkcaS5StImgla6QDPo0lTv1wxuN3pvxl84aOe", "worker.py": "Y0QhmkuzVU1ZymDD7ja4uO+jm6809pyTiiEC6M9uKc382iWco1gjyv4Ltqp2V359", "games.py": "5h/Vo+50Xh07L4wVVg/wZ0Nkz1eglnnTsCiv+JbpsN3pQupKpI8xh2Pu6jjToJrY"}


### PR DESCRIPTION
This is an alternative for #1459 . We catch the error at worker start up.