### PR TITLE
Do not print the last page in pagination

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -59,7 +59,6 @@ def pagination(page_idx, num, page_size):
             or (idx < 5 and page_idx < 4)
             or abs(idx - page_idx) < 2
             or (idx > last_idx - 5 and page_idx > last_idx - 4)
-            or idx > last_idx - 1
         ):
             pages.append(
                 {


### PR DESCRIPTION
people are attracted by the large number, and click this out of curiosity in this way, or slowest API access is just one click away. Not showing this will practically help with https://github.com/glinscott/fishtest/issues/1629