### PR TITLE
Do not sort the unfinished_runs index by last_updated.

### DIFF
--- a/server/utils/create_indexes.py
+++ b/server/utils/create_indexes.py
@@ -22,7 +22,7 @@ db = conn[db_name]
 def create_runs_indexes():
     print("Creating indexes on runs collection")
     db["runs"].create_index(
-        [("finished", ASCENDING), ("last_updated", ASCENDING)],
+        [("finished", ASCENDING)],
         name="unfinished_runs",
         partialFilterExpression={"finished": False},
     )


### PR DESCRIPTION
Sorting by last_updated is unnecessary since the unfinished runs are already sorted in code.

This presumably solves #134.

With the main page being served from a separate pserve, the current lock solution no longer works.

See the following helpful description of the issue

https://blog.meteor.com/mongodb-queries-dont-always-return-all-matching-documents-654b6594a827