### PR TITLE
Speedup in tests_view for long list of tasks

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -395,12 +395,9 @@
     <tbody>
       % for idx, task in enumerate(run['tasks'] + run.get('bad_tasks', [])):
           <%
-            if task in run["tasks"] and "bad" in task:
+            if 'bad' in task and idx < len(run['tasks']):
               continue
-            if "task_id" in task:
-              task_id = task["task_id"]
-            else:
-	      task_id = idx
+            task_id = task.get('task_id', idx)
             stats = task.get('stats', {})
             if 'stats' in task:
               total = stats['wins'] + stats['losses'] + stats['draws']


### PR DESCRIPTION
The code was very CPU-intensive for runs with long task lists:
- checking that a dictionary is contained in a list of dictionaries is expensive
- the code performed O(n^2) checks with n the length of the list

Improvements:
- check very rare events first (bad task)
- check if the task is contained in the first list by comparing idx and
  the length of the first list
- some code refactoring