### PR TITLE
Remove local storage items from earlier iterations of the notification code

### DIFF
--- a/server/fishtest/static/js/notifications.js
+++ b/server/fishtest/static/js/notifications.js
@@ -489,4 +489,14 @@ broadcast_dispatch["set_notification_status_"] = set_notification_status_;
 broadcast_dispatch["disable_notification_"] = disable_notification_;
 broadcast_dispatch["dismiss_notification_"] = dismiss_notification_;
 
+function cleanup_() {
+  // Remove stale local storage items.
+  localStorage.removeItem("fishtest_disable_notification");
+  localStorage.removeItem("fishtest_notifications");
+  localStorage.removeItem("fishtest_notifications_v2");
+  localStorage.removeItem("fishtest_timestamp");
+  localStorage.removeItem("fishtest_timestamp_purge");
+}
+
+cleanup_();
 main_follow_loop();


### PR DESCRIPTION
This adds temporary code to remove some local storage item that are no longer used. The code should be removed again in a future PR. 