### PR TITLE
Prepare Fishtest for Stockfish 16 release.

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -349,55 +349,33 @@ legend {
   content: "\f02d";
 }
 
-.mainnavbar [href="https://github.com/official-stockfish/Stockfish"]::before
-{
+.mainnavbar .stockfish-repo::before {
   content: "\f578";
 }
 
-.mainnavbar [href="https://github.com/glinscott/fishtest/wiki"]::before
-{
+.mainnavbar .wiki::before {
   content: "\f266";
   font-family: "Font Awesome 5 Brands";
   font-weight: 400;
 }
 
-.mainnavbar [href="https://groups.google.com/g/fishcooking"]::before
-{
-  content: "\f086";
-}
-
-.mainnavbar [href="https://groups.google.com/g/fishcooking-results"]::before
-{
-  content: "\f1da";
-}
-
-.mainnavbar [href="https://hxim.github.io/Stockfish-Evaluation-Guide/"]::before
-{
+.mainnavbar .eval-guide::before {
   content: "\f518";
 }
 
-.mainnavbar [href="https://github.com/official-stockfish/Stockfish/wiki/Regression-Tests"]::before
-{
+.mainnavbar .regression::before {
   content: "\f201";
 }
 
-.mainnavbar [href="https://abrok.eu/stockfish/"]::before
-{
+.mainnavbar .release::before {
   content: "\f019";
 }
 
-.mainnavbar [href="https://stockfishchess.org/download/"]::before
-{
-  content: "\f019";
-}
-
-.mainnavbar [href="https://stockfishchess.org/get-involved/"]::before
-{
+.mainnavbar .get-involved::before {
   content: "\f4c4";
 }
 
-.mainnavbar [href="https://discord.gg/awnh2qZfTT"]::before
-{
+.mainnavbar .discord::before {
   content: "\f392";
   font-family: "Font Awesome 5 Brands";
   font-weight: 400;

--- a/server/fishtest/static/js/spsa_new.js
+++ b/server/fishtest/static/js/spsa_new.js
@@ -95,7 +95,7 @@ function spsa_compute(spsa_setup) {
 /*
 Below is some code to estimate the draw ratio from the time
 control. The algorithm is very naive. It uses interpolation for
-a few data points valid for the book "UHO_XXL_+0.90_+1.19.epd".
+a few data points valid for the book "UHO_4060_v2.epd".
 */
 
 function tc_to_seconds(tc) {
@@ -153,7 +153,7 @@ function logistic(x) {
 
 function draw_ratio(tc) {
   /*
-  Formula approximately valid for the book "UHO_XXL_+0.90_+1.19.epd".
+  Formula approximately valid for the book "UHO_4060_v2.epd".
   The "virtual" draw ratio of an unbalanced book is defined as
   1 - 4 * ("pentanomial variance/game")
   */

--- a/server/fishtest/templates/base.mak
+++ b/server/fishtest/templates/base.mak
@@ -167,7 +167,6 @@
                     <li><a href="/tests/finished?ltc_only=1" class="links-link rounded">LTC</a></li>
                     <li><a href="/tests/finished?success_only=1" class="links-link rounded">Greens</a></li>
                     <li><a href="/tests/finished?yellow_only=1" class="links-link rounded">Yellows</a></li>
-                    <li><a href="https://groups.google.com/g/fishcooking-results" target="_blank" rel="noopener" class="links-link rounded">History</a></li>
                   </ul>
                 </li>
 
@@ -197,10 +196,10 @@
                 <li class="links-group">
                   <strong class="links-heading d-flex w-100 align-items-center fw-semibold">Stockfish</strong>
                   <ul class="list-unstyled fw-normal small">
-                    <li><a href="https://stockfishchess.org/download/" target="_blank" rel="noopener" class="links-link rounded">Official Releases</a></li>
-                    <li><a href="https://abrok.eu/stockfish/" target="_blank" rel="noopener" class="links-link rounded">Dev Builds</a></li>
-                    <li><a href="https://stockfishchess.org/get-involved/" target="_blank" rel="noopener" class="links-link rounded">Contribute</a></li>
-                    <li><a href="https://github.com/official-stockfish/Stockfish/wiki/Regression-Tests" target="_blank" rel="noopener" class="links-link rounded">Progress</a></li>
+                    <li><a href="https://stockfishchess.org/download/" target="_blank" rel="noopener" class="links-link rounded release">Official Releases</a></li>
+                    <li><a href="https://github.com/official-stockfish/Stockfish/releases?q=prerelease%3Atrue" target="_blank" rel="noopener" class="links-link rounded release">Prereleases</a></li>
+                    <li><a href="https://stockfishchess.org/get-involved/" target="_blank" rel="noopener" class="links-link rounded get-involved">Contribute</a></li>
+                    <li><a href="https://github.com/official-stockfish/Stockfish/wiki/Regression-Tests" target="_blank" rel="noopener" class="links-link rounded regression">Progress</a></li>
                     <li><a href="/nns" class="links-link rounded">NN Repo</a></li>
                   </ul>
                 </li>
@@ -210,11 +209,12 @@
                 <li class="links-group">
                   <strong class="links-heading d-flex w-100 align-items-center fw-semibold">Resources</strong>
                   <ul class="list-unstyled fw-normal small">
-                    <li><a href="https://discord.gg/awnh2qZfTT" target="_blank" rel="noopener" class="links-link rounded">Discord</a></li>
-                    <li><a href="https://groups.google.com/g/fishcooking" target="_blank" rel="noopener" class="links-link rounded">Forum</a></li>
-                    <li><a href="https://github.com/glinscott/fishtest/wiki" target="_blank" rel="noopener" class="links-link rounded">Wiki</a></li>
+                    <li><a href="https://discord.gg/awnh2qZfTT" target="_blank" rel="noopener" class="links-link rounded discord">Discord</a></li>
+                    <li><a href="https://github.com/glinscott/fishtest/wiki" target="_blank" rel="noopener" class="links-link rounded wiki">Fishtest Wiki</a></li>
+                    <li><a href="https://github.com/official-stockfish/Stockfish/wiki" target="_blank" rel="noopener" class="links-link rounded wiki">Stockfish Wiki</a></li>
+                    <li><a href="https://github.com/glinscott/nnue-pytorch/wiki" target="_blank" rel="noopener" class="links-link rounded wiki">NN Trainer Wiki</a></li>
                     <li><a href="/sprt_calc" class="links-link rounded">SPRT Calc</a></li>
-                    <li><a href="https://hxim.github.io/Stockfish-Evaluation-Guide/" target="_blank" rel="noopener" class="links-link rounded">Eval Guide</a></li>
+                    <li><a href="https://hxim.github.io/Stockfish-Evaluation-Guide/" target="_blank" rel="noopener" class="links-link rounded eval-guide">Eval Guide</a></li>
                   </ul>
                 </li>
 
@@ -223,7 +223,7 @@
                 <li class="links-group">
                   <strong class="links-heading d-flex w-100 align-items-center fw-semibold">Development</strong>
                   <ul class="list-unstyled fw-normal small">
-                    <li><a href="https://github.com/official-stockfish/Stockfish" target="_blank" rel="noopener" class="links-link rounded">Stockfish</a></li>
+                    <li><a href="https://github.com/official-stockfish/Stockfish" target="_blank" rel="noopener" class="links-link rounded stockfish-repo">Stockfish</a></li>
                     <li><a href="https://github.com/glinscott/fishtest" target="_blank" rel="noopener" class="links-link rounded">Fishtest</a></li>
                     <li><a href="https://github.com/glinscott/nnue-pytorch" target="_blank" rel="noopener" class="links-link rounded">NN Trainer</a></li>
                     <li><a href="https://github.com/official-stockfish/books" target="_blank" rel="noopener" class="links-link rounded">Books</a></li>

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -4,8 +4,8 @@
   from fishtest.util import format_bounds
   elo_model = "normalized"
   fb = lambda e0, e1: format_bounds(elo_model, e0, e1)
-  test_book = "UHO_XXL_+0.90_+1.19.epd"
-  pt_book = "8moves_v3.pgn"
+  test_book = "UHO_4060_v2.epd"
+  pt_book = "UHO_4060_v2.epd"
 %>
 <%
   base_branch = args.get('base_tag', 'master')
@@ -473,7 +473,7 @@
                         <a href="https://github.com/vdbergh/spsa_simul" target="_blank">
                           https://github.com/vdbergh/spsa_simul</a
                         >. Currently this option should be used with the book
-                        'UHO_XXL_+0.90_+1.19.epd' and in addition the option should not be used with
+                        'UHO_4060_v2.epd' and in addition the option should not be used with
                         nodestime or with more than one thread.
                       </div>
                     </div>

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -371,8 +371,8 @@ def remaining_hours(run):
         if llr >= llr_bound:
             return 0
 
-        # Assume all tests use default book (UHO_XXL_+0.90_+1.19).
-        book_positions = 223070
+        # Assume all tests use default book (UHO_4060_v2).
+        book_positions = 242201
         t = scipy.stats.beta(1, 15).cdf(min(N / book_positions, 1.0))
         expected_games_llr = int(2 * N * llr_bound / llr)
         expected_games = min(


### PR DESCRIPTION
* Stockfish now officially prelease dev builds so redirect to the latest one instead of Dev builds for ARM builds.
* as Stockfish's maintainer discussed on Discord, change the default testing book to UHO_4060_v2.epd in preparation for the SF16 release.
* Remove deprecated fishcooking forum link
* Adds Stockfish Wiki and NNUE Trainer Wiki as Fishtest maintainer suggested.