### PR TITLE
fixe access to the response variable

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -191,7 +191,7 @@ def sync_upload(request):
     except Exception as e:
         print("Network upload failed: " + str(e))
         request.session.flash(
-            "Network upload failed: " + str(response.status_code), "error"
+            "Post request for the network upload failed", "error"
         )
         return {}
 


### PR DESCRIPTION
fixes:
```
Dec 17 13:17:10 tests.stockfishchess.org pserve[22144]:   File "/home/fishtest/fishtest/server/fishtest/views.py", line 194, in sync_upload
Dec 17 13:17:10 tests.stockfishchess.org pserve[22144]:     "Network upload failed: " + str(response.status_code), "error"
Dec 17 13:17:10 tests.stockfishchess.org pserve[22144]: UnboundLocalError: local variable 'response' referenced before assignment
```