### PR TITLE
Stop task when heartbeat receives an error from server

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -36,7 +36,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 301
+WORKER_VERSION = 302
 
 
 @exception_view_config(HTTPException)

--- a/worker/games.py
+++ b/worker/games.py
@@ -1083,8 +1083,8 @@ def parse_fastchess_output(
     num_games_updated = 0
     while datetime.now(timezone.utc) < end_time:
         if current_state["task_id"] is None:
-            # This task is no longer necessary
-            print(finished_task_message)
+            # This task is no longer necessary.
+            # Error message has already been printed.
             return False
         try:
             line = q.get_nowait().strip()

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 301, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "qLWKRuwvwE1M+5MaixgwtAetH02cPCa9rYUkAbjErBCYxBL1hV/8bi6cl2VZtH9r", "games.py": "FvHVZE9/5kDMJ6auavCbMV1CtZ+bJHEg44yjH62/PH6wrUXisp7qGaH57BILpmXf"}
+{"__version": 302, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "IefIjuMpGHFUli5kjkBcnGIZfXyjJY80SryBrlXdM9vFvQmaaRDBfRHj0TcC+q3u", "games.py": "JdAmyr48crzHgGTFGxaE9hg3K1sWfkd2azImdoPD+Pn3pqsApWt2CykBOKaWwIBM"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -74,7 +74,7 @@ MIN_CLANG_MINOR = 0
 
 FASTCHESS_SHA = "47e686f604e6b6f1f872d6e8b2831b4a47d70dae"
 
-WORKER_VERSION = 301
+WORKER_VERSION = 302
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -1196,8 +1196,15 @@ def heartbeat(worker_info, password, remote, current_state):
                     print("(received)")
                     task_alive = req.get("task_alive", True)
                     if not task_alive:
+                        print(
+                            "The server told us that no more games are needed for the current task."
+                        )
                         current_state["task_id"] = None
                         current_state["run"] = None
+                else:
+                    # Error message has already been printed.
+                    current_state["task_id"] = None
+                    current_state["run"] = None
     else:
         print("Heartbeat stopped.")
 


### PR DESCRIPTION
Very likely the same error will prevent an update later, resulting in wasted compute.

The main (only?) use case is an external IP address change (e.g. when moving a computer to a different location).