### PR TITLE
Final itp adjustments

### DIFF
--- a/server/fishtest/templates/run_table.mak
+++ b/server/fishtest/templates/run_table.mak
@@ -116,8 +116,9 @@
                 % endif
                 @ ${run['args']['tc']} th ${str(run['args'].get('threads',1))}
                 <br>
-                ${f"itp: {round(run['args']['itp'])} " if not run['finished'] else ''}
-                ${f"cores: {run['cores']}" if not run['finished'] and 'cores' in run else ''}
+                % if not run['finished']:
+                    ${f"cores: {run.get('cores', '')} ({run.get('workers', '')})"}
+                % endif
               </td>
 
               <td class="run-info">

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -31,7 +31,7 @@ def new_run(self, add_tasks=0):
     run = self.rundb.get_run(run_id)
     run["approved"] = True
     if add_tasks > 0:
-        run["cores"] = 0
+        run["workers"] = run["cores"] = 0
         for i in range(add_tasks):
             task = {
                 "num_games": self.chunk_size,
@@ -39,6 +39,7 @@ def new_run(self, add_tasks=0):
                 "active": True,
                 "worker_info": self.worker_info,
             }
+            run["workers"] += 1
             run["cores"] += self.worker_info["concurrency"]
             run["tasks"].append(task)
     self.rundb.buffer(run, True)
@@ -184,6 +185,7 @@ class TestApi(unittest.TestCase):
 
         run = self.rundb.get_run(run_id)
         self.assertEqual(len(run["tasks"]), 1)
+        self.assertEqual(run["workers"], 1)
         self.assertEqual(run["cores"], self.concurrency)
         task = run["tasks"][task_id]
         self.assertTrue(task["active"])

--- a/server/tests/test_rundb.py
+++ b/server/tests/test_rundb.py
@@ -109,7 +109,7 @@ class CreateRunDBTest(unittest.TestCase):
         self.assertTrue(run["tasks"][0]["active"])
         run["tasks"][0]["active"] = True
         run["tasks"][0]["worker_info"] = self.worker_info
-        run["cores"] = 1
+        run["workers"] = run["cores"] = 1
 
         for run in self.rundb.get_unfinished_runs():
             if run["args"]["username"] == "travis":
@@ -119,7 +119,7 @@ class CreateRunDBTest(unittest.TestCase):
         run = self.rundb.get_run(run_id)
         run["tasks"][0]["active"] = True
         run["tasks"][0]["worker_info"] = self.worker_info
-        run["cores"] = 1
+        run["workers"] = run["cores"] = 1
         self.rundb.buffer(run, True)
         run = self.rundb.update_task(
             self.worker_info,

--- a/server/utils/upgrade.py
+++ b/server/utils/upgrade.py
@@ -52,6 +52,7 @@ run_default = {
     "finished": True,
     "approved": True,
     "approver": "?",
+    "workers": 0,
     "cores": 0,
     "results": {
         "wins": 0,


### PR DESCRIPTION
1) remove itp from run table

2) add worker count to run table like so: `cores: 150 (2)` (open to feedback)

3) adjust the itp LLR bonus to a tighter window, with asymmetric bonus (reward good LLR more than punish bad) (see commit message)