### PR TITLE
Adapt links on the events log to the run_id parameter.

### DIFF
--- a/server/fishtest/templates/actions.mak
+++ b/server/fishtest/templates/actions.mak
@@ -110,7 +110,7 @@
       % for action in actions:
           <tr>
             ## Dates in mongodb have millisecond precision. So they fit comfortably in a float without precision loss.
-            <td><a href="/actions?max_actions=1&amp;action=${action_param}&amp;user=${username_param|u,n}&amp;text=${text_param|u,n}&amp;before=${action['time'].replace(tzinfo=datetime.timezone.utc).timestamp()}">
+            <td><a href="/actions?max_actions=1&amp;action=${action_param}&amp;user=${username_param|u,n}&amp;text=${text_param|u,n}&amp;before=${action['time'].replace(tzinfo=datetime.timezone.utc).timestamp()}&amp;run_id=${run_id_param}">
              ${action['time'].strftime(r"%y&#8209;%m&#8209;%d %H:%M:%S")|n}</a></td>
             <td>${action['action']}</td>
 	    <%

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -361,7 +361,7 @@ def actions(request):
     text = sanitize_quotation_marks(request.params.get("text", ""))
     before = request.params.get("before", None)
     max_actions = request.params.get("max_actions", None)
-    run_id = request.params.get("run_id", None)
+    run_id = request.params.get("run_id", "")
 
     utc_before = before
     if before:
@@ -396,6 +396,8 @@ def actions(request):
             page["url"] += "&max_actions={}".format(num_actions)
         if before:
             page["url"] += "&before={}".format(before)
+        if run_id:
+            page["url"] += "&run_id={}".format(run_id)
 
     return {
         "actions": actions,
@@ -404,6 +406,7 @@ def actions(request):
         "action_param": search_action,
         "username_param": username,
         "text_param": text,
+        "run_id_param": run_id,
     }
 
 


### PR DESCRIPTION
The pagination was not tested since on my local fishtest I don't have events associated with runs spanning multiple pages.