### PR TITLE
Increase the default maximum number of games

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -795,7 +795,7 @@ def validate_form(request):
             batch_size=sprt_batch_size_games // 2,
         )  # game pairs
         # Limit on number of games played.
-        data["num_games"] = 800000
+        data["num_games"] = 1600000
     elif stop_rule == "spsa":
         data["num_games"] = int(request.POST["num-games"])
         if data["num_games"] <= 0:


### PR DESCRIPTION
- tests take longer, we hit 800k from time to time
- in the case the fleet lands, the number of tasks created per run is limited by 800k games. This limits the number of cores that can participate to a single run.