### PR TITLE
Fix string representation of signals for Python 3.11.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -25,7 +25,7 @@ db directly. However this information may be slightly outdated, depending
 on how frequently the main instance flushes its run cache.
 """
 
-WORKER_VERSION = 209
+WORKER_VERSION = 210
 
 
 def validate_request(request):

--- a/worker/games.py
+++ b/worker/games.py
@@ -101,7 +101,7 @@ def backup_log():
 
 def str_signal(signal_):
     try:
-        return str(signal.Signals(signal_)).split(".")[-1]
+        return signal.Signals(signal_).name
     except (ValueError, AttributeError):
         return "SIG<{}>".format(signal_)
 

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 209, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "hLagk85qdfEtzTE90p8VQ+JzuQYC5p2by2biumxioDoXXI3+Iz2tLBnlm+KcATyS", "games.py": "BGqisf99isI+HTRvHN0+t9UwkcmVKmDVRGhtgNBlCHOmJG+zsPboZ0tqWpYeY9sZ"}
+{"__version": 209, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "hLagk85qdfEtzTE90p8VQ+JzuQYC5p2by2biumxioDoXXI3+Iz2tLBnlm+KcATyS", "games.py": "7m8vZuGULuOtXGPuw6pxnu8BEW4DYjcf7RyRhzwB2XyeL783gaEDSc/ZsIUq+1zg"}

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 209, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "hLagk85qdfEtzTE90p8VQ+JzuQYC5p2by2biumxioDoXXI3+Iz2tLBnlm+KcATyS", "games.py": "7m8vZuGULuOtXGPuw6pxnu8BEW4DYjcf7RyRhzwB2XyeL783gaEDSc/ZsIUq+1zg"}
+{"__version": 210, "updater.py": "PHFUVXcoxBFiW2hTqFN5q5WdAw2pK8uzFC7hyMUC3cLY5bGZPhL8TBGThtqDmcXd", "worker.py": "Rbz9q1bCKE2MsrtUV3ywqP8tci1ao531KY26g6ZreiLnS9OnYlRJXmGBZap84CG/", "games.py": "7m8vZuGULuOtXGPuw6pxnu8BEW4DYjcf7RyRhzwB2XyeL783gaEDSc/ZsIUq+1zg"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -54,7 +54,7 @@ from updater import update
 # Several packages are called "expression".
 # So we make sure to use the locally installed one.
 
-WORKER_VERSION = 209
+WORKER_VERSION = 210
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0


### PR DESCRIPTION
See 

https://tests.stockfishchess.org/actions?max_actions=1&action=&user=&text=&before=1692105137.772177&run_id=

vs

https://tests.stockfishchess.org/actions?max_actions=1&action=&user=&text=&before=1692102104.224252&run_id=