### PR TITLE
Change the handling and presentation of events (PR1)

### DIFF
--- a/server/fishtest/templates/actions.mak
+++ b/server/fishtest/templates/actions.mak
@@ -60,9 +60,10 @@
     <thead class="sticky-top">
       <tr>
         <th>Time</th>
-        <th>Username</th>
-        <th>Run/User</th>
         <th>Event</th>
+        <th>Source</th>
+        <th>Target</th>
+        <th>Comment</th>
       </tr>
     </thead>
     <tbody>
@@ -71,19 +72,29 @@
             ## Dates in mongodb have millisecond precision. So they fit comfortably in a float without precision loss.
             <td><a href=/actions?max_actions=1&before=${action['time'].replace(tzinfo=datetime.timezone.utc).timestamp()}>
              ${action['time'].strftime(r"%y&#8209;%m&#8209;%d %H:%M:%S")|n}</a></td>
+            <td>${action['action']}</td>
+	    <%
+               if 'worker' in action:
+                 agent = action['worker']
+               else:
+                 agent = action['username']
+	    %>
             % if approver and 'fishtest.' not in action['username']:
-                <td><a href="/user/${action['username']}">${action['username']}</a></td>
+                <td><a href="/user/${action['username']}">${agent|n}</a></td>
             % else:
-                <td>${action['username']}</td>
+                <td>${agent|n}</td>
             % endif
-            % if 'run' in action:
-                <td><a href="/tests/view/${action['_id']}">${action['run'][:23]}</a></td>
+            % if 'nn' in action:
+                <td><a href=/api/nn/${action['nn']}>${action['nn'].replace('-', '&#8209;')|n}</a></td>
+            % elif 'run' in action:
+                <td><a href="/tests/view/${action['run_id']}">${action['run'][:23] + \
+                            ("/{}".format(action["task_id"]) if "task_id" in action else "")}</a></td>
             % elif approver:
                 <td><a href="/user/${action['user']}">${action['user']}</a></td>
             % else:
-                <td>${action.get('user','?')}</td>
+                <td>${action['user']}</td>
             % endif
-            <td>${action.get('description','?')}</td>
+            <td style="word-break: break-all">${action.get('message','?')}</td>
           </tr>
       % endfor
     </tbody>


### PR DESCRIPTION
Currently the handling of events is a mess, so we want to fix this. The practical aim however is to provide more options for searching in the future (on the worker name and the comment field).

This project requires a fair number of changes. So the plan is to break it up into several consecutive mergeable PR's.

*Strategy*

- Extract data from the current description field (i.e. `task_id`, `worker name`, `message`) and use it in the new event log format (PR1, i.e. this one).
- Put the extracted data back into the action collection and use the action collection directly to show the event log. Also convert the old action records to the new format (PR2).
- Change the rest of fishtest to put the data directly into the action collection in the new format. No more parsing of the description field (PR3).
- Allow searching on the worker name and the message field. This requires the creation of text indices (PR4).
- Possibly delete the superfluous never shown data in the action collection. This would free a lot of space, but should be discussed (PR5).