### PR TITLE
More robust wake up from sleep.

### DIFF
--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -228,7 +228,11 @@ function DOM_loaded() {
 
 function async_sleep(ms) {
   return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms);
+    const t0 = Date.now();
+    setTimeout(() => {
+      const t1 = Date.now();
+      resolve(t1 - t0);
+    }, ms);
   });
 }
 

--- a/server/fishtest/static/js/notifications.js
+++ b/server/fishtest/static/js/notifications.js
@@ -249,23 +249,26 @@ async function main_follow_loop() {
       timestamp_latest_fetch != null &&
       current_time - timestamp_latest_fetch < 19000
     ) {
-      await async_sleep(20000 + 500 * Math.random());
+      const t = await async_sleep(20000 + 500 * Math.random());
       // Instrumentation.
       // Note that in modern browsers timer events in
       // inactive tabs are severely throttled.
-      t = Date.now();
-      if (t - current_time > 90000) {
-        d = new Date(t);
-        console.log(
-          "Wakeup after sleep " + d + " (millis: " + d.getMilliseconds() + ")"
-        );
+      if (t > 90000) {
+        d = new Date();
+        console.log("Wakeup after sleep " + d + " (slept: " + t + "ms)");
       }
       continue;
     }
     // I won the race, other tabs should skip their fetch
     save_timestamp(current_time);
     // Extra defense against race after wakeup from sleep
-    await async_sleep(1500);
+    const t = await async_sleep(1500);
+    if (t > 90000) {
+      d = new Date();
+      console.log("Wakeup after sleep " + d + " (slept: " + t + "ms)");
+      console.log("Cancelling fetch...");
+      continue;
+    }
     if (current_time != get_timestamp()) {
       console.log("My fetch was preempted by another tab");
       continue;


### PR DESCRIPTION
I occasionally still observe duplicate notifications on ipad after wake up. I think the reason is that one tab may sleep before a fetch and another thread may sleep during the "async_sleep(1500)". This presents a race.

We catch this by checking the actual time slept. If it is > 90s then we cancel the fetch.

One would like to reduce the 90s but this would be defeated by the fact that timers on Chrome fire only once per minute in inactive tabs.

There is also some nice refactoring. The function async_sleep can now be used as
```
let t = await async_sleep(delay_ms);
```
where t is the amount of time (in ms) that is actually slept.