### PR TITLE
Remove redundant and possibly expensive condition from db query.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -240,7 +240,7 @@ class RunDb:
     def get_machines(self):
         machines = []
         active_runs = self.runs.find(
-            {"finished": False, "tasks": {"$elemMatch": {"active": True}}},
+            {"finished": False},
             sort=[("last_updated", DESCENDING)],
         )
         for run in active_runs:


### PR DESCRIPTION
The get_machines() function uses a db query that looks for runs with an active task, and then uses python code to only process the active tasks.

I suspect the query condition is redundant (assuming there are not vast numbers of old runs with; Finished = false and no active tasks) and very expensive, so I suggest we try removing it.