### PR TITLE
Reject time losses mid-run, take 2

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -78,8 +78,8 @@ def strip_run(run):
     run = copy.deepcopy(run)
     if "tasks" in run:
         run["tasks"] = []
-    if "bad_tasks" in run:
-        run["bad_tasks"] = []
+    if "purged_tasks" in run:
+        run["purged_tasks"] = []
     if "spsa" in run["args"] and "param_history" in run["args"]["spsa"]:
         run["args"]["spsa"]["param_history"] = []
     run["_id"] = str(run["_id"])
@@ -338,9 +338,9 @@ class ApiView(object):
         try:
             run = self.request.rundb.get_run(self.request.matchdict["id"])
             task_id = self.request.matchdict["task_id"]
-            if task_id.endswith("bad"):
+            if task_id.endswith("bad"): # Where in the code is this made so?
                 task_id = int(task_id[:-3])
-                task = copy.deepcopy(run["bad_tasks"][task_id])
+                task = copy.deepcopy(run["purged_tasks"][task_id])
             else:
                 task_id = int(task_id)
                 task = copy.deepcopy(run["tasks"][task_id])

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -1248,18 +1248,10 @@ class RunDb:
         if run.get("failed", False):
             return "You cannot purge, and thus revive, a failed run"
         message = "No bad workers"
-
-        # Transfer bad tasks to run["bad_tasks"], by crashes/time losses
         if "bad_tasks" not in run:
             run["bad_tasks"] = []
-        zero_stats = {
-            "wins": 0,
-            "losses": 0,
-            "draws": 0,
-            "crashes": 0,
-            "time_losses": 0,
-            "pentanomial": 5 * [0],
-        }
+
+        # First, filter and mark bad tasks to run["bad_tasks"] by crashes/time losses
         tasks = copy.copy(run["tasks"])
         for task_id, task in enumerate(tasks):
             if "bad" in task:
@@ -1267,28 +1259,12 @@ class RunDb:
             # Special cases: crashes or time losses.
             if crash_or_time(task):
                 message = ""
-                bad_task = copy.deepcopy(task)
-                # The next two lines are a bit hacky but
-                # the correct residual and color may not have
-                # been set yet.
-                task_mark_failed(bad_task, 10.0)
-                bad_task["task_id"] = task_id
-                bad_task["bad"] = True
-                run["bad_tasks"].append(bad_task)
-                # Rather than removing the task, we mark
-                # it as bad.
-                # In this way the numbering of tasks
-                # does not change.
-                # For safety we also set the stats
-                # to zero.
-                task["bad"] = True
-                task["active"] = False
-                task["stats"] = copy.deepcopy(zero_stats)
+                run["bad_tasks"].append(task_mark_bad_and_copy(task))
 
         chi2 = get_chi2(run["tasks"])
         # Make sure the residuals are up to date. Once a task is moved to
         # run["bad_tasks"] its residual will no longer change.
-        update_residuals(run["tasks"], chi2=chi2)
+        update_residuals(run["tasks"], chi2=chi2) # Marks residual color (and calls crash_or_time, marking such failures)
         bad_workers = get_bad_workers_by_residual(
             run["tasks"],
             chi2=chi2,
@@ -1296,20 +1272,14 @@ class RunDb:
             res=res,
             iters=iters - 1 if message == "" else iters,
         )
-        # Once again we filter bad tasks into run["bad_tasks"], this time by residual
+        # Second, filter and mark bad tasks to run["bad_tasks"] by residual
         tasks = copy.copy(run["tasks"])
         for task_id, task in enumerate(tasks):
             if "bad" in task:
                 continue
             if task["worker_info"]["unique_key"] in bad_workers:
                 message = ""
-                bad_task = copy.deepcopy(task)
-                bad_task["task_id"] = task_id
-                bad_task["bad"] = True
-                run["bad_tasks"].append(bad_task)
-                task["bad"] = True
-                task["active"] = False
-                task["stats"] = copy.deepcopy(zero_stats)
+                run["bad_tasks"].append(task_mark_bad_and_copy(task))
 
         if message == "":
             run["results_stale"] = True

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -1271,8 +1271,7 @@ class RunDb:
                 # The next two lines are a bit hacky but
                 # the correct residual and color may not have
                 # been set yet.
-                bad_task["residual"] = 10.0
-                bad_task["residual_color"] = "#FF6A6A"
+                task_mark_failed(bad_task, 10.0)
                 bad_task["task_id"] = task_id
                 bad_task["bad"] = True
                 run["bad_tasks"].append(bad_task)

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -389,9 +389,9 @@
       </tr>
     </thead>
     <tbody>
-      % for idx, task in enumerate(run['tasks'] + run.get('bad_tasks', [])):
+      % for idx, task in enumerate(run['tasks'] + run.get('purged_tasks', [])):
           <%
-            if task in run["tasks"] and "bad" in task:
+            if task in run["tasks"] and "purged" in task:
               continue
             if "task_id" in task:
               task_id = task["task_id"]
