### PR TITLE
Cutechess-cli Syzygy tablebases

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -1069,7 +1069,7 @@ def launch_cutechess(
     return task_alive
 
 
-def run_games(worker_info, password, remote, run, task_id, pgn_file):
+def run_games(worker_info, password, remote, run, task_id, pgn_file, syzygy_path):
     # This is the main cutechess-cli driver.
     # It is ok, and even expected, for this function to
     # raise exceptions, implicitly or explicitly, if a
@@ -1351,6 +1351,11 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
         if any(substring in book.upper() for substring in ["FRC", "960"]):
             variant = "fischerandom"
 
+        # Prepare the tablebase parameter
+        syzygy_cmd = []
+        if len(syzygy_path) > 0:
+            syzygy_cmd = ["-tb", syzygy_path]
+
         # Run cutechess binary.
         cutechess = "cutechess-cli" + EXE_SUFFIX
         cmd = (
@@ -1413,6 +1418,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
             + nodestime_cmd
             + threads_cmd
             + book_cmd
+            + syzygy_cmd
         )
 
         task_alive = launch_cutechess(


### PR DESCRIPTION
The new worker option `--syzygy_path` to supply cutechess-cli (but not the engines) with the Syzygy tablebases path to use for adjudication to finish the games faster. 

I tested this option and the majority of games are now finished by cutechess-cli with Syzygy adjudication, so it allows for the games to be resolved faster. This is a reasonable approach to supply the application that runs the engines but not the engines themselves with the tablebases. For example, it is used by TCEC. 

Here is a snapshot of my output of the Fishtest worker showing the majority of the games are adjudicated using Syzygy tablebases before they could have finished by themselves after a certain additional number of moves:

```
Score of New-d92eeb485c vs Base-acb0d204d5: 3 - 1 - 5  [0.611] 9
Started game 11 of 120 (New-d92eeb485c vs Base-acb0d204d5)
Finished game 10 (Base-acb0d204d5 vs New-d92eeb485c): 1/2-1/2 {Draw by adjudication: SyzygyTB}
Score of New-d92eeb485c vs Base-acb0d204d5: 3 - 1 - 6  [0.600] 10
Started game 12 of 120 (Base-acb0d204d5 vs New-d92eeb485c)
Finished game 11 (New-d92eeb485c vs Base-acb0d204d5): 1-0 {White wins by adjudication}
Score of New-d92eeb485c vs Base-acb0d204d5: 4 - 1 - 6  [0.636] 11
Started game 13 of 120 (New-d92eeb485c vs Base-acb0d204d5)
Finished game 12 (Base-acb0d204d5 vs New-d92eeb485c): 1/2-1/2 {Draw by adjudication}
Score of New-d92eeb485c vs Base-acb0d204d5: 4 - 1 - 7  [0.625] 12
Started game 14 of 120 (Base-acb0d204d5 vs New-d92eeb485c)
Finished game 13 (New-d92eeb485c vs Base-acb0d204d5): 1/2-1/2 {Draw by adjudication: SyzygyTB}
Score of New-d92eeb485c vs Base-acb0d204d5: 4 - 1 - 8  [0.615] 13
Started game 15 of 120 (New-d92eeb485c vs Base-acb0d204d5)
Finished game 14 (Base-acb0d204d5 vs New-d92eeb485c): 0-1 {White loses on time}
Score of New-d92eeb485c vs Base-acb0d204d5: 5 - 1 - 8  [0.643] 14
Started game 16 of 120 (Base-acb0d204d5 vs New-d92eeb485c)
Finished game 15 (New-d92eeb485c vs Base-acb0d204d5): 1/2-1/2 {Draw by 3-fold repetition}
Score of New-d92eeb485c vs Base-acb0d204d5: 5 - 1 - 9  [0.633] 15
Started game 17 of 120 (New-d92eeb485c vs Base-acb0d204d5)
Finished game 16 (Base-acb0d204d5 vs New-d92eeb485c): 1-0 {White wins by adjudication}
Score of New-d92eeb485c vs Base-acb0d204d5: 5 - 2 - 9  [0.594] 16
Started game 18 of 120 (Base-acb0d204d5 vs New-d92eeb485c)
Finished game 17 (New-d92eeb485c vs Base-acb0d204d5): 1-0 {White wins by adjudication: SyzygyTB}
Score of New-d92eeb485c vs Base-acb0d204d5: 6 - 2 - 9  [0.618] 17
Started game 19 of 120 (New-d92eeb485c vs Base-acb0d204d5)
Finished game 18 (Base-acb0d204d5 vs New-d92eeb485c): 1/2-1/2 {Draw by adjudication}
Score of New-d92eeb485c vs Base-acb0d204d5: 6 - 2 - 10  [0.611] 18
Started game 20 of 120 (Base-acb0d204d5 vs New-d92eeb485c)
Finished game 19 (New-d92eeb485c vs Base-acb0d204d5): 1/2-1/2 {Draw by adjudication}
Score of New-d92eeb485c vs Base-acb0d204d5: 6 - 2 - 11  [0.605] 19
Started game 21 of 120 (New-d92eeb485c vs Base-acb0d204d5)
Finished game 20 (Base-acb0d204d5 vs New-d92eeb485c): 1-0 {White wins by adjudication}
Score of New-d92eeb485c vs Base-acb0d204d5: 6 - 3 - 11  [0.575] 20
Started game 22 of 120 (Base-acb0d204d5 vs New-d92eeb485c)
Finished game 21 (New-d92eeb485c vs Base-acb0d204d5): 1-0 {White wins by adjudication: SyzygyTB}
Score of New-d92eeb485c vs Base-acb0d204d5: 7 - 3 - 11  [0.595] 21
Started game 23 of 120 (New-d92eeb485c vs Base-acb0d204d5)
Finished game 23 (New-d92eeb485c vs Base-acb0d204d5): 1/2-1/2 {Draw by 3-fold repetition}
Score of New-d92eeb485c vs Base-acb0d204d5: 7 - 3 - 12  [0.591] 22
Started game 24 of 120 (Base-acb0d204d5 vs New-d92eeb485c)
Finished game 22 (Base-acb0d204d5 vs New-d92eeb485c): 1-0 {White wins by adjudication: SyzygyTB}
Score of New-d92eeb485c vs Base-acb0d204d5: 7 - 4 - 12  [0.565] 23
Started game 25 of 120 (New-d92eeb485c vs Base-acb0d204d5)
Finished game 24 (Base-acb0d204d5 vs New-d92eeb485c): 1-0 {White wins by adjudication}
Score of New-d92eeb485c vs Base-acb0d204d5: 7 - 5 - 12  [0.542] 24
Started game 26 of 120 (Base-acb0d204d5 vs New-d92eeb485c)
Finished game 25 (New-d92eeb485c vs Base-acb0d204d5): 1-0 {White wins by adjudication: SyzygyTB}
Score of New-d92eeb485c vs Base-acb0d204d5: 8 - 5 - 12  [0.560] 25
Started game 27 of 120 (New-d92eeb485c vs Base-acb0d204d5)
Finished game 26 (Base-acb0d204d5 vs New-d92eeb485c): 1/2-1/2 {Draw by adjudication}
Score of New-d92eeb485c vs Base-acb0d204d5: 8 - 5 - 13  [0.558] 26
Started game 28 of 120 (Base-acb0d204d5 vs New-d92eeb485c)
Finished game 27 (New-d92eeb485c vs Base-acb0d204d5): 1/2-1/2 {Draw by adjudication: SyzygyTB}
Score of New-d92eeb485c vs Base-acb0d204d5: 8 - 5 - 14  [0.556] 27
Started game 29 of 120 (New-d92eeb485c vs Base-acb0d204d5)
```



