### PR TITLE
raise max network upload size

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -290,8 +290,8 @@ def upload(request):
         request.session.flash(f"Network {filename} already exists", "error")
         return {}
     errors = []
-    if len(network) >= 120000000:
-        errors.append("Network must be < 120MB")
+    if len(network) >= 200000000:
+        errors.append("Network must be < 200MB")
     if not re.match(r"^nn-[0-9a-f]{12}\.nnue$", filename):
         errors.append('Name must match "nn-[SHA256 first 12 digits].nnue"')
     hash = hashlib.sha256(network).hexdigest()


### PR DESCRIPTION
Needed to test latest threat inputs nets. Current largest threat net is 130MB