@@ -412,7 +412,7 @@
           %>
           <tr class="${active_style}" id=task${task_id}>
             <td><a href=${f"/api/pgn/{run['_id']}-{task_id:d}.pgn"}>${task_id}</a></td>
-            % if 'bad' in task:
+            % if 'purged' in task:
                 <td style="text-decoration:line-through; background-color:#ffebeb">
             % else:
                 <td>

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -47,9 +47,9 @@ def crash_or_time(task):
     total = stats.get("wins", 0) + stats.get("losses", 0) + stats.get("draws", 0)
     crashes = stats.get("crashes", 0)
     time_losses = stats.get("time_losses", 0)
-    failed = crashes > 3 or (total > 20 and time_losses / total > 0.1)
+    failed = crashes > 3 or (time_losses * 25 > total + 25)
     if failed:
-        task_mark_excessive_residual(task, 11.0)
+        task_mark_excessive_residual(task, 10.0)
     return failed
 
 

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -550,3 +550,15 @@ def get_hash(s):
     if h:
         return int(h.group(1))
     return 0
+
+
+class BinaryHistory:
+    def __init__(self, n):
+        self._n = n
+        self._l = n * [False]
+        self._i = 0
+    def update(self, bit):
+        self._l[self._i] = bool(bit)
+        self._i = (self._i + 1) % self._n
+    def sum(self):
+        return sum(self._;)

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -53,12 +53,11 @@ def crash_or_time(task):
     return failed
 
 
-def task_mark_bad_and_copy(task):
-    # To preserve the number of tasks, we mark it as bad without removing it.
-    bad_task = copy.deepcopy(task)
-    bad_task["task_id"] = task_id
-    bad_task["bad"] = True
-    task["bad"] = True
+def task_purge_and_copy(task):
+    # To preserve the number of tasks, we mark it as purged without removing it.
+    purged_task = copy.deepcopy(task)
+    purged_task["task_id"] = task_id
+    purged_task["purged"] = task["purged"] = True
     task["active"] = False
     task["stats"] = {
             "wins": 0,
@@ -68,7 +67,7 @@ def task_mark_bad_and_copy(task):
             "time_losses": 0,
             "pentanomial": 5 * [0],
     })
-    return bad_task
+    return purged_task
 
 
 def get_chi2(tasks, exclude_workers=set()): # All (global) invocations of this function share the same set() (!)
@@ -87,9 +86,7 @@ def get_chi2(tasks, exclude_workers=set()): # All (global) invocations of this f
     users = {}
     has_pentanomial = None
     for task in tasks:
-        if "bad" in task:
-            continue
-        if "worker_info" not in task:
+        if "purged" in task or "worker_info" not in task:
             continue
         key = task["worker_info"]["unique_key"]
         if key in exclude_workers:
@@ -199,7 +196,7 @@ def update_residuals(tasks, chi2=None):
     residuals = chi2["residual"]
 
     for task in tasks:
-        if "bad" in task or crash_or_time(task) or "worker_info" not in task:
+        if "purged" in task or crash_or_time(task) or "worker_info" not in task:
             continue
 
         task["residual"] = residuals.get(

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -191,29 +191,6 @@ def get_chi2(tasks, exclude_workers=set()): # All (global) invocations of this f
     }
 
 
-def get_bad_workers_by_residual(tasks, chi2=None, p=0.001, res=7.0, iters=1):
-    # If we have an up-to-date result of get_chi2(), pass it to avoid needless
-    # recomputation.
-    bad_workers = set()
-    for _ in range(iters):
-        if chi2 is None:
-            chi2 = get_chi2(tasks, exclude_workers=bad_workers)
-        worst_user = {}
-        residuals = chi2["residual"]
-        for worker_key in residuals:
-            if worker_key in bad_workers:
-                continue
-            if chi2["p"] < p or residuals[worker_key] > res:
-                if worst_user == {} or residuals[worker_key] > worst_user["residual"]:
-                    worst_user["unique_key"] = worker_key
-                    worst_user["residual"] = residuals[worker_key]
-        if worst_user == {}:
-            break
-        bad_workers.add(worst_user["unique_key"])
-
-    return bad_workers
-
-
 def update_residuals(tasks, chi2=None):
     # If we have an up-to-date result of get_chi2(), pass it to avoid needless
     # recomputation.
@@ -235,6 +212,29 @@ def update_residuals(tasks, chi2=None):
             task["residual_color"] = "yellow"
         else:
             task_mark_excessive_residual(task)
