### PR TITLE
Set the SF16 pure NNUE reference nps wrt SF11

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 206
+WORKER_VERSION = 207
 
 
 def validate_request(request):

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -523,7 +523,7 @@ class RunDb:
                     nps += concurrency * task["worker_info"]["nps"]
                     if task["worker_info"]["nps"] != 0:
                         games_per_minute += (
-                            (task["worker_info"]["nps"] / 1184000)
+                            (task["worker_info"]["nps"] / 640000)
                             * (60.0 / estimate_game_duration(run["args"]["tc"]))
                             * (
                                 int(task["worker_info"]["concurrency"])

--- a/server/utils/delta_update_users.py
+++ b/server/utils/delta_update_users.py
@@ -47,7 +47,7 @@ def compute_games_rates(rundb, info_tuple):
     # 1184000 nps is the reference core, also set in rundb.py and games.py
     for machine in rundb.get_machines():
         games_per_hour = (
-            (machine["nps"] / 1184000)
+            (machine["nps"] / 640000)
             * (3600.0 / estimate_game_duration(machine["run"]["args"]["tc"]))
             * (int(machine["concurrency"]) // machine["run"]["args"].get("threads", 1))
         )

--- a/worker/games.py
+++ b/worker/games.py
@@ -1290,7 +1290,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
         games_concurrency * threads,
     )
 
-    if base_nps < 462000 / (1 + math.tanh((worker_concurrency - 1) / 8)):
+    if base_nps < 231000 / (1 + math.tanh((worker_concurrency - 1) / 8)):
         raise FatalException(
             "This machine is too slow ({} nps / thread) to run fishtest effectively - sorry!".format(
                 base_nps
@@ -1298,7 +1298,7 @@ def run_games(worker_info, password, remote, run, task_id, pgn_file):
         )
     # 1184000 nps is the reference core benched with respect to SF 11,
     # also set in rundb.py and delta_update_users.py
-    factor = 1184000 / base_nps
+    factor = 640000 / base_nps
 
     # Adjust CPU scaling.
     _, tc_limit_ltc = adjust_tc("60+0.6", factor)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 206, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "R8rJ4c9ZQTbuSu80ayVyMs7D6/TOVR5qMn6R04XCsBp4BTkCKXfy7hSrpMaLa0nX", "games.py": "D+5sFwptbwAhvn+VM4oHyRwqUPfGUWLQPFbWHA/uK77rTUsU/r49gBMjjz6k5Ncq"}
+{"__version": 207, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "6v8r4DGKbGAS8joczJrNjO3xX4/QImrKkU4xOpNXc5PGy4kFNgcyvxGc96FsUVww", "games.py": "LI8f72sm9yoqxO0sJPbpXTSGIgVfJhb0WuKPZ2AU2z0QCz/4IYnfYik+B/NiWG7x"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -54,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 206
+WORKER_VERSION = 207
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
Fishtest with Stockfish 11 had 1.6Mnps as reference nps and 0.7Mnps as threshold for the slow worker.
Set the new reference nps to 0.64Mnps according to the 60% slowdown of the SF 16 wrt SF 11 on the ARCH=x86-64-bmi2
Set the new threshold for slow worker to 0.231Mnps according to the 67% slowdown of the SF 16 wrt SF 11 on the ARCH=x86-64-sse41-popcnt

compiler clang++ 16.0.6

- arch=bmi2 (Intel Xeon CPU E5-2680 v3)
```
sf_base =  1515099 +/-   6276 (95%)
sf_test =   610755 +/-   2686 (95%)
diff    =  -904343 +/-   5940 (95%)
speedup = -59.689% +/- 0.392% (95%)
```

- arch=sse41-popcnt (Intel core i7 3770k)
```
sf_base =  1929595 +/-  19733 (95%)
sf_test =   654161 +/-   5421 (95%)
diff    = -1275433 +/-  14999 (95%)
speedup = -66.099% +/- 0.777% (95%)
```

Raise worker version to 207, also server side.