### PR TITLE
Increase batch size

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -781,7 +781,8 @@ def validate_form(request):
     # Integer parameters
 
     if stop_rule == "sprt":
-        sprt_batch_size_games = 8
+        # Too small a number results in many API calls, especially with highly concurrent workers.
+        sprt_batch_size_games = 32
         assert sprt_batch_size_games % 2 == 0
         elo_model = request.POST["elo_model"]
         if elo_model not in ["BayesElo", "logistic", "normalized"]:

--- a/worker/games.py
+++ b/worker/games.py
@@ -1286,6 +1286,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
     factor = 1328000 / base_nps
 
     # Adjust CPU scaling.
+    scaled_tc_ltc, tc_limit_ltc = adjust_tc("60+0.6", factor)
     scaled_tc, tc_limit = adjust_tc(run["args"]["tc"], factor)
     scaled_new_tc = scaled_tc
     if "new_tc" in run["args"]:
@@ -1312,7 +1313,8 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
         tc_limit *= 2
 
     while games_remaining > 0:
-        batch_size = games_concurrency * 4  # update frequency
+        # update frequency: every 4 games at LTC, or a similar time interval at other TCs
+        batch_size = games_concurrency * 4 * max(1, round(tc_limit_ltc / tc_limit))
 
         if spsa_tuning:
             games_to_play = min(batch_size, games_remaining)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 199, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "uFRfeWMhIxsSBppqLLWpNKfYd6VAq8MGRZUjtu+XKWE1RhM4cACqLhXA9jP+92Z1", "games.py": "wzzUVbeYyxLGRQTxx0RyCh67lHVadBe6HIQi84GM2W27cF3+aJIXLZkZmysfxTv5"}
+{"__version": 199, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "uFRfeWMhIxsSBppqLLWpNKfYd6VAq8MGRZUjtu+XKWE1RhM4cACqLhXA9jP+92Z1", "games.py": "0kqs7uzEyvg9AlU/55YvF7SPzohdPsIlkNf3zFWsRWxK5gJDdEZIBg0BZXRAIhsp"}


### PR DESCRIPTION
api_update_task and api_request_spsa are among the most called api functions, they limit the scalability of the framework.

With the large number of workers, we have frequent updates also with these new defaults. LTC SPRT tests update at the same rate, STC SPRT tests slower.

SPSA tests load the framework quickly, increase the batch size. This also make sense with highly concurrent workers that otherwise update very frequently.