### PR TITLE
Replace +- by ± in Elo output

### DIFF
--- a/server/fishtest/templates/elo_results.mak
+++ b/server/fishtest/templates/elo_results.mak
@@ -64,7 +64,7 @@
   % endfor
   % if elo_ptnml_run:
     <br>
-    ${f"nElo: {nelo5:.2f} +-{nelo5_delta:.1f} (95%) PairsRatio: {results5_pairs_ratio:.2f}"}
+    ${f"nElo: {nelo5:.2f} ± {nelo5_delta:.1f} (95%) PairsRatio: {results5_pairs_ratio:.2f}"}
   % endif
 </%def>
 

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -266,7 +266,7 @@ def format_results(run_results, run):
             elo, elo95, los = fishtest.stats.stat_util.get_elo([WLD[1], WLD[2], WLD[0]])
 
         # Display the results
-        eloInfo = "Elo: {:.2f} +-{:.1f} (95%)".format(elo, elo95)
+        eloInfo = "Elo: {:.2f} ± {:.1f} (95%)".format(elo, elo95)
         losInfo = "LOS: {:.1%}".format(los)
 
         result["info"].append(eloInfo + " " + losInfo)

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -1371,8 +1371,7 @@ def get_paginated_finished_runs(request):
     for run in finished_runs:
         # Ensure finished runs have results_info
         results = request.rundb.get_results(run)
-        if "results_info" not in run:
-            run["results_info"] = format_results(results, run)
+        run["results_info"] = format_results(results, run)
 
         # Look for failed runs
         if "failed" in run and run["failed"]:


### PR DESCRIPTION
Also use consistent spacing around ±.

When loading finished runs, we now always re-format the results because the stored results might still contain +-.