### PR TITLE
Append to CXXFLAGS environment variable instead of overwriting it

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -642,7 +642,13 @@ def setup_engine(
         make_cmd = "build" if arch == "apple-silicon" else "profile-build"
         cmd = "make -j {} {} ARCH={} COMP={}".format(concurrency, make_cmd, arch, comp)
 
-        env = dict(os.environ, CXXFLAGS="-DNNUE_EMBEDDING_OFF")
+        # append -DNNUE_EMBEDDING_OFF to existing CXXFLAGS environment variable, if any
+        cxx = "-DNNUE_EMBEDDING_OFF"
+        if 'CXXFLAGS' in os.environ:
+	        cxx = ' '.join(cxx, os.environ['CXXFLAGS'])
+
+        env = dict(os.environ, CXXFLAGS=cxx)
+
         with subprocess.Popen(
             cmd,
             shell=True,

--- a/worker/games.py
+++ b/worker/games.py
@@ -643,11 +643,8 @@ def setup_engine(
         cmd = "make -j {} {} ARCH={} COMP={}".format(concurrency, make_cmd, arch, comp)
 
         # append -DNNUE_EMBEDDING_OFF to existing CXXFLAGS environment variable, if any
-        cxx = "-DNNUE_EMBEDDING_OFF"
-        if 'CXXFLAGS' in os.environ:
-	        cxx = ' '.join(cxx, os.environ['CXXFLAGS'])
-
-        env = dict(os.environ, CXXFLAGS=cxx)
+        cxx = os.environ.get("CXXFLAGS", "") + " -DNNUE_EMBEDDING_OFF"
+        env = dict(os.environ, CXXFLAGS=cxx.strip())
 
         with subprocess.Popen(
             cmd,

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 197, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "/Lu4ip+T1nwF1Wi7yEIIfhUwn0VPz6P7Z/flcnJWIWLjxliLmyLFJAoYHTStaShc", "games.py": "U/LQtRw/dlRyIgOYz+ioiACLnn9Qu/laZOaenm61HHglhcAYpVysgNLlO9bvhFGD"}
+{"__version": 197, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "/Lu4ip+T1nwF1Wi7yEIIfhUwn0VPz6P7Z/flcnJWIWLjxliLmyLFJAoYHTStaShc", "games.py": "N3B0O8pv2uM6wI93BAz8+xms335S1gwS/8uejzyKUyK93scR1aionrzVO059aoxZ"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 197, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "/Lu4ip+T1nwF1Wi7yEIIfhUwn0VPz6P7Z/flcnJWIWLjxliLmyLFJAoYHTStaShc", "games.py": "N3B0O8pv2uM6wI93BAz8+xms335S1gwS/8uejzyKUyK93scR1aionrzVO059aoxZ"}
+{"__version": 197, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "/Lu4ip+T1nwF1Wi7yEIIfhUwn0VPz6P7Z/flcnJWIWLjxliLmyLFJAoYHTStaShc", "games.py": "xupSyNafSCjybqIXLV9wzUvqr0KEaoZEIwYhSfjSSyLoEnCxrNtwruvpbdRGWR/+"}


### PR DESCRIPTION
Make Fishtest honor previously configured CXXFLAGS environment variable to allow using local options such as "-march=native" or "-march=raptorlake" or "-march="znver4". Previously, CXXFLAGS were overwritten by -DNNUE_EMBEDDING_OFF. Now, "-DNNUE_EMBEDDING_OFF" is appended to existing CXXFLAGS, if any.