### PR TITLE
Make the task target links in the event log point to tasks.

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -500,6 +500,11 @@ td {
   background-color: #cff4fc;
 }
 
+/* Background colors for a highlighted task */
+.table tbody tr.highlight > td {
+  background-color: #fff0f5;
+}
+
 /* Pagination links */
 .pagination {
   --bs-pagination-color: var(--bs-body-color);

--- a/server/fishtest/static/css/theme.dark.css
+++ b/server/fishtest/static/css/theme.dark.css
@@ -236,6 +236,12 @@ div#tasks thead {
   background-color: #0f3373;
 }
 
+/* Background colors for a highlighted task */
+.table tbody tr.highlight > td {
+  background-color: #800080;
+}
+
+
 /* Override - test tasks table - purged tasks red background */
 td[style*="background-color:#ffebeb"] {
   background: #5f1c1c !important;

--- a/server/fishtest/templates/actions.mak
+++ b/server/fishtest/templates/actions.mak
@@ -126,8 +126,7 @@
             % if 'nn' in action:
                 <td><a href=/api/nn/${action['nn']}>${action['nn'].replace('-', '&#8209;')|n}</a></td>
             % elif 'run' in action and 'run_id' in action:
-                <td><a href="/tests/view/${action['run_id']}">${action['run'][:23] + \
-                            ("/{}".format(action["task_id"]) if "task_id" in action else "")}</a></td>
+                <td><a href="/tests/view/${action['run_id']}${"?show_task={}".format(action["task_id"]) if "task_id" in action else ""}">${action['run'][:23]}-${str(action['run_id'])[2:8]}${("/{}".format(action["task_id"]) if "task_id" in action else "")}</a></td>
             % elif approver and 'user' in action:
                 <td><a href="/user/${action['user']}">${action['user']}</a></td>
             % else:

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -8,6 +8,15 @@
     spsa_data = json.dumps(run["args"]["spsa"])
 %>
 
+<script>
+if(${show_task} >= 0){
+  window.addEventListener("load", (event) => {
+    task=document.getElementById("task${show_task}");
+    task.scrollIntoView();
+  });
+}
+</script>
+
 <%namespace name="base" file="base.mak"/>
 
 % if 'spsa' in run['args']:
@@ -272,7 +281,7 @@
 <div id="tasks"
      class="overflow-auto ${'collapse show' if tasks_shown else 'collapse'}">
   <table class='table table-striped table-sm'>
-    <thead class="sticky-top">
+    <thead class=${"sticky-top" if show_task == -1 else ""}>
       <tr>
         <th>Idx</th>
         <th>Worker</th>
@@ -303,12 +312,14 @@
             else:
               continue
 
-            if task['active']:
+            if idx==show_task:
+              active_style = 'highlight'
+            elif task['active']:
               active_style = 'info'
             else:
               active_style = ''
           %>
-          <tr class="${active_style}">
+          <tr class="${active_style}" id=task${idx}>
             <td><a href=${f"/api/pgn/{run['_id']}-{idx:d}.pgn"}>${idx}</a></td>
             % if 'bad' in task:
                 <td style="text-decoration:line-through; background-color:#ffebeb">

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1214,6 +1214,14 @@ def tests_view(request):
 
     chi2 = get_chi2(run["tasks"])
     update_residuals(run["tasks"], cached_chi2=chi2)
+
+    try:
+        show_task = int(request.params.get("show_task", -1))
+    except:
+        show_task = -1
+    if show_task >= len(run["tasks"]) or show_task < -1:
+        show_task = -1
+
     return {
         "run": run,
         "run_args": run_args,
@@ -1223,7 +1231,8 @@ def tests_view(request):
         "totals": "({} active worker{} with {} core{})".format(
             active, ("s" if active != 1 else ""), cores, ("s" if cores != 1 else "")
         ),
-        "tasks_shown": request.cookies.get("tasks_state") == "Hide",
+        "tasks_shown": show_task != -1 or request.cookies.get("tasks_state") == "Hide",
+        "show_task": show_task,
     }
 
 


### PR DESCRIPTION
Also: include the bytes 2-4 of the run_id in the run name (there may be many tests with the same branch, currently these are indistinguishable).

One cannot yet search for the extra data. This will require again a database conversion.