### PR TITLE
A new option to override default platform version to remove sensitive information displayed to the public in the "System" column of the FishTest website workers list

### DIFF
--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 197, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "/Lu4ip+T1nwF1Wi7yEIIfhUwn0VPz6P7Z/flcnJWIWLjxliLmyLFJAoYHTStaShc", "games.py": "U/LQtRw/dlRyIgOYz+ioiACLnn9Qu/laZOaenm61HHglhcAYpVysgNLlO9bvhFGD"}
+{"__version": 197, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "a3p/OjAI9NdfK/rP11AZCbSlR4f5tYf3CX8DSzuTQ9Wmx8HBSJntIJEuIRAQFiYT", "games.py": "U/LQtRw/dlRyIgOYz+ioiACLnn9Qu/laZOaenm61HHglhcAYpVysgNLlO9bvhFGD"}


### PR DESCRIPTION
There are custom Linux builds that may contain sensitive information that is inappropriate to be sent to the server to be further displayed in the "System" column of the Fishtest website. An example is "Linux 5.15.0-53-contoso". The platform version here is "5.15.0-53-contoso". We have to patch the Fishtest code to remove this sensitive info, e.g.
```
sed -i 's/uname\[2\]/uname2/g' worker.py
sed -i '/    uname = platform.uname()/a\
    uname2 = uname[2].replace("-contoso", "")' worker.py
```
As a result of such patching, the version of Fishtest is displayed in the Worker column as one being modified, i.e. with an asterisk: "197*".

A better alternative would have been an option to override the platform version (one returned in uname[2] of platform.uname(), such as "5.15.0-53-contoso") to have the Python source code of the worker unmodified.

I propose the --platform_release command-line option (-R) and the same config file value, so that the users will be able to pass this information via command line, e.g. 

```
python3 worker.py --platform_release $(uname -r | sed s/-contoso//)
```
