### PR TITLE
Create an api for querying the event log.

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -68,6 +68,7 @@ def main(global_config, **settings):
     config.add_static_view("css", "static/css", cache_max_age=3600)
     config.add_static_view("js", "static/js", cache_max_age=3600)
     config.add_static_view("img", "static/img", cache_max_age=3600)
+    config.add_static_view("html", "static/html", cache_max_age=3600)
 
     config.add_route("home", "/")
     config.add_route("login", "/login")
@@ -114,6 +115,7 @@ def main(global_config, **settings):
     config.add_route("api_download_pgn_100", "/api/pgn_100/{skip}")
     config.add_route("api_download_nn", "/api/nn/{id}")
     config.add_route("api_get_elo", "/api/get_elo/{id}")
+    config.add_route("api_actions", "/api/actions")
 
     config.scan()
     return config.make_wsgi_app()

--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -1,6 +1,6 @@
 import base64
 import copy
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 import requests
 from fishtest.stats.stat_util import SPRT_elo
@@ -310,6 +310,25 @@ class ApiView(object):
         for run in self.request.rundb.get_unfinished_runs():
             active[str(run["_id"])] = strip_run(run)
         return active
+
+    @view_config(route_name="api_actions")
+    def actions(self):
+        try:
+            query = self.request.json_body
+            actions = self.request.rundb.db["actions"].find(query).limit(200)
+        except:
+            actions = []
+        ret = []
+        for action in actions:
+            action["_id"] = str(action["_id"])
+            if "run_id" in action:
+                action["run_id"] = str(action["run_id"])
+            if "time" in action:
+                action["time"] = action["time"].replace(tzinfo=timezone.utc).timestamp()
+            ret.append(action)
+        self.request.response.headers["access-control-allow-origin"] = "*"
+        self.request.response.headers["access-control-allow-headers"] = "content-type"
+        return ret
 
     @view_config(route_name="api_get_run")
     def get_run(self):

--- a/server/fishtest/static/html/finished_runs.html
+++ b/server/fishtest/static/html/finished_runs.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head> </head>
+  <body>
+    <script>
+      // Example script to demonstrate the api.
+      // Not used by Fishtest.
+
+      URL = "/api/actions";
+
+      payload = { action: "finished_run" };
+
+      function async_sleep(ms) {
+        return new Promise((resolve, reject) => {
+          setTimeout(resolve, ms);
+        });
+      }
+
+      async function doit() {
+        while (true) {
+          try {
+            response = await fetch(URL, {
+              method: "POST",
+              mode: "cors",
+              cache: "no-cache",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(payload),
+            });
+          } catch (e) {
+            console.log(e);
+            return;
+          }
+          if (response.ok) {
+            json = await response.json();
+          } else {
+            console.log("response.status=" + response.status);
+            return;
+          }
+          document.body.innerText = JSON.stringify(json);
+          await async_sleep(10000);
+        }
+      }
+
+      doit();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
A valid request consists of a POST request with a body that is a stringified version of the json query.

The response is limited to 200 events.

To test the api there is an example document

<server>/html/finished_runs.html

This will be removed later.