### PR TITLE
Adjust settings for the SMP PT

### DIFF
--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -157,13 +157,13 @@
                     <input class="list-group-item-check pe-none" type="radio" name="test-type" id="pt_smp_test"
                       data-options='{
                         "name": "PT SMP",
-                        "tc": "30+0.3",
-                        "new_tc": "30+0.3",
+                        "tc": "60+0.6",
+                        "new_tc": "60+0.6",
                         "threads": 8,
-                        "options": "Hash=256 Use NNUE=true",
+                        "options": "Hash=512 Use NNUE=true",
                         "book": "${pt_book}",
                         "stop_rule": "stop-rule-games",
-                        "games": 40000,
+                        "games": 60000,
                         "test_branch": "master",
                         "base_branch": "${pt_branch}",
                         "test_signature": ${latest_bench},


### PR DESCRIPTION
perform SMP PT at 60+0.6T. The reason is that we're doing quite a few tests at those settings today, so it might be nice to capture that.