### PR TITLE
Rewrite "delta_update_users.py"

### DIFF
--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -7,35 +7,77 @@ from fishtest.rundb import RunDb
 from fishtest.util import delta_date, diff_date, estimate_game_duration
 from pymongo import DESCENDING
 
-new_deltas = {}
-skip = False
 
+def initialize_info(rundb, clear_stats):
+    info_total = {}
+    info_top_month = {}
+    diff_ini = diff_date(datetime.min).total_seconds()
+    last_ini = delta_date(diff_date(datetime.min))
 
-def process_run(run, info, deltas=None):
-    global skip
-    if deltas and (skip or str(run["_id"]) in deltas):
-        skip = True
-        return
-    if deltas is not None and str(run["_id"]) in new_deltas:
-        print("Warning: skipping repeated run!")
-        return
-    if "username" in run["args"]:
-        username = run["args"]["username"]
-        if username in info:
-            info[username]["tests"] += 1
+    for u in rundb.userdb.get_users():
+        username = u["username"]
+        # Initialize info_top_month with cleared contribution values
+        info_top_month[username] = {
+            "username": username,
+            "cpu_hours": 0,
+            "games": 0,
+            "games_per_hour": 0.0,
+            "tests": 0,
+            "tests_repo": u.get("tests_repo", ""),
+            "task_last_updated": datetime.min,
+            "diff": diff_ini,
+            "last_updated": last_ini,
+        }
+        if clear_stats:
+            info_total[username] = info_top_month[username].copy()
         else:
-            print("not in info:", username)
-            return
+            # Load user data from the user_cache
+            info_total[username] = rundb.userdb.user_cache.find_one(
+                {"username": username}
+            )
+            if info_total[username]:
+                # Reset to zero the games_per_hour contribution
+                info_total[username]["games_per_hour"] = 0.0
+            else:
+                # No "user_cache" entry, initialize with cleared contribution
+                info_total[username] = info_top_month[username].copy()
+    return info_total, info_top_month
 
