### PR TITLE
No GitHub api calls if repo is not forked from official-stockfish

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -543,6 +543,7 @@ class RunDb:
         spsa=None,
         username=None,
         tests_repo=None,
+        master_repo=None,
         auto_purge=False,
         throughput=100,
         priority=0,
@@ -579,6 +580,9 @@ class RunDb:
             "priority": priority,
             "adjudication": adjudication,
         }
+
+        if master_repo is not None:
+            run_args["master_repo"] = master_repo
 
         if sprt is not None:
             run_args["sprt"] = sprt

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -659,7 +659,7 @@ valid_aggregated_data = intersect(
 # about non-validation of runs created with the prior
 # schema.
 
-RUN_VERSION = 19
+RUN_VERSION = 20
 
 runs_schema = intersect(
     {
@@ -707,6 +707,7 @@ runs_schema = intersect(
                 "new_signature": str_int,
                 "username": username,
                 "tests_repo": github_repo,
+                "master_repo?": github_repo,  # present only when non-standard (rare)
                 "auto_purge": bool,
                 "throughput": unumber,
                 "itp": unumber,


### PR DESCRIPTION
The GitHub api calls which compare the official master repo with the dev repo will fail.

Also: display corresponding warning.