### PR TITLE
Remove redundant call to machines.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -482,7 +482,7 @@ class RunDb:
                 ]
             return unfinished_runs
 
-    def aggregate_unfinished_runs(self, username=None):
+    def aggregate_unfinished_runs(self, machines, username=None):
         unfinished_runs = self.get_unfinished_runs(username)
         runs = {"pending": [], "active": []}
         for run in unfinished_runs:
@@ -513,7 +513,7 @@ class RunDb:
         # Calculate but don't save results_info on runs using info on current machines
         cores = 0
         nps = 0
-        for m in self.get_machines():
+        for m in machines:
             concurrency = int(m["concurrency"])
             cores += concurrency
             nps += concurrency * m["nps"]
@@ -614,7 +614,7 @@ class RunDb:
         llr = run["args"].get("sprt", {}).get("llr", 0)
         # Don't throw workers at a run that finishes in 2 minutes anyways
         llr = min(max(llr, 0), 2.0)
-        a = 3 # max bonus 1.67x
+        a = 3  # max bonus 1.67x
         itp *= (llr + a) / a
 
         # Extra bonus for most promising LTCs at strong-gainer bounds

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1370,7 +1370,10 @@ def tests_user(request):
     username = request.matchdict.get("username", "")
     response = {**get_paginated_finished_runs(request), "username": username}
     if int(request.params.get("page", 1)) == 1:
-        response["runs"] = request.rundb.aggregate_unfinished_runs(username)[0]
+        machines = request.rundb.get_machines()
+        response["runs"] = request.rundb.aggregate_unfinished_runs(machines, username)[
+            0
+        ]
     # page 2 and beyond only show finished test results
     return response
 
@@ -1392,7 +1395,9 @@ def homepage_results(request):
                 )
             )
     # Get updated results for unfinished runs + finished runs
-    (runs, pending_hours, cores, nps) = request.rundb.aggregate_unfinished_runs()
+    (runs, pending_hours, cores, nps) = request.rundb.aggregate_unfinished_runs(
+        machines
+    )
     return {
         **get_paginated_finished_runs(request),
         "runs": runs,


### PR DESCRIPTION
Profiling the home page generation, get_machines is one of the expensive calls. It is needlessly called twice. Remove one call for a small speedup.

profile of a home page build
```
         1    0.016    0.016    7.485    7.485 fishtest/views.py:1379(homepage_results)
     18/10    0.000    0.000    6.937    0.694 pymongo/_csot.py:98(csot_wrapper)
         9    0.000    0.000    6.935    0.771 pymongo/mongo_client.py:1418(_retryable_read)
       280    0.001    0.000    6.861    0.025 pymongo/cursor.py:1244(next)
        12    0.000    0.000    6.861    0.572 pymongo/cursor.py:1128(_refresh)
         8    0.000    0.000    6.860    0.857 pymongo/cursor.py:1037(__send_message)
         8    0.000    0.000    6.859    0.857 pymongo/mongo_client.py:1302(_run_operation)
         8    0.000    0.000    6.854    0.857 pymongo/mongo_client.py:1324(_cmd)
         8    0.001    0.000    6.854    0.857 pymongo/server.py:76(run_operation)
         1    0.071    0.071    6.772    6.772 fishtest/rundb.py:485(aggregate_unfinished_runs)
        10    0.000    0.000    6.466    0.647 pymongo/message.py:1391(unpack_response)
        10    0.000    0.000    6.466    0.647 bson/__init__.py:1184(_decode_all_selective)
        10    0.019    0.002    6.466    0.647 bson/__init__.py:1093(decode_all)
         8    0.000    0.000    6.466    0.808 pymongo/cursor.py:1117(_unpack_response)
        10    6.445    0.644    6.447    0.645 {built-in method bson._cbson._decode_all}
         2    0.041    0.020    3.117    1.559 fishtest/rundb.py:240(get_machines)
```