### PR TITLE
Proper engine paths for cutechess-cli 1.3.0 (When cutechess-cli 1.3.0 was already installed before running Fishtest, the engine binaries were searched in the same directory as the initial installation of cutechess-cli)

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -2,14 +2,13 @@ import base64
 import hashlib
 from pathlib import Path
 
+from fishtest import helpers
 from fishtest.rundb import RunDb
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.config import Configurator
 from pyramid.events import BeforeRender, NewRequest
 from pyramid.session import SignedCookieSessionFactory
-
-from fishtest import helpers
 
 
 def main(global_config, **settings):

--- a/worker/games.py
+++ b/worker/games.py
@@ -1392,7 +1392,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
                 "-engine",
                 "name=New-" + run["args"]["resolved_new"][:10],
                 "tc={}".format(scaled_new_tc),
-                "cmd={}".format(new_engine_name),
+                "cmd=./{}".format(new_engine_name),
                 "dir=.",
             ]
             + new_options
@@ -1401,7 +1401,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
                 "-engine",
                 "name=Base-" + run["args"]["resolved_base"][:10],
                 "tc={}".format(scaled_tc),
-                "cmd={}".format(base_engine_name),
+                "cmd=./{}".format(base_engine_name),
                 "dir=.",
             ]
             + base_options

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 197, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "/Lu4ip+T1nwF1Wi7yEIIfhUwn0VPz6P7Z/flcnJWIWLjxliLmyLFJAoYHTStaShc", "games.py": "U/LQtRw/dlRyIgOYz+ioiACLnn9Qu/laZOaenm61HHglhcAYpVysgNLlO9bvhFGD"}
+{"__version": 197, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "/Lu4ip+T1nwF1Wi7yEIIfhUwn0VPz6P7Z/flcnJWIWLjxliLmyLFJAoYHTStaShc", "games.py": "QE8sBBJrT7bsFrfxW7wj4CeG1okuLQy3WIvgge6gG7Z07GBayucPhW+givsaA7bN"}


### PR DESCRIPTION
When `cutechess-cli` 1.3.0 (the latest version at the moment) was already installed before running Fishtest, the engine binaries were searched in the same directory as the initial installation of `cutechess-cli`.

For example, when `cutechess-cli` was used on Ubuntu Linux for **ARM64**, and `cutechess-cli` was already installed before installing Fishtest, the engine binaries were searched in the same directory as the initial installation of `cutechess-cli` (such as `/usr/local/bin/`) rather than in the test directory `~/fishtest/worker/testing/`). 

Without this patch, we could not run Fishtest on Ubuntu Linux for **ARM64** where Fishtest could not download the proper binary for `cutechess-cli`, and relied on the `cutechess-cli` installed before running Fishtest.

It does not matter whether you run `cutechess-cli` 1.3.0 (latest version) as a local copy or via a symlink. This later version does not accept the engine binaries without `./`. Because earlier versions of `cutechess-cli` can accept engine paths with and without `./` but later versions require `./`, I suggest to modify FishTest to call it with `./`.