### PR TITLE
Some enhancements

### DIFF
--- a/server/fishtest/static/js/notifications.js
+++ b/server/fishtest/static/js/notifications.js
@@ -47,26 +47,49 @@ LRU.load = function (name) {
 };
 
 const fishtest_notifications_key = "fishtest_notifications";
+const fishtest_broadcast_key = "fishtest_broadcast";
 
-let current_nofitication = "";
+function notify_fishtest_(message) {
+  const div = document.getElementById("fallback_div");
+  const span = document.getElementById("fallback");
+  const fallback_div = document.getElementById("fallback_div");
+  if (fallback_div.style.display == "none") {
+    span.innerHTML = message;
+  } else {
+    span.innerHTML += "<hr> " + title + " " + body;
+  }
+  div.style.display = "block";
+}
+
+function notify_fishtest(message) {
+  notify_fishtest_(message);
+  broadcast_fishtest(message);
+}
+
+function broadcast_fishtest(message) {
+  localStorage.setItem(
+    fishtest_broadcast_key,
+    JSON.stringify({ message: message, rnd: Math.random() })
+  );
+}
+
+window.addEventListener("storage", (event) => {
+  if (event.key == fishtest_broadcast_key) {
+    notify_fishtest_(JSON.parse(event.newValue)["message"]);
+  }
+});
+
 function notify_elo(entry) {
   const tag = entry["run"].slice(0, -8);
   const message = entry["message"];
+  const username = entry["username"];
   const color = message.split(" ")[0].split(":")[1];
   const elo = message.split(" ")[1];
   const LOS = message.split(" ")[2];
-  const title = `Test ${tag} finished ${color}!`;
+  const title = `Test ${tag} by ${username} finished ${color}!`;
   const body = elo + " " + LOS;
   notify(title, body, (title, body) => {
-    const div = document.getElementById("fallback_div");
-    const span = document.getElementById("fallback");
-    const fallback_div = document.getElementById("fallback_div");
-    if (fallback_div.style.display == "none") {
-      span.innerHTML = title + " " + body;
-    } else {
-      span.innerHTML += "<hr> " + title + " " + body;
-    }
-    div.style.display = "block";
+    notify_fishtest(title + " " + body);
   });
 }
 
@@ -157,8 +180,8 @@ function set_follow_button(run_id) {
 }
 
 async function handle_follow_button(run_id) {
-    await DOM_loaded();
-    window.addEventListener("storage", (event) => {
+  await DOM_loaded();
+  window.addEventListener("storage", (event) => {
     if (event.key == fishtest_notifications_key) {
       set_follow_button(run_id);
     }

--- a/server/fishtest/static/js/notifications.js
+++ b/server/fishtest/static/js/notifications.js
@@ -49,6 +49,22 @@ LRU.load = function (name) {
 const fishtest_notifications_key = "fishtest_notifications";
 const fishtest_broadcast_key = "fishtest_broadcast";
 
+async function process_title(count) {
+  // async because the document title is set in javascript
+  await DOM_loaded();
+  title = document.title;
+  // check if there is already a number
+  if (/\([\d]+\)/.test(title)) {
+    title = title.split(") ")[1]; // if so, remove it
+  }
+  // add it again if necessary
+  if (count > 0) {
+    document.title = `(${count}) ${title}`;
+  } else {
+    document.title = title;
+  }
+}
+
 function notify_fishtest_(message) {
   const div = document.getElementById("fallback_div");
   const span = document.getElementById("fallback");
@@ -56,8 +72,10 @@ function notify_fishtest_(message) {
   if (fallback_div.style.display == "none") {
     span.innerHTML = message;
   } else {
-    span.innerHTML += "<hr> " + title + " " + body;
+    span.innerHTML += "<hr> " + message;
   }
+  let count = span.innerHTML.split("<hr").length;
+  process_title(count);
   div.style.display = "block";
 }
 

--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -233,6 +233,8 @@
                     // The bootstrap dismiss destroys the alert. So we roll our own.
                     const div = document.getElementById("fallback_div");
                     div.style.display = "none";
+		    // remove message count from the title
+		    process_title(0);
                   }
                   const fallback_button = document.getElementById("fallback_button");
                   fallback_button.addEventListener("click", dismiss_notification);

--- a/server/fishtest/templates/run_tables.mak
+++ b/server/fishtest/templates/run_tables.mak
@@ -18,7 +18,6 @@
   }
 
   function handle_notification(notification) {
-    console.log("in handle_notification");
     run_id = notification.id.split("_")[1];
     if(!following_run(run_id)){
       if (supportsNotifications() && Notification.permission === "default") {


### PR DESCRIPTION
The PR has two independent commits

- Display the bootstrap notifications in all fishtest browser windows (currently a bootstrap notification is displayed only once, like a system notifications).

- Display the number of received (and non closed) notifications in the title of the tab.