+
+
+def get_bad_workers_by_residual(tasks, chi2=None, p=0.001, res=7.0, iters=1):
+    # If we have an up-to-date result of get_chi2(), pass it to avoid needless
+    # recomputation.
+    bad_workers = set()
+    for _ in range(iters):
+        if chi2 is None:
+            chi2 = get_chi2(tasks, exclude_workers=bad_workers)
+        worst_user = {}
+        residuals = chi2["residual"]
+        for worker_key in residuals:
+            if worker_key in bad_workers:
+                continue
+            if chi2["p"] < p or residuals[worker_key] > res:
+                if worst_user == {} or residuals[worker_key] > worst_user["residual"]:
+                    worst_user["unique_key"] = worker_key
+                    worst_user["residual"] = residuals[worker_key]
+        if worst_user == {}:
+            break
+        bad_workers.add(worst_user["unique_key"])
+
+    return bad_workers
 
 
 def format_bounds(elo_model, elo0, elo1):

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -156,6 +156,12 @@ def get_chi2(tasks, exclude_workers=set()): # All (global) invocations of this f
     }
 
 
+def task_mark_failed(task, residual=None):
+    if residual is not None:
+        task["residual"] = residual
+    task["residual_color"] = "#FF6A6A"
+
+
 def crash_or_time(task):
     stats = task.get("stats", {})
     total = stats.get("wins", 0) + stats.get("losses", 0) + stats.get("draws", 0)
@@ -204,14 +210,13 @@ def update_residuals(tasks, chi2=None):
         )
 
         if crash_or_time(task):
-            task["residual"] = 10.0
-            task["residual_color"] = "#FF6A6A"
+            task_mark_failed(task, 10.0)
         elif abs(task["residual"]) < chi2["z_95"]:
             task["residual_color"] = "#44EB44"
         elif abs(task["residual"]) < chi2["z_99"]:
             task["residual_color"] = "yellow"
         else:
-            task["residual_color"] = "#FF6A6A"
+            task_mark_failed(task)
 
 
 def format_bounds(elo_model, elo0, elo1):

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -36,7 +36,7 @@ def worker_name(worker_info):
     return name
 
 
-def get_chi2(tasks, exclude_workers=set()):
+def get_chi2(tasks, exclude_workers=set()): # All (global) invocations of this function share the same set() (!)
     """Perform chi^2 test on the stats from each worker"""
 
     default_results = {
@@ -164,16 +164,13 @@ def crash_or_time(task):
     return crashes > 3 or (total > 20 and time_losses / total > 0.1)
 
 
-def get_bad_workers(tasks, cached_chi2=None, p=0.001, res=7.0, iters=1):
-    # If we have an up-to-date result of get_chi2() we can pass
-    # it as cached_chi2 to avoid needless recomputation.
+def get_bad_workers_by_residual(tasks, chi2=None, p=0.001, res=7.0, iters=1):
+    # If we have an up-to-date result of get_chi2(), pass it to avoid needless
+    # recomputation.
     bad_workers = set()
     for _ in range(iters):
-        if cached_chi2 is None:
+        if chi2 is None:
             chi2 = get_chi2(tasks, exclude_workers=bad_workers)
-        else:
-            chi2 = cached_chi2
-            cached_chi2 = None
         worst_user = {}
         residuals = chi2["residual"]
         for worker_key in residuals:
@@ -190,13 +187,11 @@ def get_bad_workers(tasks, cached_chi2=None, p=0.001, res=7.0, iters=1):
     return bad_workers
 
 
-def update_residuals(tasks, cached_chi2=None):
-    # If we have an up-to-date result of get_chi2() we can pass
-    # it as cached_chi2 to avoid needless recomputation.
-    if cached_chi2 is None:
+def update_residuals(tasks, chi2=None):
+    # If we have an up-to-date result of get_chi2(), pass it to avoid needless
+    # recomputation.
+    if chi2 is None:
         chi2 = get_chi2(tasks)
-    else:
-        chi2 = cached_chi2
     residuals = chi2["residual"]
 
     for task in tasks:

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1282,7 +1282,7 @@ def tests_view(request):
         task["last_updated"] = last_updated
 
     chi2 = get_chi2(run["tasks"])
-    update_residuals(run["tasks"], cached_chi2=chi2)
+    update_residuals(run["tasks"], chi2=chi2)
 
     try:
         show_task = int(request.params.get("show_task", -1))


### PR DESCRIPTION
Considerably more sophisticated than my prior attempt some months ago. There's a lot going on here.

The first 6 commits are very nearly non functional, being solely cleanups and refactorings which were necessary for me to even hope to be able to understand what I was modifying (and even then I'm only like 80% sure). Even if the functionality of this PR is rejected, the first 6 commits of cleanups and refactoring should be considered/merged independently. (The third commit is slightly functional, but only the slightest bit, I believe only cosmetically.)

The last two commits are the meat of the proposed new functionality. Instead of waiting until the run is "over" to autopurge `crash_or_time` tasks (if autopurge is even set, which it usually is not), we purge them immediately, mid-run, if the worker has a recent history of spewing garbage.

My usual caveat applies: this is completely untested, and even more than that, I'm not even entirely sure that the last two commits are correct, in the sense of doing what I intended. In any case, I believe it should be easier to understand each commit individually than the grand sum diff. All kinds of review/feedback is requested and appreciated.