### PR TITLE
feat(worker): add support for python 3.14

### DIFF
--- a/.github/workflows/worker_posix.yaml
+++ b/.github/workflows/worker_posix.yaml
@@ -26,6 +26,12 @@ jobs:
             python-version: "3.12"
           - os: ubuntu-24.04
             python-version: "3.13"
+          - os: ubuntu-24.04
+            python-version: "3.14"
+          - os: macos-15-intel
+            python-version: "3.6"
+          - os: macos-15-intel
+            python-version: "3.7"
           - os: macos-15
             python-version: "3.8"
           - os: macos-15
@@ -38,18 +44,8 @@ jobs:
             python-version: "3.12"
           - os: macos-15
             python-version: "3.13"
-          - os: macos-15-intel
-            python-version: "3.8"
-          - os: macos-15-intel
-            python-version: "3.9"
-          - os: macos-15-intel
-            python-version: "3.10"
-          - os: macos-15-intel
-            python-version: "3.11"
-          - os: macos-15-intel
-            python-version: "3.12"
-          - os: macos-15-intel
-            python-version: "3.13"
+          - os: macos-15
+            python-version: "3.14"
     defaults:
       run:
         working-directory: worker

--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -36,7 +36,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 299
+WORKER_VERSION = 300
 
 
 @exception_view_config(HTTPException)

--- a/worker/packages/expression/__init__.py
+++ b/worker/packages/expression/__init__.py
@@ -18,5 +18,5 @@ limitations under the License.
 
 from .parser import Expression_Parser
 
-__all__ = ['Expression_Parser']
-__version__ = '0.0.5'
+__all__ = ["Expression_Parser"]
+__version__ = "0.0.6"

--- a/worker/packages/expression/interpreter.py
+++ b/worker/packages/expression/interpreter.py
@@ -22,7 +22,9 @@ from __future__ import print_function
 import cmd
 import sys
 import traceback
+
 import expression
+
 
 class Expression_Interpreter(cmd.Cmd):
     """
@@ -32,14 +34,14 @@ class Expression_Interpreter(cmd.Cmd):
 
     def __init__(self):
         cmd.Cmd.__init__(self)
-        self.prompt = '>> '
+        self.prompt = ">> "
         self.parser = expression.Expression_Parser(assignment=True)
 
     def default(self, line):
         try:
             output = self.parser.parse(line)
             if output is not None:
-                self.stdout.write(str(output) + '\n')
+                self.stdout.write(str(output) + "\n")
 
             variables = self.parser.variables
             variables.update(self.parser.modified_variables)
@@ -52,13 +54,14 @@ class Expression_Interpreter(cmd.Cmd):
         Exit the interpreter.
         """
 
-        if line != '' and line != '()':
-            self.stdout.write(line + '\n')
+        if line != "" and line != "()":
+            self.stdout.write(line + "\n")
         self._quit()
 
     @staticmethod
     def _quit():
         sys.exit(1)
