### PR TITLE
Avoid long task lists

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -654,7 +654,7 @@ class RunDb:
         assert concurrency >= 1
         # as we have more tasks done (>250), make them longer to avoid
         # having many tasks in long running tests
-        scale_duration = 1 + (len(run["tasks"]) // 250)
+        scale_duration = 1 + min(4, len(run["tasks"]) // 250)
         games = self.task_duration * scale_duration / game_time * concurrency
         if "sprt" in run["args"]:
             batch_size = 2 * run["args"]["sprt"].get("batch_size", 1)

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -93,7 +93,7 @@ class RunDb:
             print(f"Unable to obtain the port number. Error: {self.port}", flush=True)
         self.task_runs = []
 
-        self.task_duration = 900  # 15 minutes
+        self.task_duration = 1800  # 30 minutes
         self.ltc_lower_bound = 40  # Beware: this is used as a filter in an index!
         self.pt_info = {
             "pt_version": "SF_15",
@@ -652,9 +652,9 @@ class RunDb:
         game_time = estimate_game_duration(run["args"]["tc"])
         concurrency = worker_info["concurrency"] // run["args"]["threads"]
         assert concurrency >= 1
-        # as we have more tasks done (>1000), make them longer to avoid
+        # as we have more tasks done (>250), make them longer to avoid
         # having many tasks in long running tests
-        scale_duration = 1 + (len(run["tasks"]) // 1000) ** 2
+        scale_duration = 1 + (len(run["tasks"]) // 250)
         games = self.task_duration * scale_duration / game_time * concurrency
         if "sprt" in run["args"]:
             batch_size = 2 * run["args"]["sprt"].get("batch_size", 1)

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -514,7 +514,7 @@ class TestRunFinished(unittest.TestCase):
         stop_all_runs(self)
         run_id = new_run(self)
         run = self.rundb.get_run(run_id)
-        num_games = 600
+        num_games = 1200
         run["args"]["num_games"] = num_games
         self.rundb.buffer(run, True)
 


### PR DESCRIPTION
they make some operations in fishtest much slower, and the db bigger. Additionally larger batches means less idle time at the end of the batch for workers, which is good.