### PR TITLE
Do not delete a task after purging but mark it as bad.

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -355,21 +355,27 @@
     <tbody>
       % for idx, task in enumerate(run['tasks'] + run.get('bad_tasks', [])):
           <%
+            if task in run["tasks"] and "bad" in task:
+              continue
+            if "task_id" in task:
+              task_id = task["task_id"]
+            else:
+	      task_id = idx
             stats = task.get('stats', {})
             if 'stats' in task:
               total = stats['wins'] + stats['losses'] + stats['draws']
             else:
               continue
 
-            if idx==show_task:
+            if task_id == show_task:
               active_style = 'highlight'
             elif task['active']:
               active_style = 'info'
             else:
               active_style = ''
           %>
-          <tr class="${active_style}" id=task${idx}>
-            <td><a href=${f"/api/pgn/{run['_id']}-{idx:d}.pgn"}>${idx}</a></td>
+          <tr class="${active_style}" id=task${task_id}>
+            <td><a href=${f"/api/pgn/{run['_id']}-{task_id:d}.pgn"}>${task_id}</a></td>
             % if 'bad' in task:
                 <td style="text-decoration:line-through; background-color:#ffebeb">
             % else:

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -45,6 +45,8 @@ def get_chi2(tasks, exclude_workers=set()):
     users = {}
     has_pentanomial = None
     for task in tasks:
+        if "bad" in task:
+            continue
         if "worker_info" not in task:
             continue
         key = task["worker_info"]["unique_key"]
@@ -191,6 +193,8 @@ def update_residuals(tasks, cached_chi2=None):
     residuals = chi2["residual"]
 
     for task in tasks:
+        if "bad" in task:
+            continue
         if "worker_info" not in task:
             continue
         task["residual"] = residuals.get(


### PR DESCRIPTION
With the current code a purged task is deleted from the task list. This means that the numbering of tasks changes.

One consequence of this is that links to tasks in the event log may become invalid.

Another issue is that task_id's held by the worker become invalid. This is unlikely to cause problems but it is still not nice and could lead to bugs later.

In this PR we mark a purged task as bad. For safety we also make it non-active and set all its stats to zero.