+
 
 def main():
     """
@@ -67,5 +70,6 @@ def main():
 
     Expression_Interpreter().cmdloop()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/worker/packages/expression/parser.py
+++ b/worker/packages/expression/parser.py
@@ -18,21 +18,15 @@ limitations under the License.
 
 # Use Python 3 division
 from __future__ import division
+
 import ast
+
 
 class Expression_Parser(ast.NodeVisitor):
     """
     Transformer that safely parses an expression, disallowing any complicated
     functions or control structures (inline if..else is allowed though).
     """
-
-    # Boolean operators
-    # The AST nodes may have multiple ops and right comparators, but we
-    # evaluate each op individually.
-    _boolean_ops = {
-        ast.And: lambda left, right: left and right,
-        ast.Or: lambda left, right: left or right
-    }
 
     # Binary operators
     _binary_ops = {
@@ -41,13 +35,13 @@ class Expression_Parser(ast.NodeVisitor):
         ast.Mult: lambda left, right: left * right,
         ast.Div: lambda left, right: left / right,
         ast.Mod: lambda left, right: left % right,
-        ast.Pow: lambda left, right: left ** right,
+        ast.Pow: lambda left, right: left**right,
         ast.LShift: lambda left, right: left << right,
         ast.RShift: lambda left, right: left >> right,
         ast.BitOr: lambda left, right: left | right,
         ast.BitXor: lambda left, right: left ^ right,
         ast.BitAnd: lambda left, right: left & right,
-        ast.FloorDiv: lambda left, right: left // right
+        ast.FloorDiv: lambda left, right: left // right,
     }
 
     # Unary operators
@@ -55,7 +49,7 @@ class Expression_Parser(ast.NodeVisitor):
         ast.Invert: lambda operand: ~operand,
         ast.Not: lambda operand: not operand,
         ast.UAdd: lambda operand: +operand,
-        ast.USub: lambda operand: -operand
+        ast.USub: lambda operand: -operand,
     }
 
     # Comparison operators
@@ -71,22 +65,14 @@ class Expression_Parser(ast.NodeVisitor):
         ast.Is: lambda left, right: left is right,
         ast.IsNot: lambda left, right: left is not right,
         ast.In: lambda left, right: left in right,
-        ast.NotIn: lambda left, right: left not in right
+        ast.NotIn: lambda left, right: left not in right,
     }
 
     # Predefined variable names
-    _variable_names = {
-        'True': True,
-        'False': False,
-        'None': None
-    }
+    _variable_names = {"True": True, "False": False, "None": None}
 
     # Predefined functions
-    _function_names = {
-        'int': int,
-        'float': float,
-        'bool': bool
-    }
+    _function_names = {"int": int, "float": float, "bool": bool}
 
     def __init__(self, variables=None, functions=None, assignment=False):
         self._variables = None
@@ -103,7 +89,7 @@ class Expression_Parser(ast.NodeVisitor):
         self._used_variables = set()
         self._modified_variables = {}
 
-    def parse(self, expression, filename='<expression>'):
+    def parse(self, expression, filename="<expression>"):
         """
         Parse a string `expression` and return its result.
         """
@@ -112,7 +98,8 @@ class Expression_Parser(ast.NodeVisitor):
         self._modified_variables = {}
 
         try:
-            return self.visit(ast.parse(expression))
+            # Explicit mode for clarity and to allow assignment statements when enabled
+            return self.visit(ast.parse(expression, filename=filename, mode="exec"))
         except SyntaxError as error:
             error.filename = filename
             error.text = expression
@@ -124,8 +111,10 @@ class Expression_Parser(ast.NodeVisitor):
             else:
                 line_col = (1, 0)
 
-            error = SyntaxError('{}: {}'.format(error_type, error.args[0]),
-                                (filename,) + line_col + (expression,))
+            error = SyntaxError(
+                "{}: {}".format(error_type, error.args[0]),
+                (filename,) + line_col + (expression,),
+            )
             raise error
 
     @property
@@ -156,9 +145,9 @@ class Expression_Parser(ast.NodeVisitor):
         constant_names = set(self._variable_names.keys())
         forbidden_variables = variable_names.intersection(constant_names)
         if forbidden_variables:
-            keyword = 'keyword' if len(forbidden_variables) == 1 else 'keywords'
-            forbidden = ', '.join(forbidden_variables)
-            raise NameError('Cannot override {} {}'.format(keyword, forbidden))
+            keyword = "keyword" if len(forbidden_variables) == 1 else "keywords"
+            forbidden = ", ".join(forbidden_variables)
+            raise NameError("Cannot override {} {}".format(keyword, forbidden))
 
         self._variables = variables
 
@@ -211,8 +200,10 @@ class Expression_Parser(ast.NodeVisitor):
         This visitor denies any nodes that may not be part of the expression.
         """
 
-        raise SyntaxError('Node {} not allowed'.format(ast.dump(node)),
-                          ('', node.lineno, node.col_offset, ''))
+        raise SyntaxError(
+            "Node {} not allowed".format(ast.dump(node)),
+            ("", node.lineno, node.col_offset, ""),
+        )
 
     def visit_Module(self, node):
         """
@@ -227,8 +218,9 @@ class Expression_Parser(ast.NodeVisitor):
                 lineno = 1
                 col_offset = 0
 
-            raise SyntaxError('Exactly one expression must be provided',
-                              ('', lineno, col_offset, ''))
+            raise SyntaxError(
+                "Exactly one expression must be provided", ("", lineno, col_offset, "")
+            )
 
         return self.visit(node.body[0])
 
@@ -242,15 +234,34 @@ class Expression_Parser(ast.NodeVisitor):
     def visit_BoolOp(self, node):
         """
         Visit a boolean expression node.
