### PR TITLE
pre-wrap `<code>` to fix expanding width issue in test view

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -137,6 +137,10 @@
   color: var(--bs-secondary);
 }
 
+code {
+  white-space: pre-wrap; 
+}
+
 /* Confirm deny button */
 .run-deny .dropdown-menu.show {
   min-width: 0;


### PR DESCRIPTION
This fixes the expanded page width issue reported on discord, x-axis appears with an x-scrollbar when the code in the diff is too long and ruins the layout (mostly in windows and macos).
For reference see: 
1- https://tests.stockfishchess.org/tests/view/6389512bd2b9c924c4c60151
2- https://tests.stockfishchess.org/tests/view/6385efc7d2b9c924c4c56abe

before:
![image](https://user-images.githubusercontent.com/41402573/204572380-c48a4c13-6f3b-451b-9337-55692a7e43cc.png)

after:
![Capture](https://user-images.githubusercontent.com/41402573/204573398-be6d53b2-cdbd-479f-a3ce-0d648ae640e6.PNG)