### PR TITLE
Set the SF16 reference Nps using SF11 as base

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 205
+WORKER_VERSION = 206
 
 
 def validate_request(request):

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -523,7 +523,7 @@ class RunDb:
                     nps += concurrency * task["worker_info"]["nps"]
                     if task["worker_info"]["nps"] != 0:
                         games_per_minute += (
-                            (task["worker_info"]["nps"] / 1328000.0)
+                            (task["worker_info"]["nps"] / 1184000)
                             * (60.0 / estimate_game_duration(run["args"]["tc"]))
                             * (
                                 int(task["worker_info"]["concurrency"])

--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -44,10 +44,10 @@ def initialize_info(rundb, clear_stats):
 
 
 def compute_games_rates(rundb, info_tuple):
-    # 1328000 nps is the reference core, also sets in views.py and game.py
+    # 1184000 nps is the reference core, also set in rundb.py and games.py
     for machine in rundb.get_machines():
         games_per_hour = (
-            (machine["nps"] / 1328000.0)
+            (machine["nps"] / 1184000)
             * (3600.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
             * (int(machine["concurrency"]) // machine["run"]["args"].get("threads", 1))
         )

--- a/worker/games.py
+++ b/worker/games.py
@@ -1290,14 +1290,15 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
         games_concurrency * threads,
     )
 
-    if base_nps < 434000 / (1 + math.tanh((worker_concurrency - 1) / 8)):
+    if base_nps < 462000 / (1 + math.tanh((worker_concurrency - 1) / 8)):
         raise FatalException(
             "This machine is too slow ({} nps / thread) to run fishtest effectively - sorry!".format(
                 base_nps
             )
         )
-    # 1328000 nps is the reference core, also set in views.py and delta_update_users.py
-    factor = 1328000 / base_nps
+    # 1184000 nps is the reference core benched with respect to SF 11,
+    # also set in rundb.py and delta_update_users.py
+    factor = 1184000 / base_nps
 
     # Adjust CPU scaling.
     _, tc_limit_ltc = adjust_tc("60+0.6", factor)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 205, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "cCyr244zHs0k/Uur7lQlXSCsmGwCT7L+bSxrH4kLB6Dol2AsUCz/Lg+Bo2VPgQVk", "games.py": "bK3SvG/8oGKOZlgT4oczbfgzOS6LMOesBKWWVI4P74z1cMJB9C2cqqas7U42XO3x"}
+{"__version": 206, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "R8rJ4c9ZQTbuSu80ayVyMs7D6/TOVR5qMn6R04XCsBp4BTkCKXfy7hSrpMaLa0nX", "games.py": "D+5sFwptbwAhvn+VM4oHyRwqUPfGUWLQPFbWHA/uK77rTUsU/r49gBMjjz6k5Ncq"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -54,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 205
+WORKER_VERSION = 206
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
Fishtest with Stockfish 11 had 1.6MNps as reference Nps and 0.7MNps as threshold for the slow worker.
Set the new reference Nps according to the 26% slowdown of the SF 16 wrt SF 11 on the ARCH=x86-64-bmi2.
Set the new threshold for slow worker according to the 34% slowdown of the SF 16 wrt SF 11 on the ARCH=x86-64-modern (x86-64-sse41-popcnt).

compiler clang++ 16.0.6

- arch=bmi2 (Intel Xeon CPU E5-2680 v3)
```
sf_base =  1580934 +/-  12410 (95%)
sf_test =  1163656 +/-   7679 (95%)
diff    =  -417278 +/-  11547 (95%)
speedup = -26.394% +/- 0.730% (95%
```

- arch=modern (Intel core i7 3770k)
```
sf_base =  1865978 +/-  14061 (95%)
sf_test =  1228350 +/-  11701 (95%)
diff    =  -637627 +/-   5230 (95%)
speedup = -34.171% +/- 0.280% (95%)
```

Raise worker version to 206, also server side.