### PR TITLE
Reduce "LTC only" thread threshold

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -826,7 +826,7 @@ class RunDb:
             # probably due to cutechess-cli as discussed in issue #822,
             # assign linux workers to LTC or multi-threaded jobs
             # and windows workers only to LTC jobs
-            if max_threads > 32:
+            if max_threads >= 29:
                 if "windows" in worker_info["uname"].lower():
                     short_tc = estimate_game_duration(
                         run["args"]["tc"]


### PR DESCRIPTION
Several workers in the last month between 30 and 32 threads have fallen afoul of the well-established cutechess bugs in many-threaded contexts. Altho most such workers run fine, we currently have no server-side filtering of garbage results, nor any worker-side workaround, so this is the best we've got. Update it now to reduce future garbage with the least current effort.

As stated, most workers in the 29-32 thread run fine, but those that don't are a significant problem. To the best of my knowledge, all workers at 28 or less have run fine so far. It's certainly easy to adjust this again in the future.