+
+def compute_games_rates(rundb, info_tuple):
+    # 1328000 nps is the reference core, also sets in views.py and game.py
+    for machine in rundb.get_machines():
+        games_per_hour = (
+            (machine["nps"] / 1328000.0)
+            * (3600.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
+            * (int(machine["concurrency"]) // machine["run"]["args"].get("threads", 1))
+        )
+        for info in info_tuple:
+            info[machine["username"]]["games_per_hour"] += games_per_hour
+
+
+def process_run(run, info):
+    # Update the number of tests contributed by the user
+    r_username = run["args"].get("username")
+    if r_username in info:
+        info[r_username]["tests"] += 1
+    else:
+        # TODO: run created by an user not in rundb.userdb.get_users() ???
+        print(f"not in userdb: {r_username=}; {run['_id']=}")
+        return
+
+    # Update the information for the workers contributed by the users
     tc = estimate_game_duration(run["args"]["tc"])
     for task in run["tasks"]:
         if "worker_info" not in task:
             continue
-        username = task["worker_info"].get("username", None)
-        if username is None:
+        t_username = task["worker_info"].get("username")
+        if t_username is None:
             continue
-        if username not in info:
-            print("not in info:", username)
+        if t_username not in info:
+            print(
+                f"not in userdb: {t_username=}; {run['_id']=}; {task['worker_info']=}"
+            )
             continue
 
         if "stats" in task:
@@ -44,164 +86,104 @@ def process_run(run, info, deltas=None):
         else:
             num_games = 0
 
-        try:
-            info[username]["last_updated"] = max(
-                task["last_updated"], info[username]["last_updated"]
-            )
-            info[username]["task_last_updated"] = max(
-                task["last_updated"], info[username]["last_updated"]
-            )
-        except (TypeError, KeyError):
-            # Comparison between a datetime and a string as "6 hours ago"
-            info[username]["last_updated"] = task["last_updated"]
-        except Exception as e:
-            print("Exception updating info[username]:", e, sep="\n", file=sys.stderr)
-
-        info[username]["cpu_hours"] += float(
+        info_user = info[t_username]
+        info_user["task_last_updated"] = max(
+            info_user["task_last_updated"], task.get("last_updated", datetime.min)
+        )
+        info_user["cpu_hours"] += float(
             num_games * int(run["args"].get("threads", 1)) * tc / (60 * 60)
         )
-        info[username]["games"] += num_games
-    if deltas is not None:
-        new_deltas.update({str(run["_id"]): None})
+        info_user["games"] += num_games
 
 
-def build_users(machines, info):
-    for machine in machines:
-        games_per_hour = (
-            (machine["nps"] / 1328000.0)
-            * (3600.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
-            * (int(machine["concurrency"]) // machine["run"]["args"].get("threads", 1))
-        )
-        info[machine["username"]]["games_per_hour"] += games_per_hour
-
-    users = []
-    for u in info.keys():
-        user = info[u]
+def update_info(rundb, clear_stats, deltas, info_total, info_top_month):
+    for run in rundb.get_unfinished_runs():
         try:
-            # eg "11 minutes ago", "6 hours ago", "Never"
-            if isinstance(user["last_updated"], str):
-                if "task_last_updated" in user:
-                    diff = diff_date(user["task_last_updated"])
-                    user["diff"] = diff.total_seconds()
-                    user["last_updated"] = delta_date(diff)
-            else:
-                # eg "2022-08-30 01:05:23.656000", "0001-01-01 00:00:00"
-                diff = diff_date(user["last_updated"])
-                user["diff"] = diff.total_seconds()
-                user["last_updated"] = delta_date(diff)
+            # Update info_top_month with the contribution of the unfinished runs
+            process_run(run, info_top_month)
         except Exception as e:
-            print("Exception updating user['diff']:", e, sep="\n", file=sys.stderr)
-        users.append(user)
+            print(f"Exception on unfinished run {run['_id']=} for info_top_month:\n{e}")
+
+    now = datetime.utcnow()
+    skip = False
+    skip_count = 0
+    new_deltas = {}
+
+    for run in rundb.runs.find({"finished": True}, sort=[("last_updated", DESCENDING)]):
+        if str(run["_id"]) in new_deltas:
+            # Lazy reads of an indexed collection, skip a repeated new finished run
+            print("Warning: skipping repeated finished run!")
+            continue
+
+        if not clear_stats and not skip and str(run["_id"]) in deltas:
+            # The run is in deltas, skip for info_total because we have already
+            # processed this run in previous script executions
+            skip = True
+        if not skip:
+            new_deltas |= {str(run["_id"]): None}
+            try:
+                # Update info_total with the contribution of the unfinished runs
+                process_run(run, info_total)
+            except Exception as e:
+                print(f"Exception on finished run {run['_id']=} for info_total:\n{e}")
+        if skip and skip_count < 10:
+            skip = False
+            skip_count += 1
+
+        # Update info_top_month with finished runs having start_time in the last 30 days
+        if (now - run["start_time"]).days < 30:
+            try:
+                process_run(run, info_top_month)
+            except Exception as e:
+                print(
+                    f"Exception on finished run {run['_id']=} for info_top_month:\n{e}"
+                )
+        elif not clear_stats and skip:
+            break
+
+    compute_games_rates(rundb, (info_total, info_top_month))
+    return new_deltas
+
+
+def build_users(info):
+    users = []
+    # diff_date(given_date) = datetime.utcnow() - given_date
+    # delta_date(diff: timedelta) -> str:
+    for username, info_user in info.items():
+        try:
+            diff = diff_date(info_user["task_last_updated"])
+            info_user["diff"] = diff.total_seconds()
+            info_user["last_updated"] = delta_date(diff)
+        except Exception as e:
+            print(f"Exception updating 'diff' for {username=}:\n{e}")
+        users.append(info_user)
 
     users = [u for u in users if u["games"] > 0 or u["tests"] > 0]
     return users
 
 
-def update_users():
-    rundb = RunDb()
+def update_deltas(rundb, deltas, new_deltas):
+    print("update deltas:")
+    print(f"{len(new_deltas)=}\n{next(iter(new_deltas))=}")
+    new_deltas |= deltas
+    print(f"{len(new_deltas)=}\n{next(iter(new_deltas))=}")
+    rundb.deltas.delete_many({})
+    rundb.deltas.insert_many([{k: v} for k, v in new_deltas.items()])
 
-    deltas = {}
-    info = {}
-    top_month = {}
 
-    clear_stats = True
-    if len(sys.argv) > 1:
-        print("scan all")
-    else:
-        deltas = rundb.deltas.find_one()
-        if deltas:
-            clear_stats = False
-        else:
-            deltas = {}
-
-    for u in rundb.userdb.get_users():
-        username = u["username"]
-        top_month[username] = {
-            "username": username,
-            "cpu_hours": 0,
-            "games": 0,
-            "tests": 0,
-            "tests_repo": u.get("tests_repo", ""),
-            "last_updated": datetime.min,
-            "games_per_hour": 0.0,
-        }
-        if clear_stats:
-            info[username] = top_month[username].copy()
-        else:
-            info[username] = rundb.userdb.user_cache.find_one({"username": username})
-            if info[username]:
-                info[username]["games_per_hour"] = 0.0
-            else:
-                info[username] = top_month[username].copy()
-
-    for run in rundb.get_unfinished_runs():
-        try:
-            process_run(run, top_month)
-        except Exception as e:
-            print(
-                "Exception processing run {} for top_month:".format(run["_id"]),
-                e,
-                sep="\n",
-                file=sys.stderr,
-            )
-
-    # Step through these in small batches (step size 100) to save RAM
-    step_size = 100
-
-    now = datetime.utcnow()
-    more_days = True
-    last_updated = None
-    while more_days:
-        q = {"finished": True}
-        if last_updated:
-            q["last_updated"] = {"$lt": last_updated}
-        runs = list(
-            rundb.runs.find(q, sort=[("last_updated", DESCENDING)], limit=step_size)
-        )
-        if len(runs) == 0:
-            break
-        for run in runs:
-            try:
-                process_run(run, info, deltas)
-            except Exception as e:
-                print(
-                    "Exception processing run {} for deltas:".format(run["_id"]),
-                    e,
-                    sep="\n",
-                    file=sys.stderr,
-                )
-            if (now - run["start_time"]).days < 30:
-                try:
-                    process_run(run, top_month)
-                except Exception as e:
-                    print(
-                        "Exception on run {} for top_month:".format(run["_id"]),
-                        e,
-                        sep="\n",
-                        file=sys.stderr,
-                    )
-            elif not clear_stats:
-                more_days = False
-        last_updated = runs[-1]["last_updated"]
-
-    if new_deltas:
-        new_deltas.update(deltas)
-        rundb.deltas.delete_many({})
-        rundb.deltas.insert_many([{k: v} for k, v in new_deltas.items()])
-
-    machines = list(rundb.get_machines())
-
+def update_users(rundb, users_total, users_top_month):
     rundb.userdb.user_cache.delete_many({})
-    users = build_users(machines, info)
-    if users:
-        rundb.userdb.user_cache.insert_many(users)
+    if users_total:
+        rundb.userdb.user_cache.insert_many(users_total)
         rundb.userdb.user_cache.create_index("username", unique=True)
-
+        print(f"Successfully updated {len(users_total)} users")
     rundb.userdb.top_month.delete_many({})
-    users_top = build_users(machines, top_month)
-    if users_top:
-        rundb.userdb.top_month.insert_many(users_top)
+    if users_top_month:
+        rundb.userdb.top_month.insert_many(users_top_month)
+        print(f"Successfully updated {len(users_top_month)} top month users")
 
+
+def cleanup_users(rundb):
     # Delete users that have never been active and old admins group
     idle = {}
     for u in rundb.userdb.get_users():
@@ -228,11 +210,72 @@ def update_users():
             print("Delete:", str(u["_id"]))
             rundb.userdb.users.delete_one({"_id": u["_id"]})
 
-    print("Successfully updated {} users".format(len(users)))
 
-    # record this update run
+def main():
+    # The script computes the total and top month contributions of all users in two modes:
+    # - full scan  : from scratch, starting from a clean status.
+    # - update scan: incrementally, using the status from previous executions of the script
+    # Note that the update scan is not perfect:
+    # - It does not account for the additional contribution of runs that have switched
+    #   from finished to unfinished and back to finished in the meantime.
+    # - It underestimates the top month contribution compared to the full scan
+    #   due to the exit condition.
+
+    # "info_total" and "info_top_month" are dictionaries with the username as the key.
+    # They are used to collect information about the contributions of each user for these runs
+    # "info_total"    : all finished runs.
+    # "info_top_month": unfinished runs and finished runs started within the previous 30 days.
+    # Each username/key has a nested dictionary with the following structure:
+    # info[username] = {
+    #     "username": username,
+    #     "cpu_hours": 0,
+    #     "games": 0,
+    #     "games_per_hour": 0.0,
+    #     "tests": 0,
+    #     "tests_repo": u.get("tests_repo", ""),
+    #     "task_last_updated": datetime.min, # latest datetime of all user's tasks
+    #     "diff": diff_date(datetime.min),   # used to sort in the users table
+    #     "last_updated": delta_date(diff_date(datetime.min)), # e.g. "Never", "12 days ago"
+
+    # "new_deltas": dictionary with keys representing the IDs of newly finished runs
+    # since the previous script execution. It is used to update the "deltas" collection.
+    # "deltas"    : dictionary with keys representing the IDs of all finished runs that
+    # have already been processed in previous script executions to avoid double counting.
+    # It is loaded from the "deltas" collection.
+    # If in clear_stats mode, it is an empty dictionary.
+
+    rundb = RunDb()
+
+    if len(sys.argv) > 1:
+        # Force full scan
+        deltas = {}
+    else:
+        # No guarantee that the returned natural order will be the insertion order
+        deltas = rundb.deltas.find({}, {"_id": 0})
+
+    if deltas:
+        print("update scan")
+        clear_stats = False
+        deltas = {k: v for d in deltas for k, v in d.items()}
+        print("load deltas:")
+        print(f"{len(deltas)=}\n{next(iter(deltas))=}")
+    else:
+        print("full scan")
+        clear_stats = True
+        deltas = {}
+
+    info_total, info_top_month = initialize_info(rundb, clear_stats)
+    new_deltas = update_info(rundb, clear_stats, deltas, info_total, info_top_month)
+    if new_deltas:
+        update_deltas(rundb, deltas, new_deltas)
+
+    users_total = build_users(info_total)
+    users_top_month = build_users(info_top_month)
+    update_users(rundb, users_total, users_top_month)
+    cleanup_users(rundb)
+    # Record this update run
     rundb.actiondb.system_event(message="Update user statistics")
 
 
 if __name__ == "__main__":
-    update_users()
+    main()


### PR DESCRIPTION
The previous version of the script had two major issues:
1. it loaded only one run ID from the deltas collection without any sorting
   criterion. Since there is no guarantee that the returned natural order
   is the insertion order, this could result in a very inaccurate contribution
   calculation in the first update scan after a full scan, when the deltas
   collection contains all the finished run IDs.
2. the run, with the ID loaded from the deltas collection, could switch
   to active status (e.g., after a purge).
   This resulted in failing to stop the processing and double counting
   of already processed finished runs from the last 30 days.

Changes:
- load and save the IDs of all the processed finished runs in
  deltas collection, python checks if a key is in a dict in O(1)
- in update scan mode, for the total contribution:
  - skip processing of any finished run with ID in deltas
  - stop processing after hitting 10 finished runs with ID in deltas
- lazy load the data from collections to lower the RAM footprint
- simplify the algorithms
- add comments

Note that the update scan is not perfect:
- it does not account for the additional contribution of runs that have
  switched from finished to unfinished and back to finished in the meantime.
- it underestimates the top month contribution compared to the full scan
  due to the exit condition.