### PR TITLE
Simplify html escaping in mako

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -2,7 +2,6 @@
 
 <%!
   import json
-  import markupsafe
 %>
 
 <%namespace name="base" file="base.mak"/>
@@ -116,8 +115,8 @@
                 % elif arg[0] == 'itp':
                   <td>${f"{float(arg[1]):.2f}"}</a></td>
                 % else:
-                  <td ${'class="run-info"' if arg[0]=="info" else "" | n}>
-                      ${str(markupsafe.Markup(arg[1])).replace('\n', '<br>') | n}
+                  <td ${'class="run-info"' if arg[0]=="info" else ""|n}>
+                    ${arg[1].replace('\n', '<br>')|n}
                   </td>
                 % endif
               </tr>
@@ -126,7 +125,7 @@
                 <td>${arg[0]}</td>
                 <td>
                   <a href="${arg[2]}" target="_blank" rel="noopener">
-                    ${str(markupsafe.Markup(arg[1]))}
+                    ${arg[1]|n}
                   </a>
                 </td>
               </tr>

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -458,14 +458,14 @@
 
   let fetchedTasksBefore = false;
   async function handleRenderTasks(){
-      await DOM_loaded();
-      const tasksButton = document.getElementById("tasks-button");
-      tasksButton?.addEventListener("click", async () => {
-        await toggle_tasks();
-      })
-       if (${str(tasks_shown).lower()})
-         await renderTasks();
-    }
+    await DOM_loaded();
+    const tasksButton = document.getElementById("tasks-button");
+    tasksButton?.addEventListener("click", async () => {
+      await toggle_tasks();
+    })
+     if (${str(tasks_shown).lower()})
+       await renderTasks();
+  }
 
   async function renderTasks() {
     await DOM_loaded();

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1319,13 +1319,7 @@ def tests_view(request):
         if name == "spsa":
             run_args.append(("spsa", value, ""))
         else:
-            try:
-                strval = str(value)
-            except:
-                strval = value.encode("ascii", "replace")
-            if name not in ["new_tag", "base_tag"]:
-                strval = html.escape(strval)
-            run_args.append((name, strval, url))
+            run_args.append((name, html.escape(str(value)), url))
 
     active = 0
     cores = 0

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -336,7 +336,7 @@ def sprt_calc(request):
 # Different LOCALES may have different quotation marks.
 # See https://op.europa.eu/en/web/eu-vocabularies/formex/physical-specifications/character-encoding/quotation-marks
 
-quotation_marks = [
+quotation_marks = (
     0x0022,
     0x0027,
     0x00AB,
@@ -351,9 +351,9 @@ quotation_marks = [
     0x201F,
     0x2039,
     0x203A,
-]
+)
 
-quotation_marks = "".join([chr(c) for c in quotation_marks])
+quotation_marks = "".join(chr(c) for c in quotation_marks)
 quotation_marks_translation = str.maketrans(quotation_marks, len(quotation_marks) * '"')
 
 
@@ -1223,7 +1223,7 @@ def tests_view(request):
     if run.get("rescheduled_from"):
         run_args.append(("rescheduled_from", run["rescheduled_from"], ""))
 
-    for name in [
+    for name in (
         "new_tag",
         "new_signature",
         "new_options",
@@ -1249,7 +1249,7 @@ def tests_view(request):
         "tests_repo",
         "adjudication",
         "info",
-    ]:
+    ):
         if name not in run["args"]:
             continue
 


### PR DESCRIPTION
- the string is already html escaped in "view.py", simplify the escaping in mako template
- python3 string supports unicode, drop unnecessary try except