### PR TITLE
Faster rendering and no more artifacts when processing ?show_task=xxx.

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -10,6 +10,7 @@
 
 % if show_task >= 0:
 <script>
+  document.documentElement.style="scroll-behavior:auto !important; visibility:hidden !important;";
   function scroll_to(task_id) {
     document.getElementById("task" + task_id)
       .scrollIntoView();
@@ -626,6 +627,7 @@
     .then( () => {
     % if show_task >= 0:
       scroll_to(${show_task});
+      document.documentElement.style="visibility:visible !important;";
     % endif
     });
 </script>


### PR DESCRIPTION
We set `scroll-behavior` to `auto` (instantaneous scrolling) and we only make the page visible when the scrolling is complete.