+
+        Implements true short-circuit semantics and returns the deciding
+        operand value (for 'and': first falsy, else last; for 'or': first
+        truthy, else last), matching Python behavior.
         """
 
         op = type(node.op)
-        func = self._boolean_ops[op]
-        result = func(self.visit(node.values[0]), self.visit(node.values[1]))
-        for value in node.values[2:]:
-            result = func(result, self.visit(value))
-
-        return result
+        if op is ast.And:
+            last = None
+            for value in node.values:
+                current = self.visit(value)
+                if not current:
+                    return current
+                last = current
+            return last
+        elif op is ast.Or:
+            last = None
+            for value in node.values:
+                current = self.visit(value)
+                if current:
+                    return current
+                last = current
+            return last
+        else:
+            # Defensive, though BoolOp only has And/Or
+            raise SyntaxError(
+                "Unsupported boolean operator", ("", node.lineno, node.col_offset, "")
+            )
 
     def visit_BinOp(self, node):
         """
@@ -275,25 +286,37 @@ class Expression_Parser(ast.NodeVisitor):
         Visit an inline if..else expression node.
         """
 
-        return self.visit(node.body) if self.visit(node.test) else self.visit(node.orelse)
+        return (
+            self.visit(node.body) if self.visit(node.test) else self.visit(node.orelse)
+        )
 
     def visit_Compare(self, node):
         """
         Visit a comparison expression node.
+
+        Implement correct chained comparison semantics: each comparison is
+        evaluated pairwise with short-circuiting on first False.
         """
 
-        result = self.visit(node.left)
+        left = self.visit(node.left)
         for operator, comparator in zip(node.ops, node.comparators):
-            op = type(operator)
-            func = self._compare_ops[op]
-            result = func(result, self.visit(comparator))
-
-        return result
+            func = self._compare_ops[type(operator)]
+            right = self.visit(comparator)
+            if not func(left, right):
+                return False
+            left = right
+        return True
 
     def visit_Call(self, node):
         """
-        Visit a function call node.
+        Visit a function call node. Only direct function names are allowed.
         """
+
+        if not isinstance(node.func, ast.Name):
+            raise SyntaxError(
+                "Only direct function names are allowed",
+                ("", node.lineno, node.col_offset, ""),
+            )
 
         name = node.func.id
         if name in self._functions:
@@ -301,17 +324,22 @@ class Expression_Parser(ast.NodeVisitor):
         elif name in self._function_names:
             func = self._function_names[name]
         else:
-            raise NameError("Function '{}' is not defined".format(name),
-                            node.lineno, node.col_offset)
+            raise NameError(
+                "Function '{}' is not defined".format(name),
+                node.lineno,
+                node.col_offset,
+            )
 
         args = [self.visit(arg) for arg in node.args]
         keywords = dict([self.visit(keyword) for keyword in node.keywords])
 
         # Python 2.7 starred arguments
-        if hasattr(node, 'starargs') and hasattr(node, 'kwargs'):
+        if hasattr(node, "starargs") and hasattr(node, "kwargs"):
             if node.starargs is not None or node.kwargs is not None:
-                raise SyntaxError('Star arguments are not supported',
-                                  ('', node.lineno, node.col_offset, ''))
+                raise SyntaxError(
+                    "Star arguments are not supported",
+                    ("", node.lineno, node.col_offset, ""),
+                )
 
         return func(*args, **keywords)
 
@@ -321,15 +349,21 @@ class Expression_Parser(ast.NodeVisitor):
         """
 
         if not self.assignment:
-            raise SyntaxError('Assignments are not allowed in this expression',
-                              ('', node.lineno, node.col_offset, ''))
+            raise SyntaxError(
+                "Assignments are not allowed in this expression",
+                ("", node.lineno, node.col_offset, ""),
+            )
 
         if len(node.targets) != 1:
-            raise SyntaxError('Multiple-target assignments are not supported',
-                              ('', node.lineno, node.col_offset, ''))
+            raise SyntaxError(
+                "Multiple-target assignments are not supported",
+                ("", node.lineno, node.col_offset, ""),
+            )
         if not isinstance(node.targets[0], ast.Name):
-            raise SyntaxError('Assignment target must be a variable name',
-                              ('', node.lineno, node.col_offset, ''))
+            raise SyntaxError(
+                "Assignment target must be a variable name",
+                ("", node.lineno, node.col_offset, ""),
+            )
 
         name = node.targets[0].id
         self._modified_variables[name] = self.visit(node.value)
