### PR TITLE
Reduce latency of LTC relative to STC

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -599,10 +599,7 @@ class RunDb:
 
     def calc_itp(self, run):
         itp = run["args"]["throughput"]
-        if itp < 1:
-            itp = 1
-        elif itp > 500:
-            itp = 500
+        itp = max(min(itp, 500), 1)
 
         # Base TP derived from power law of TC relative to STC
         tc_ratio = run["args"]["threads"] * estimate_game_duration(run["args"]["tc"]) \

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -613,11 +613,17 @@ class RunDb:
             # => LTC base tp = 4 => log(4)/log(6) ~ 0.774
             itp *= tc_ratio**0.774
 
-        # TP bonus derived from LLR (or min-bonus for nonSPRTs)
+        # Gentle bonus/malus for positive/negative LLR (non-SPRTs are like worst LLR)
         llr = -2.94
         if "sprt" in run["args"]:
-            llr = run["args"]["sprt"].get("llr", 0)
+            # Sanity check that we're no lower than standard lower bound
+            llr = max(llr, run["args"]["sprt"].get("llr", 0))
         itp *= (llr + 8) / 8 # max/min bonus 1.37/0.63
+
+        # Extra bonus for most promising tests -- LTC at strong-gainer bounds with good LLR
+        if tc_ratio >= 3.0 and llr > 1.5 \
+           and run["args"].get("sprt", {}).get("elo0", 0) > 0:
+            itp *= 1.2 # LLR 1.5 bonus from 1.19 to 1.42, LLR 2.9 bonus from 1.36 to 1.64
 
         run["args"]["itp"] = itp
 


### PR DESCRIPTION
Adjust the TC power law exponent to make base LTC TP of 4x STC TP, with the goal of reducing LTC latency to only 1.5x STC latency.

With the recent of busyness of fishtest (a good thing IMO), the current LTC latency of sqrt(6) ~ 2.5x is making for painfully long feedback time, potentially causing authors to submit more later-unnecessary STC tests rather than wait for LTC results. The latency is actually more than 2.5x on average since LTC elo bounds are higher as well, requiring more games at the same elo performance (on average).

This adjustment reduces LTC base latency from 2.5x to 1.5x, which should hopefully reduce the number of red-herring STC submissions as the test result feedback loop tightens up.

Edit: And, quite aside from red-herring STCs and test result feedback loops, the simple fact of semantically overlapping tests taking a while even while master changes "underneath them" could lead to conflicts of results and ideas, leading to more wasted tests and/or untried ideas. In other words, there are multiple ways in which this patch should benefit stockfish.

I also tweaked the LLR bonus TP, reducing it slightly on both ends, but I'm not nearly as attached to this as to the exponent change. (1.37/0.63 new max/min vs old max/min 1.59/0.41)

Also, don't boost shorter-than-STC latency.