### PR TITLE
Parameters Tweak New Bounds (0 , 2)

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -334,7 +334,7 @@
                   <select class="form-select" id="bounds" name="bounds">
                     <option value="standard STC">Standard STC ${fb(0.0, 2.0)}</option>
                     <option value="standard LTC">Standard LTC ${fb(0.5, 2.5)}</option>
-                    <option value="Parameter's Tweak LTC">Parameter's Tweak LTC ${fb(0, 2)}</option>
+                    <option value="Parameters Tweak LTC">Parameters Tweak LTC ${fb(0, 2)}</option>
                     <option value="regression STC">Non-regression STC ${fb(-1.75, 0.25)}</option>
                     <option value="regression LTC">Non-regression LTC ${fb(-1.75, 0.25)}</option>
                     <option value="custom" ${'selected' if is_rerun else ''}>Custom bounds...</option>
@@ -653,7 +653,7 @@
   const preset_bounds = {
     'standard STC': [ 0.0, 2.0],
     'standard LTC': [ 0.5, 2.5],
-    'Parameter's Tweak LTC': [ 0.0, 2.0],
+    'Parameters Tweak LTC': [ 0.0, 2.0],
     'regression STC': [-1.75, 0.25],
     'regression LTC': [-1.75, 0.25],
   };

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -334,7 +334,7 @@
                   <select class="form-select" id="bounds" name="bounds">
                     <option value="standard STC">Standard STC ${fb(0.0, 2.0)}</option>
                     <option value="standard LTC">Standard LTC ${fb(0.5, 2.5)}</option>
-                    <option value="Parameter's Tweak LTC">Standard LTC ${fb(0, 2)}</option>
+                    <option value="Parameter's Tweak LTC">Parameter's Tweak LTC ${fb(0, 2)}</option>
                     <option value="regression STC">Non-regression STC ${fb(-1.75, 0.25)}</option>
                     <option value="regression LTC">Non-regression LTC ${fb(-1.75, 0.25)}</option>
                     <option value="custom" ${'selected' if is_rerun else ''}>Custom bounds...</option>

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -334,6 +334,7 @@
                   <select class="form-select" id="bounds" name="bounds">
                     <option value="standard STC">Standard STC ${fb(0.0, 2.0)}</option>
                     <option value="standard LTC">Standard LTC ${fb(0.5, 2.5)}</option>
+                    <option value="Parameter's Tweak LTC">Standard LTC ${fb(0, 2)}</option>
                     <option value="regression STC">Non-regression STC ${fb(-1.75, 0.25)}</option>
                     <option value="regression LTC">Non-regression LTC ${fb(-1.75, 0.25)}</option>
                     <option value="custom" ${'selected' if is_rerun else ''}>Custom bounds...</option>

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -653,6 +653,7 @@
   const preset_bounds = {
     'standard STC': [ 0.0, 2.0],
     'standard LTC': [ 0.5, 2.5],
+    'Parameter's Tweak LTC': [ 0.0, 2.0],
     'regression STC': [-1.75, 0.25],
     'regression LTC': [-1.75, 0.25],
   };


### PR DESCRIPTION
I suggest changing the LTC bounds for the patches that only change the values of parameters, without touching anything else, from <0.5, 2.5> to <0, 2> As there is no complexity addition in these types of patches. And if it proves to pass STC and LTC both of them at <0, 2> bounds, this should confirm that the patch is good enough to be merged. This should also help in getting out local max/min.

For a very long time, in Fishtest history, we had easier bounds for parameters-tweak patches, so is not something against the logic of Stockfish maintainers.
The "paramater-tweak-only patches" does not increase the complexity at all, so the code would remain basically the same.
And having more parameters-tweak patches being merged would help in improving the engine overall by getting out local max/min, and by improving the strength of the engine even if by only 0.75 Elo each time.