### PR TITLE
Enable the standard exceptions for make.

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -515,7 +515,7 @@ def make_targets():
                     targets.append(line.split()[0])
                 if "Supported archs:" in line:
                     read_targets = True
-    except (FileNotFoundError, PermissionError) as e:
+    except (OSError, subprocess.SubprocessError) as e:
         print("Exception while executing make help:\n", e, sep="", file=sys.stderr)
         raise FatalException("It appears 'make' is not properly installed")
 

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 190, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "5JdDQFtXeTKTjWFu7PLL7lrxIEawmO7NKdvDvCzIVv5b+1u+mjCfprSFstl7mvTC", "games.py": "93db+K9RIbypPNz7cHKwE/3stQJ1ZBAsP6JjIgTjwXmd0ntFBRaA1ZspeLHegZpE"}
+{"__version": 190, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "5JdDQFtXeTKTjWFu7PLL7lrxIEawmO7NKdvDvCzIVv5b+1u+mjCfprSFstl7mvTC", "games.py": "p2tU85Cn5oq/rK+i9oiOCF5u8DCEiEQNEqj8HAVW16ZKtfo4vtUzGQs4+v3H0lBe"}


### PR DESCRIPTION
Workers come up with ever more obscure exceptions, so it seems it difficult to catch them all. See

https://tests.stockfishchess.org/actions?max_actions=1&before=1669310498.047