### PR TITLE
Reduce concurrency if needed

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 203
+WORKER_VERSION = 204
 
 
 def validate_request(request):

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -825,6 +825,7 @@ class RunDb:
             need_tt += get_hash(run["args"]["base_options"])
             need_tt *= max_threads // run["args"]["threads"]
             # estime another 10MB per process, 30MB per thread, and 80MB for net as a base memory need besides hash
+            # Note that changes here need the corresponding worker change to STC_memory, which limits concurrency
             need_base = (
                 2
                 * (max_threads // run["args"]["threads"])

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 203, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "kzHtjE+/Lb4UQlMBlpx8IQ6i0WTkLc9W7yETMEEaVeif6HkM4HX20jf3vj2kWFU4", "games.py": "bK3SvG/8oGKOZlgT4oczbfgzOS6LMOesBKWWVI4P74z1cMJB9C2cqqas7U42XO3x"}
+{"__version": 204, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "9EKKj10GM/RmhL/3FwbMwFjfM4h+nS+c2PBxwDHqPo1sSZUi8NvQMXLQQkhVn/N5", "games.py": "bK3SvG/8oGKOZlgT4oczbfgzOS6LMOesBKWWVI4P74z1cMJB9C2cqqas7U42XO3x"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 203, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "ERkY0Llrcv8pa6weOZs+dHtTHxbd5zCjqfeqlXwZjmqBcCOmsRQ3hgjE7ZQKfhzN", "games.py": "bK3SvG/8oGKOZlgT4oczbfgzOS6LMOesBKWWVI4P74z1cMJB9C2cqqas7U42XO3x"}
+{"__version": 203, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "kzHtjE+/Lb4UQlMBlpx8IQ6i0WTkLc9W7yETMEEaVeif6HkM4HX20jf3vj2kWFU4", "games.py": "bK3SvG/8oGKOZlgT4oczbfgzOS6LMOesBKWWVI4P74z1cMJB9C2cqqas7U42XO3x"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -782,6 +782,24 @@ def setup_parameters(worker_dir):
         print("Changing port to 443")
         options.port = 443
 
+    # Limit concurrency so that at least STC tests can run with the evailable memory
+    # The memory need per engine is 16 for the TT Hash, 10 for the process 80 for the net and 30 per thread
+    # These numbers need to be up-to-date with the server values
+    STC_memory = 2 * (16 + 10 + 80 + 30)
+    max_concurrency = max(1, int(options.max_memory / STC_memory))
+    if max_concurrency < options.concurrency:
+        print(
+            "Changing concurrency to allow for running STC tests with the available memory"
+        )
+        print(
+            "The required memory to run with {} concurrency is {} MB".format(
+                options.concurrency, STC_memory * options.concurrency
+            )
+        )
+        print("The concurrency has been reduced to {}".format(max_concurrency))
+        print("Consider increasing max_memory if possible")
+        options.concurrency = max_concurrency
+
     options.compiler = compilers[options.compiler_]
 
     options.hw_id = hw_id(config.getint("private", "hw_seed"))

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -54,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 203
+WORKER_VERSION = 204
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
In case the worker has little memory (noob's workers), it might be impossible to run any tasks at the full concurrency specified by the user.

In that case, reduce concurrency to be able to run at least STC tests.