@@ -340,42 +374,52 @@ class Expression_Parser(ast.NodeVisitor):
         """
 
         if not self.assignment:
-            raise SyntaxError('Assignments are not allowed in this expression',
-                              ('', node.lineno, node.col_offset, ''))
+            raise SyntaxError(
+                "Assignments are not allowed in this expression",
+                ("", node.lineno, node.col_offset, ""),
+            )
 
         if not isinstance(node.target, ast.Name):
-            raise SyntaxError('Assignment target must be a variable name',
-                              ('', node.lineno, node.col_offset, ''))
+            raise SyntaxError(
+                "Assignment target must be a variable name",
+                ("", node.lineno, node.col_offset, ""),
+            )
 
         name = node.target.id
         if name not in self._variables:
-            raise NameError("Assignment name '{}' is not defined".format(name),
-                            node.lineno, node.col_offset)
+            raise NameError(
+                "Assignment name '{}' is not defined".format(name),
+                node.lineno,
+                node.col_offset,
+            )
 
         op = type(node.op)
         func = self._binary_ops[op]
-        self._modified_variables[name] = func(self._variables[name],
-                                              self.visit(node.value))
+        self._modified_variables[name] = func(
+            self._variables[name], self.visit(node.value)
+        )
 
     def visit_Starred(self, node):
         """
         Visit a starred function keyword argument node.
         """
 
-        # pylint: disable=no-self-use
-
-        raise SyntaxError('Star arguments are not supported',
-                          ('', node.lineno, node.col_offset, ''))
+        raise SyntaxError(
+            "Star arguments are not supported", ("", node.lineno, node.col_offset, "")
+        )
 
     def visit_keyword(self, node):
         """
         Visit a function keyword argument node.
         """
 
+        # Python 3.x: '**' (keyword expansion) is represented by a keyword with arg=None.
+        # Note: ast.keyword typically does NOT have lineno/col_offset across 3.6+,
+        # so use safe fallbacks when constructing a SyntaxError with location info.
         if node.arg is None:
-            raise SyntaxError('Star arguments are not supported',
-                              ('', node.lineno, node.col_offset, ''))
-
+            lineno = getattr(node, "lineno", 1)
+            col = getattr(node, "col_offset", 0)
+            raise SyntaxError("Star arguments are not supported", ("", lineno, col, ""))
         return (node.arg, self.visit(node.value))
 
     def visit_Num(self, node):
@@ -383,7 +427,6 @@ class Expression_Parser(ast.NodeVisitor):
         Visit a literal number node.
         """
 
-        # pylint: disable=no-self-use
         return node.n
 
     def visit_Name(self, node):
@@ -398,13 +441,17 @@ class Expression_Parser(ast.NodeVisitor):
         if node.id in self._variable_names:
             return self._variable_names[node.id]
 
-        raise NameError("Name '{}' is not defined".format(node.id),
-                        node.lineno, node.col_offset)
+        raise NameError(
+            "Name '{}' is not defined".format(node.id), node.lineno, node.col_offset
+        )
 
     def visit_NameConstant(self, node):
         """
         Visit a named constant singleton node (Python 3).
         """
 
-        # pylint: disable=no-self-use
+        return node.value
+
+    def visit_Constant(self, node):  # Python 3.8+ unified literal node
+        """Visit a constant literal node (numbers, strings, booleans, None, Ellipsis)."""
         return node.value

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -5,7 +5,7 @@ description = "fishtest-worker"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
-    "expression-parser>=0.0.5",
+    "expression-parser>=0.0.6",
     "openlock>=1.1.5",
     "requests>=2.25.1",
 ]

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 299, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "Qj8ZLJjAHbe5lQaa9wrsiDL0JtKK6lu8xYYPdx7hwAabvCYdX+SUMOAr+Ajm9uSV", "games.py": "FvHVZE9/5kDMJ6auavCbMV1CtZ+bJHEg44yjH62/PH6wrUXisp7qGaH57BILpmXf"}
+{"__version": 300, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "q5vB0FS27Kf2ZTfUXMZjxb5b6VpSTM2MSX6OTs8e1SypNfGZ73GzS69WRdk+mLOg", "games.py": "FvHVZE9/5kDMJ6auavCbMV1CtZ+bJHEg44yjH62/PH6wrUXisp7qGaH57BILpmXf"}

--- a/worker/uv.lock
+++ b/worker/uv.lock
@@ -22,16 +22,16 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.8.3"
+version = "2025.10.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.9'",
     "python_full_version == '3.8.*'",
     "python_full_version == '3.7.*'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519, upload-time = "2025-10-05T04:12:15.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286, upload-time = "2025-10-05T04:12:14.03Z" },
 ]
 
 [[package]]
