### PR TITLE
Send heartbeat at a somewhat slower rate

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -438,11 +438,11 @@ class RunDb:
             self.start_timer()
 
     def scavenge(self, run):
-        if datetime.utcnow() < boot_time + timedelta(seconds=150):
+        if datetime.utcnow() < boot_time + timedelta(seconds=300):
             return False
         # print("scavenge ", run["_id"])
         dead_task = False
-        old = datetime.utcnow() - timedelta(minutes=3)
+        old = datetime.utcnow() - timedelta(minutes=6)
         task_id = -1
         run_id = str(run["_id"])
         for task in run["tasks"]:

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 199, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "uFRfeWMhIxsSBppqLLWpNKfYd6VAq8MGRZUjtu+XKWE1RhM4cACqLhXA9jP+92Z1", "games.py": "wzzUVbeYyxLGRQTxx0RyCh67lHVadBe6HIQi84GM2W27cF3+aJIXLZkZmysfxTv5"}
+{"__version": 199, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "ezyrBIdut68zLPQqrrdmJJLn0Su5wm9LPizF/v8Zw+N0MntjMLjKT7BjwGkiyQXV", "games.py": "wzzUVbeYyxLGRQTxx0RyCh67lHVadBe6HIQi84GM2W27cF3+aJIXLZkZmysfxTv5"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1130,7 +1130,7 @@ def heartbeat(worker_info, password, remote, current_state):
     while current_state["alive"]:
         time.sleep(1)
         count += 1
-        if count == 60:
+        if count == 120:
             count = 0
             print("  Send heartbeat for", worker_info["unique_key"], end=" ... ")
             run = current_state["run"]


### PR DESCRIPTION
send every 2min instead of every 1min. Scavenge after 6 instead of 3min.

Based on the profile that shows this is the top api call: https://github.com/glinscott/fishtest/pull/1616#issuecomment-1515224083 when the fleet is on.