### PR TITLE
Add itp tooltip to each run's core count

### DIFF
--- a/server/fishtest/templates/run_table.mak
+++ b/server/fishtest/templates/run_table.mak
@@ -119,7 +119,7 @@
                     ${run['args']['tc']} th ${str(run['args'].get('threads',1))}
                 </span>
                 % if not run['finished']:
-                    <div>
+                    <div title="${f"itp: {run["itp"]:d}, c/i: {run["cores"]/run["itp"]:.2f}"}">
                         ${f"cores: {run.get('cores', '')} ({run.get('workers', '')})"}
                     </div>
                 % endif


### PR DESCRIPTION
Allows site experts to better keep the finger on the pulse without overwhelming newbs