### PR TITLE
Set slow worker threshold

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 202
+WORKER_VERSION = 203
 
 
 def validate_request(request):

--- a/worker/games.py
+++ b/worker/games.py
@@ -1290,7 +1290,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
         games_concurrency * threads,
     )
 
-    if base_nps < 540000 / (1 + math.tanh((worker_concurrency - 1) / 8)):
+    if base_nps < 434000 / (1 + math.tanh((worker_concurrency - 1) / 8)):
         raise FatalException(
             "This machine is too slow ({} nps / thread) to run fishtest effectively - sorry!".format(
                 base_nps

--- a/worker/games.py
+++ b/worker/games.py
@@ -309,7 +309,7 @@ def establish_validated_net(remote, testing_dir, net):
                         "Failed to validate the network: {}".format(net)
                     )
                 break
-            except WorkerException as e:
+            except WorkerException:
                 if attempt > 5:
                     raise
                 waitTime = UPDATE_RETRY_TIME * attempt

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 202, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "P3WT0Yhdj/rQ3ZrZ327nM7JQz87NhZC7wggqnqizeJJPbFy49ayo9n7JHoL/7eqv", "games.py": "sgnOBQQ9sZz6AlBg1SP7B1btuY0/p1StAwUtmoVzQk1+I/PjphRKlh2ak4yIpzFP"}
+{"__version": 203, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "ERkY0Llrcv8pa6weOZs+dHtTHxbd5zCjqfeqlXwZjmqBcCOmsRQ3hgjE7ZQKfhzN", "games.py": "bK3SvG/8oGKOZlgT4oczbfgzOS6LMOesBKWWVI4P74z1cMJB9C2cqqas7U42XO3x"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -5,7 +5,6 @@ import datetime
 import getpass
 import hashlib
 import json
-import math
 import multiprocessing
 import os
 import platform
@@ -55,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 202
+WORKER_VERSION = 203
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
Fishtest with Stockfish 11 had 1.6MNps as reference Nps and 0.7MNps as
threshold for the slow worker.
Set the new threshold for slow worker according to the 38% slowdown
of the SF dev-20230531-d99942f2 wrt SF 11 on the arch=modern.

The new reference Nps will be set (using the recent arch=bmi2) with
the next SF release to avoid a jump in the progression tests.

compiler clang 16.0.5

- arch=bmi2 (Dual Xeon workstation)
```
sf_base =  1591512 +/-   5997 (95%)
sf_test =  1125091 +/-   5203 (95%)
diff    =  -466420 +/-   7277 (95%)
speedup = -29.307% +/- 0.457% (95%)
```

- arch=modern (core i7 3770k)
```
sf_base =  1873067 +/-  18016 (95%)
sf_test =  1161362 +/-   8271 (95%)
diff    =  -711704 +/-  12171 (95%)
speedup = -37.997% +/- 0.650% (95%)
```