### PR TITLE
Remove GUI option to priority >0 for non-approvers

### DIFF
--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -364,6 +364,9 @@
               class="form-control"
               name="priority"
               id="modify-priority"
+            % if not approver:
+              max="0"
+            % endif
               value="${run['args']['priority']}"
             >
           </div>


### PR DESCRIPTION
Recently a new contributor got understandably confused about the global nature of priority and set their test's priority to be >0. This should prevent that from accidentally happening again.