### PR TITLE
Simplified main loop in live_elo.js.

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -142,6 +142,20 @@ function supportsNotifications() {
   return false;
 }
 
+function raise_for_status(response) {
+  // A useful function from the python requests package
+  if (response.ok) {
+    return;
+  }
+  throw `request failed with status code ${response.status}`;
+}
+
+async function fetch_json(url) {
+  const response = await fetch(url);
+  raise_for_status(response);
+  return response.json();
+}
+
 function DOM_loaded() {
   // Use as
   // await DOM_loaded();

--- a/server/fishtest/static/js/live_elo.js
+++ b/server/fishtest/static/js/live_elo.js
@@ -198,30 +198,23 @@ async function follow_live(test_id) {
     set_gauges(j.LLR, j.a, j.b, j.LOS, j.elo, j.ci_lower, j.ci_upper);
   }
 
-  // Main worker.
+  // Main worker
 
   let handled_once = false;
   while (true) {
     const timestamp = new Date().getTime();
-    let response = null;
     try {
-      response = await fetch("/api/get_elo/" + test_id + "?" + timestamp);
-    } catch (e) {
-      await async_sleep(20000);
-      continue;
-    }
-    if (response.ok) {
-      const m = await response.json();
-      if (m) {
-        display_data(m);
-        if (m.args.sprt.state) {
-          if (handled_once) {
-            notify(m.args.new_tag, m.args.sprt.state, m.elo.elo);
-          }
-          return;
+      const m = await fetch_json("/api/get_elo/" + test_id + "?" + timestamp);
+      display_data(m);
+      if (m.args.sprt.state) {
+        if (handled_once) {
+          notify(m.args.new_tag, m.args.sprt.state, m.elo.elo);
         }
-        handled_once = true;
+        return;
       }
+      handled_once = true;
+    } catch (e) {
+      console.log("Network error: " + e);
     }
     await async_sleep(20000);
   }


### PR DESCRIPTION
It should also be robust now. All error paths were tested.

To simplify the logic we implement `raise_for_status()` as in the python requests package.