### PR TITLE
Fix typos (part 2)

### DIFF
--- a/server/fishtest/spsa_handler.py
+++ b/server/fishtest/spsa_handler.py
@@ -7,7 +7,7 @@ import numpy as np
 def _pack_flips(flips):
     """
     This transforms a list of +-1 into a sequence of bytes
-    with the meaning of the indivual bits being 1:1, 0:-1.
+    with the meaning of the individual bits being 1:1, 0:-1.
     """
     return np.packbits(np.array(flips, dtype=np.int8) == 1).tobytes() if flips else b""
 

--- a/server/fishtest/stats/LLRcalc.py
+++ b/server/fishtest/stats/LLRcalc.py
@@ -51,7 +51,7 @@ def uniform(pdf):
 
 def MLE_expected(pdfhat, s):
     """
-    Compute the maximum likelood estimate for
+    Compute the maximum likelihood estimate for
     a discrete distribution with expectation value s,
     given an observed (i.e. empirical) distribution pdfhat.
 
@@ -71,7 +71,7 @@ def MLE_expected(pdfhat, s):
 
 def MLE_t_value(pdfhat, ref, s):
     """
-    Compute the maximum likelood estimate for
+    Compute the maximum likelihood estimate for
     a discrete distribution with t-value ((mu-ref)/sigma),
     given an observed (i.e. empirical) distribution pdfhat.
 

--- a/server/fishtest/stats/sprt.py
+++ b/server/fishtest/stats/sprt.py
@@ -126,7 +126,7 @@ class sprt:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--alpha", help="probability of a false positve", type=float, default=0.05
+        "--alpha", help="probability of a false positive", type=float, default=0.05
     )
     parser.add_argument(
         "--beta", help="probability of a false negative", type=float, default=0.05

--- a/server/fishtest/stats/stat_util.py
+++ b/server/fishtest/stats/stat_util.py
@@ -8,7 +8,7 @@ from fishtest.stats import LLRcalc, sprt
 
 def Phi(q):
     """
-    Cumlative distribution function for the standard Gaussian law: quantile -> probability
+    Cumulative distribution function for the standard Gaussian law: quantile -> probability
     """
     return scipy.stats.norm.cdf(q)
 


### PR DESCRIPTION
This PR fixes a few typos found in the codebase.
This is a continuation of the work done in PR #2363 . The fishtest code was split into two parts for analysis; the first part was addressed in the previous PR, and this one contains the fixes for the second and final part.