@@ -139,11 +139,11 @@ wheels = [
 
 [[package]]
 name = "expression-parser"
-version = "0.0.5"
+version = "0.0.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/fc/357eba12b9009f8b2702b5ed33bfdd40a25525a9210aae5c44eef6dfbdcb/expression-parser-0.0.5.tar.gz", hash = "sha256:3482056c561bdb1e397c750eff229b732ff369488d127761ccd2e8bd6ef51f9d", size = 6556, upload-time = "2018-01-29T12:50:39.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/c5/6013a06039617ba326999d5b7377e7bdf6893baecfb85f4f23f6de123070/expression_parser-0.0.6.tar.gz", hash = "sha256:1e3be22698999b680bca314443f4e78f66c79f231b732082f2fddd2a9829ba7c", size = 13150, upload-time = "2025-10-11T15:34:05.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/84/cc619dcc14e1cde59155d0746179808af716168f40ebcb8f4976a97f68a3/expression_parser-0.0.5-py2.py3-none-any.whl", hash = "sha256:71008539c018fef7c6b05b79bc5a3943b1dbd758600ef7958a36b55ee8c58520", size = 7720, upload-time = "2018-01-29T12:50:37.288Z" },
+    { url = "https://files.pythonhosted.org/packages/95/61/68de2ed03fa764537f6584df302ed543b85e514371fa92aa419699cc58f3/expression_parser-0.0.6-py2.py3-none-any.whl", hash = "sha256:66afa793d9632c9d7fbedcd60712de51d13976acf07f515d5735380e6bb6aa43", size = 11374, upload-time = "2025-10-11T15:34:03.802Z" },
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "expression-parser", specifier = ">=0.0.5" },
+    { name = "expression-parser", specifier = ">=0.0.6" },
     { name = "openlock", specifier = ">=1.1.5" },
     { name = "requests", specifier = ">=2.25.1" },
 ]
@@ -210,7 +210,7 @@ resolution-markers = [
     "python_full_version == '3.7.*'",
 ]
 dependencies = [
-    { name = "certifi", version = "2025.8.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.7.*'" },
+    { name = "certifi", version = "2025.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.7.*'" },
     { name = "charset-normalizer", version = "3.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.7.*'" },
     { name = "idna", marker = "python_full_version == '3.7.*'" },
     { name = "urllib3", version = "2.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.7.*'" },
@@ -228,7 +228,7 @@ resolution-markers = [
     "python_full_version == '3.8.*'",
 ]
 dependencies = [
-    { name = "certifi", version = "2025.8.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
+    { name = "certifi", version = "2025.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
     { name = "charset-normalizer", version = "3.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
     { name = "idna", marker = "python_full_version == '3.8.*'" },
     { name = "urllib3", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.8.*'" },
@@ -246,7 +246,7 @@ resolution-markers = [
     "python_full_version >= '3.9'",
 ]
 dependencies = [
-    { name = "certifi", version = "2025.8.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "certifi", version = "2025.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "charset-normalizer", version = "3.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "idna", marker = "python_full_version >= '3.9'" },
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -74,7 +74,7 @@ MIN_CLANG_MINOR = 0
 
 FASTCHESS_SHA = "47e686f604e6b6f1f872d6e8b2831b4a47d70dae"
 
-WORKER_VERSION = 299
+WORKER_VERSION = 300
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -182,10 +182,10 @@ class _memory:
         self.__name__ = "memory"
 
     def __call__(self, x):
-        e = Expression_Parser(
-            variables={"MAX": self.MAX}, functions={"min": min, "max": max}
-        )
         try:
+            e = Expression_Parser(
+                variables={"MAX": self.MAX}, functions={"min": min, "max": max}
+            )
             ret = round(max(min(e.parse(x), self.MAX), 0))
         except Exception:
             print("Unable to parse expression for max_memory.")
@@ -200,10 +200,10 @@ class _concurrency:
         self.__name__ = "concurrency"
 
     def __call__(self, x):
-        e = Expression_Parser(
-            variables={"MAX": self.MAX}, functions={"min": min, "max": max}
-        )
         try:
+            e = Expression_Parser(
+                variables={"MAX": self.MAX}, functions={"min": min, "max": max}
+            )
             ret = round(e.parse(x))
         except Exception:
             print("Unable to parse expression for concurrency.")


### PR DESCRIPTION
- update `expression-parser` with vendored fallback version 0.0.6
- tests: add tests for memory and concurrency expression evaluation and use `sys.executable` for subprocess robustness in tests
- ci: add python 3.14 to the matrix

Raise worker version to 300 (also server side).

Thanks to @lhelwerd for the fast update of the `expression-parser` package.