### PR TITLE
update fastchess

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -36,7 +36,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 302
+WORKER_VERSION = 303
 
 
 @exception_view_config(HTTPException)

--- a/worker/games.py
+++ b/worker/games.py
@@ -1614,7 +1614,7 @@ def run_games(
             pgnout = []
         else:
             games_to_play = games_remaining
-            pgnout = ["-pgnout", f"file={pgn_name}"]
+            pgnout = ["-pgnout", f"file={pgn_name}", "append=false"]
 
         if "sprt" in run["args"]:
             batch_size = 2 * run["args"]["sprt"].get("batch_size", 1)

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 302, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "IefIjuMpGHFUli5kjkBcnGIZfXyjJY80SryBrlXdM9vFvQmaaRDBfRHj0TcC+q3u", "games.py": "JdAmyr48crzHgGTFGxaE9hg3K1sWfkd2azImdoPD+Pn3pqsApWt2CykBOKaWwIBM"}
+{"__version": 303, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "f8YZy2eGjfNUU4WOnpiP92BqwkniTrsiENSaa6YPUsPYcLv14PjfxDnEVJTNytzA", "games.py": "xb1DODe7mtxfJ2kqCTuh4TODbUYtB//6d/Q23axr/2+oMwbLbMIkGCgtFj3nj2Ur"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -72,9 +72,9 @@ MIN_GCC_MINOR = 3
 MIN_CLANG_MAJOR = 10
 MIN_CLANG_MINOR = 0
 
-FASTCHESS_SHA = "47e686f604e6b6f1f872d6e8b2831b4a47d70dae"
+FASTCHESS_SHA = "e892ad92a74c8a4fd7184b9e4867b97ae8952685"
 
-WORKER_VERSION = 302
+WORKER_VERSION = 303
 FILE_LIST = ["updater.py", "worker.py", "games.py"]
 HTTP_TIMEOUT = 30.0
 INITIAL_RETRY_TIME = 15.0
@@ -381,7 +381,7 @@ def verify_fastchess(fastchess_path, fastchess_sha):
     print(f"Obtaining version info for {fastchess_path}...")
     try:
         with subprocess.Popen(
-            [fastchess_path, "--version"],
+            [fastchess_path, "-version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,


### PR DESCRIPTION
This PR serves as a placeholder to keep track of changes in fastchess during its development.

List of changes:
* `--version` becomes `-version`
* fastchess now produces correct PGN output for games ending with illegal moves
* we use the option `-pgnout append=false` as an extra safety measure to avoid corrupt PGN files
* fix crash on older mac workers, see #2412 