### PR TITLE
Introduce a scheduled start

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -104,6 +104,7 @@ def main(global_config, **settings):
     config.add_route("api_failed_task", "/api/failed_task")
     config.add_route("api_stop_run", "/api/stop_run")
     config.add_route("api_request_version", "/api/request_version")
+    config.add_route("api_request_start", "/api/request_start")
     config.add_route("api_beat", "/api/beat")
     config.add_route("api_request_spsa", "/api/request_spsa")
     config.add_route("api_active_runs", "/api/active_runs")

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 199, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "uFRfeWMhIxsSBppqLLWpNKfYd6VAq8MGRZUjtu+XKWE1RhM4cACqLhXA9jP+92Z1", "games.py": "wzzUVbeYyxLGRQTxx0RyCh67lHVadBe6HIQi84GM2W27cF3+aJIXLZkZmysfxTv5"}
+{"__version": 199, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "8aSYWiLJgWZAq+ueR+vFWzmNPLm5AbxCJz9Zou+1ugt+pVhBSM/uPJZ5Otf91u+W", "games.py": "wzzUVbeYyxLGRQTxx0RyCh67lHVadBe6HIQi84GM2W27cF3+aJIXLZkZmysfxTv5"}


### PR DESCRIPTION
in case a fleet of workers lands at simultaneously, the server can be overloaded.

To have a more gradual start, schedule worker start times,
ensuring at least 200ms spacing between worker starts.

200ms is a rough estimate, might need refinement after tests

The scheduling is per user name (and not per IP or globally),
to ensure different use cases (fleet behind single IP, or with different IPs) work,
and to ensure that malicious or single workers can not block other user's workers
to join the framework.