### PR TITLE
Add linters and formatters to CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,36 @@
+name: CI lint
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        node-version: ["18.x"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Set up linters and formatters
+        run: |
+          python -m pip install pipx
+          npm install --global prettier
+
+      - name: Run linters and formatters
+        run: |
+          pipx run flake8 --max-line-length=88 --exclude worker/packages . && echo "✔️ flake8 succeded" || echo "❌ flake8 failed"
+          pipx run black --check --exclude="packages" . && echo "✔️ black succeded" || echo "❌ black failed"
+          pipx run isort --check --profile black --skip worker/packages . && echo "✔️ isort succeded" || echo "❌ isort failed"
+          prettier --check "server/fishtest/static/{css/*.css,html/*.html,js/*[!highlight.diff.min].js}" && echo "✔️ prettier succeded" || echo "❌ prettier failed"


### PR DESCRIPTION
The workflow never fails but it writes the linters and formatters outputs and the final results, eg:
```
./worker/worker.py:1570:89: E501 line too long (90 > 88 characters)
❌ flake8 failed
creating virtual environment...
installing black...
would reformat /home/runner/work/fishtest/fishtest/server/fishtest/api.py
would reformat /home/runner/work/fishtest/fishtest/server/fishtest/views.py

Oh no! 💥 💔 💥
2 files would be reformatted, 33 files would be left unchanged.
❌ black failed
creating virtual environment...
installing isort...
ERROR: /home/runner/work/fishtest/fishtest/server/fishtest/views.py Imports are incorrectly sorted and/or formatted.
Skipped 1 files
❌ isort failed
Checking formatting...
All matched files use Prettier code style!
✔️ prettier succeded
```