### PR TITLE
Remove cached binaries on worker startup

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 210
+WORKER_VERSION = 211
 
 
 def validate_request(request):

--- a/worker/games.py
+++ b/worker/games.py
@@ -1094,7 +1094,7 @@ def launch_cutechess(
     return task_alive
 
 
-def run_games(worker_info, password, remote, run, task_id, pgn_file):
+def run_games(worker_info, password, remote, run, task_id, pgn_file, clear_binaries):
     # This is the main cutechess-cli driver.
     # It is ok, and even expected, for this function to
     # raise exceptions, implicitly or explicitly, if a
@@ -1182,7 +1182,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
     # Clean up old engines (keeping the num_bkps most recent).
     worker_dir = Path(__file__).resolve().parent
     testing_dir = worker_dir / "testing"
-    num_bkps = 50
+    num_bkps = 0 if clear_binaries else 50
     try:
         engines = sorted(
             testing_dir.glob("stockfish_*" + EXE_SUFFIX),

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 210, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "Rbz9q1bCKE2MsrtUV3ywqP8tci1ao531KY26g6ZreiLnS9OnYlRJXmGBZap84CG/", "games.py": "7m8vZuGULuOtXGPuw6pxnu8BEW4DYjcf7RyRhzwB2XyeL783gaEDSc/ZsIUq+1zg"}
+{"__version": 210, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "VQgNFEcvtmOvmRaSYTiLOgXXQ9ZXx/Pvi1ZR16mjy6DgbxuO3rmLEsWb9odsGt1x", "games.py": "au3WiGyUAb26mcz5C2MhnU7rhe8X3JMEgnyUlo4aAH+dPjxnXCZrWh9xFjdNQoFZ"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 210, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "VQgNFEcvtmOvmRaSYTiLOgXXQ9ZXx/Pvi1ZR16mjy6DgbxuO3rmLEsWb9odsGt1x", "games.py": "au3WiGyUAb26mcz5C2MhnU7rhe8X3JMEgnyUlo4aAH+dPjxnXCZrWh9xFjdNQoFZ"}
+{"__version": 211, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "Kfmwq7iHKEU1eulS2Ka2iJ5n1k9U2ryEoBP2LvJv0OuSrC3pi3sdcfgWmNaZtiKh", "games.py": "au3WiGyUAb26mcz5C2MhnU7rhe8X3JMEgnyUlo4aAH+dPjxnXCZrWh9xFjdNQoFZ"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1310,7 +1310,9 @@ def verify_worker_version(remote, username, password):
     return True
 
 
-def fetch_and_handle_task(worker_info, password, remote, lock_file, current_state):
+def fetch_and_handle_task(
+    worker_info, password, remote, lock_file, current_state, clear_binaries
+):
     # This function should normally not raise exceptions.
     # Unusual conditions are handled by returning False.
     # If an immediate exit is necessary then one can set
@@ -1398,7 +1400,7 @@ def fetch_and_handle_task(worker_info, password, remote, lock_file, current_stat
     api = remote + "/api/failed_task"
     pgn_file = [None]
     try:
-        run_games(worker_info, password, remote, run, task_id, pgn_file)
+        run_games(worker_info, password, remote, run, task_id, pgn_file, clear_binaries)
         success = True
     except FatalException as e:
         message = str(e)
@@ -1611,6 +1613,7 @@ def worker():
     # Start the main loop.
     delay = INITIAL_RETRY_TIME
     fish_exit = False
+    clear_binaries = True
     while current_state["alive"]:
         if (worker_dir / "fish.exit").is_file():
             current_state["alive"] = False
@@ -1618,7 +1621,12 @@ def worker():
             fish_exit = True
             break
         success = fetch_and_handle_task(
-            worker_info, options.password, remote, lock_file, current_state
+            worker_info,
+            options.password,
+            remote,
+            lock_file,
+            current_state,
+            clear_binaries,
         )
         if not current_state["alive"]:  # the user may have pressed Ctrl-C...
             break
@@ -1632,6 +1640,7 @@ def worker():
                 safe_sleep(delay)
                 delay = min(MAX_RETRY_TIME, delay * 2)
         else:
+            clear_binaries = False
             delay = INITIAL_RETRY_TIME
 
     print("Waiting for the heartbeat thread to finish...")

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -54,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 210
+WORKER_VERSION = 211
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
as the user could change the compiler at worker startup time (e.g. clang vs gcc), the binary cache might contain binaries compiled with a different compiler than the ones generated by the worker. As different compilers lead to binaries of different speed, test results could be biased, unless we assure that the same compiler is used for both base and new test.

This patch just clears the binary cache once at worker startup, leaving the caching mechanism unchanged otherwise.

Possibly the binary cache should also be flushed on worker update (e.g. the architecture selection logic might change). This is not implemented.

fixes https://github.com/glinscott/fishtest/issues/1666