### PR TITLE
Add a bit of randomness to current_time.

### DIFF
--- a/server/fishtest/static/js/notifications.js
+++ b/server/fishtest/static/js/notifications.js
@@ -241,16 +241,20 @@ async function main_follow_loop() {
   await DOM_loaded();
   await async_sleep(5000 + 10000 * Math.random());
   while (true) {
-    const current_time = Date.now();
+    // Milliseconds seem quantized on Chrome.
+    // We add a bit of randomness.
+    const current_time = Date.now() + Math.floor(200 * Math.random() - 100);
     const timestamp_latest_fetch = get_timestamp();
     if (
       timestamp_latest_fetch != null &&
       current_time - timestamp_latest_fetch < 19000
     ) {
       await async_sleep(20000 + 500 * Math.random());
-      // Instrumentation
+      // Instrumentation.
+      // Note that in modern browsers timer events in
+      // inactive tabs are severely throttled.
       t = Date.now();
-      if (t - current_time > 40000) {
+      if (t - current_time > 90000) {
         d = new Date(t);
         console.log(
           "Wakeup after sleep " + d + " (millis: " + d.getMilliseconds() + ")"


### PR DESCRIPTION
We deal with some issues observed on Chrome/Linux.

- Tabs that are not active are severely throttled. A 20 second (asynchronous) sleep can last much longer. Thus the console becomes flooded with "Wake up from sleep" messages. This should be fixed in this PR.

- The milliseconds part of the time (obtained by `Date.now()`) is quantized. So it cannot be used as a simple source of randomness (see the code how it is used).