### PR TITLE
Retry failed net downloads

### DIFF
--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 201, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "u/59SX/1gXYsW+/1TMR1VjHj+dezgkR+5o2ngxUZDfxzjyd+fEgg7EqyFIzo4Zf6", "games.py": "ihdlyY+E5f241WjDM7si9WF4kRwCH1AqolhwshM2ROYP/DG4crhm9m4LCtMcOaoz"}
+{"__version": 201, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "u/59SX/1gXYsW+/1TMR1VjHj+dezgkR+5o2ngxUZDfxzjyd+fEgg7EqyFIzo4Zf6", "games.py": "sgnOBQQ9sZz6AlBg1SP7B1btuY0/p1StAwUtmoVzQk1+I/PjphRKlh2ak4yIpzFP"}


### PR DESCRIPTION
on fleet arrival cdn might have troubles to serve the net. This issue only affects some downloads, and usually corrects itself relatively quickly. Retry up to 5 times before throwing the exception.