### PR TITLE
PR4: Add a free text search field to the event log page.

### DIFF
--- a/server/fishtest/actiondb.py
+++ b/server/fishtest/actiondb.py
@@ -69,6 +69,7 @@ class ActionDb:
         self,
         username=None,
         action=None,
+        text=None,
         limit=0,
         skip=0,
         utc_before=None,
@@ -81,6 +82,8 @@ class ActionDb:
             q["action"] = {"$nin": ["update_stats", "dead_task"]}
         if username:
             q["username"] = username
+        if text:
+            q["$text"] = {"$search": text}
         if utc_before:
             q["time"] = {"$lte": utc_before}
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -9,6 +9,7 @@ import time
 
 import fishtest.stats.stat_util
 import requests
+import urllib
 from fishtest.util import (
     delta_date,
     diff_date,
@@ -329,7 +330,8 @@ def sprt_calc(request):
 @view_config(route_name="actions", renderer="actions.mak")
 def actions(request):
     search_action = request.params.get("action", "")
-    username = request.params.get("user", "")
+    username = request.params.get("user", "").replace("'",'"')
+    text = request.params.get("text", "").replace("'",'"')
     before = request.params.get("before", None)
     max_actions = request.params.get("max_actions", None)
 
@@ -345,6 +347,7 @@ def actions(request):
     actions, num_actions = request.actiondb.get_actions(
         username=username,
         action=search_action,
+        text=text,
         skip=page_idx * page_size,
         limit=page_size,
         utc_before=utc_before,
@@ -358,6 +361,8 @@ def actions(request):
             page["url"] += "&user={}".format(username)
         if search_action:
             page["url"] += "&action={}".format(search_action)
+        if text:
+            page["url"] += "&text={}".format(text)
         if max_actions:
             page["url"] += "&max_actions={}".format(num_actions)
         if before:
@@ -369,6 +374,7 @@ def actions(request):
         "pages": pages,
         "action_param": search_action,
         "username_param": username,
+        "text_param": text,
     }
 
 

--- a/server/utils/create_indexes.py
+++ b/server/utils/create_indexes.py
@@ -80,6 +80,19 @@ def create_users_indexes():
 def create_actions_indexes():
     db["actions"].create_index([("username", ASCENDING), ("_id", DESCENDING)])
     db["actions"].create_index([("action", ASCENDING), ("_id", DESCENDING)])
+    db["actions"].create_index(
+        [
+            ("action", "text"),
+            ("username", "text"),
+            ("worker", "text"),
+            ("message", "text"),
+            ("run", "text"),
+            ("user", "text"),
+            ("nn", "text"),
+            ("_id", DESCENDING),
+        ],
+        default_language="none",
+    )
 
 
 def create_flag_cache_indexes():
@@ -140,7 +153,7 @@ if __name__ == "__main__":
         print("Finished creating indexes!\n")
     print_current_indexes()
     if not collection_names:
-        print("Collections in {}: {}".format(db_name, db.collection_names()))
+        print("Collections in {}: {}".format(db_name, db.list_collection_names()))
         print(
             "Give a list of collection names as arguments to re-create indexes. For example:\n"
         )


### PR DESCRIPTION
For this to work one needs to run

utils/create_indexes.py actions

to create a text index on the string fields of an event:

action, username, worker, message, run, nn.