### PR TITLE
When cutechess-cli was already installed before running Fishtest, the engine binaries were searched in the same directory as the initial installation of cutechess-cli

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -1405,7 +1405,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
                 "-engine",
                 "name=New-" + run["args"]["resolved_new"][:10],
                 "tc={}".format(scaled_new_tc),
-                "cmd={}".format(new_engine_name),
+                "cmd=./{}".format(new_engine_name),
                 "dir=.",
             ]
             + new_options
@@ -1414,7 +1414,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
                 "-engine",
                 "name=Base-" + run["args"]["resolved_base"][:10],
                 "tc={}".format(scaled_tc),
-                "cmd={}".format(base_engine_name),
+                "cmd=./{}".format(base_engine_name),
                 "dir=.",
             ]
             + base_options

--- a/worker/games.py
+++ b/worker/games.py
@@ -542,6 +542,19 @@ def find_arch(compiler):
         ):
             arch = "apple-silicon"
         elif (
+            "armv8" in props["arch"]
+            "dotprod" in props["arch"]
+        ):
+            arch = "armv8-dotprod"
+        elif (
+            "armv8" in props["arch"]
+        ):
+            arch = "armv8"
+        elif (
+            "armv7" in props["arch"]
+        ):
+            arch = "armv7"
+        elif (
             "avx512vnni" in props["flags"]
             and "avx512dq" in props["flags"]
             and "avx512f" in props["flags"]


### PR DESCRIPTION
When cutechess-cli was already installed before running Fishtest, the engine binaries were searched in the same directory as the initial installation of cutechess-cli.

For example, when cutechess-cli was used on Ubuntu Linux for ARM64, and cutechess-cli was already installed before installing Fishtest, the engine binaries were searched in the same directory as the initial installation of cutechess-cli (such as `/usr/local/bin/`) rather than in the test directory `~/fishtest/worker/testing/`). 

Without this patch, we could not run Fishtest on Ubuntu Linux for ARM64 where Fishtest could not download the proper binary for cutechess-cli, and relied on the cutechess-cli installed before running Fishtest.