### PR TITLE
Go through task lists in reverse order to find active runs.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -470,7 +470,7 @@ class RunDb:
         runs = {"pending": [], "active": []}
         for run in unfinished_runs:
             state = (
-                "active" if any(task["active"] for task in run["tasks"]) else "pending"
+                "active" if any(task["active"] for task in reversed(run["tasks"])) else "pending"
             )
             if state == "pending":
                 run["workers"] = run["cores"] = 0


### PR DESCRIPTION
Active tasks are near the end of the task list so this should give a small speed up.