### PR TITLE
Add Password Reset Page

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -5,6 +5,7 @@ import threading
 import traceback
 
 import fishtest.github_api as gh
+from fishtest.emailer import EmailSender
 from fishtest.routes import setup_routes
 from fishtest.rundb import RunDb
 from pyramid.authentication import AuthTktAuthenticationPolicy
@@ -47,6 +48,8 @@ def main(global_config, **settings):
     # assume the instance is primary for backward compatibility.
     is_primary_instance = port == primary_port
 
+    email_sender = EmailSender()
+
     rundb = RunDb(port=port, is_primary_instance=is_primary_instance)
 
     def add_rundb(event):
@@ -54,6 +57,7 @@ def main(global_config, **settings):
         event.request.userdb = rundb.userdb
         event.request.actiondb = rundb.actiondb
         event.request.workerdb = rundb.workerdb
+        event.request.email_sender = email_sender
 
     def add_renderer_globals(event):
         pass

--- a/server/fishtest/emailer.py
+++ b/server/fishtest/emailer.py
@@ -22,6 +22,18 @@ class EmailSender:
         self.from_email = from_email or os.getenv("FISHTEST_RESEND_FROM_EMAIL")
         self.from_name = from_name or os.getenv("FISHTEST_RESEND_FROM_NAME", "Fishtest")
         self.session = session or requests.Session()
+        missing_settings = []
+        if not self.api_key:
+            missing_settings.append("FISHTEST_RESEND_API_KEY")
+        if not self.from_email:
+            missing_settings.append("FISHTEST_RESEND_FROM_EMAIL")
+        if missing_settings:
+            print(
+                "Email sending is not configured; missing {}.".format(
+                    ", ".join(missing_settings)
+                ),
+                flush=True,
+            )
 
     def _from_field(self):
         if not self.from_email:

--- a/server/fishtest/emailer.py
+++ b/server/fishtest/emailer.py
@@ -42,7 +42,6 @@ class EmailSender:
             return f"{self.from_name} <{self.from_email}>"
         return self.from_email
 
-    # ideally only allow a limited number of emails per user per time period
     def send(
         self,
         to_email,

--- a/server/fishtest/emailer.py
+++ b/server/fishtest/emailer.py
@@ -19,7 +19,9 @@ class EmailSender:
         session=None,
     ):
         self.api_key = api_key or os.getenv("FISHTEST_RESEND_API_KEY")
-        self.from_email = from_email or os.getenv("FISHTEST_RESEND_FROM_EMAIL")
+        self.from_email = from_email or os.getenv(
+            "FISHTEST_RESEND_FROM_EMAIL", "fishtest@resend.dev"
+        )
         self.from_name = from_name or os.getenv("FISHTEST_RESEND_FROM_NAME", "Fishtest")
         self.session = session or requests.Session()
         missing_settings = []

--- a/server/fishtest/emailer.py
+++ b/server/fishtest/emailer.py
@@ -42,9 +42,10 @@ class EmailSender:
             return f"{self.from_name} <{self.from_email}>"
         return self.from_email
 
+    # ideally only allow a limited number of emails per user per time period
     def send(
         self,
-        username,
+        _username,
         to_email,
         subject,
         text,

--- a/server/fishtest/emailer.py
+++ b/server/fishtest/emailer.py
@@ -45,7 +45,6 @@ class EmailSender:
     # ideally only allow a limited number of emails per user per time period
     def send(
         self,
-        _username,
         to_email,
         subject,
         text,

--- a/server/fishtest/emailer.py
+++ b/server/fishtest/emailer.py
@@ -1,0 +1,71 @@
+import os
+
+import requests
+
+RESEND_API_URL = "https://api.resend.com/emails"
+RESEND_TIMEOUT = 10
+
+
+class EmailSendError(RuntimeError):
+    pass
+
+
+class EmailSender:
+    def __init__(
+        self,
+        api_key=None,
+        from_email=None,
+        from_name=None,
+        session=None,
+    ):
+        self.api_key = api_key or os.getenv("FISHTEST_RESEND_API_KEY")
+        self.from_email = from_email or os.getenv("FISHTEST_RESEND_FROM_EMAIL")
+        self.from_name = from_name or os.getenv("FISHTEST_RESEND_FROM_NAME", "Fishtest")
+        self.session = session or requests.Session()
+
+    def _from_field(self):
+        if not self.from_email:
+            raise EmailSendError("FISHTEST_RESEND_FROM_EMAIL is missing.")
+        if self.from_name:
+            return f"{self.from_name} <{self.from_email}>"
+        return self.from_email
+
+    def send(
+        self,
+        username,
+        to_email,
+        subject,
+        text,
+        html=None,
+        reply_to=None,
+    ):
+        if not self.api_key:
+            raise EmailSendError("FISHTEST_RESEND_API_KEY is missing.")
+        if not to_email:
+            raise EmailSendError("to_email is required.")
+
+        payload = {
+            "from": self._from_field(),
+            "to": [to_email] if isinstance(to_email, str) else to_email,
+            "subject": subject,
+            "text": text,
+        }
+        if html:
+            payload["html"] = html
+        if reply_to:
+            payload["reply_to"] = reply_to
+
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        try:
+            response = self.session.post(
+                RESEND_API_URL, json=payload, headers=headers, timeout=RESEND_TIMEOUT
+            )
+        except Exception as exc:
+            raise EmailSendError(f"Failed to reach Resend: {exc}") from exc
+
+        if not response.ok:
+            raise EmailSendError(
+                f"Resend error {response.status_code}: {response.text}"
+            )
+
+        return response.json()

--- a/server/fishtest/routes.py
+++ b/server/fishtest/routes.py
@@ -14,6 +14,8 @@ def setup_routes(config):
 
     config.add_route("home", "/")
     config.add_route("login", "/login")
+    config.add_route("forgot_password", "/forgot_password")
+    config.add_route("reset_password", "/reset_password/{token}")
     config.add_route("nn_upload", "/upload")
     config.add_route("logout", "/logout")
     config.add_route("signup", "/signup")

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -108,6 +108,7 @@ user_schema = {
     "groups": [str, ...],
     "tests_repo": union(github_repo, ""),
     "machine_limit": uint,
+    "password_reset?": {"token": str, "expires_at": datetime_utc},
 }
 
 kvstore_schema = {

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -108,7 +108,11 @@ user_schema = {
     "groups": [str, ...],
     "tests_repo": union(github_repo, ""),
     "machine_limit": uint,
-    "password_reset?": {"token": str, "expires_at": datetime_utc},
+    "password_reset?": {
+        "token": str,
+        "expires_at": datetime_utc,
+        "opened_at?": datetime_utc,
+    },
 }
 
 kvstore_schema = {

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -112,6 +112,7 @@ user_schema = {
         "token": str,
         "expires_at": datetime_utc,
         "opened_at?": datetime_utc,
+        "form_token?": str,
     },
 }
 

--- a/server/fishtest/templates/forgot_password.mak
+++ b/server/fishtest/templates/forgot_password.mak
@@ -1,0 +1,36 @@
+<%inherit file="base.mak"/>
+
+<script>
+  document.title = "Forgot Password | Stockfish Testing";
+</script>
+
+<div class="col-limited-size">
+  <header class="text-md-center py-2">
+    <h2>Reset your password</h2>
+    <div class="alert alert-info">
+      Enter the email linked to your account and we'll send a reset link.
+    </div>
+  </header>
+
+  <form method="POST">
+    <div class="form-floating mb-3">
+      <input
+        type="email"
+        class="form-control mb-3"
+        id="email"
+        name="email"
+        placeholder="Email"
+        autocomplete="email"
+        required
+        autofocus
+      >
+      <label for="email" class="d-flex align-items-end">Email</label>
+    </div>
+
+    <button type="submit" class="btn btn-primary w-100">Send reset link</button>
+  </form>
+
+  <div class="text-center mt-3">
+    <a href="/login" class="alert-link">Back to login</a>
+  </div>
+</div>

--- a/server/fishtest/templates/forgot_password.mak
+++ b/server/fishtest/templates/forgot_password.mak
@@ -4,6 +4,10 @@
   document.title = "Forgot Password | Stockfish Testing";
 </script>
 
+<%block name="head">
+  <script src='https://www.google.com/recaptcha/api.js'></script>
+</%block>
+
 <div class="col-limited-size">
   <header class="text-md-center py-2">
     <h2>Reset your password</h2>
@@ -26,6 +30,9 @@
       >
       <label for="email" class="d-flex align-items-end">Email</label>
     </div>
+
+    <div class="g-recaptcha mb-3"
+         data-sitekey="6LePs8YUAAAAABMmqHZVyVjxat95Z1c_uHrkugZM"></div>
 
     <button type="submit" class="btn btn-primary w-100">Send reset link</button>
   </form>

--- a/server/fishtest/templates/forgot_password.mak
+++ b/server/fishtest/templates/forgot_password.mak
@@ -31,6 +31,6 @@
   </form>
 
   <div class="text-center mt-3">
-    <a href="/login" class="alert-link">Back to login</a>
+    <a href="${request.route_url('login')}" class="alert-link">Back to login</a>
   </div>
 </div>

--- a/server/fishtest/templates/login.mak
+++ b/server/fishtest/templates/login.mak
@@ -58,6 +58,10 @@
 
     <button type="submit" class="btn btn-primary w-100">Login</button>
   </form>
+
+  <div class="mt-3">
+    <a href="/forgot_password" class="btn btn-outline-secondary w-100">Reset password</a>
+  </div>
 </div>
 
 <script src="${request.static_url('fishtest:static/js/toggle_password.js')}"></script>

--- a/server/fishtest/templates/login.mak
+++ b/server/fishtest/templates/login.mak
@@ -60,7 +60,7 @@
   </form>
 
   <div class="mt-3">
-    <a href="/forgot_password" class="btn btn-outline-secondary w-100">Reset password</a>
+    <a href="${request.route_url('forgot_password')}" class="btn btn-outline-secondary w-100">Reset password</a>
   </div>
 </div>
 

--- a/server/fishtest/templates/reset_password.mak
+++ b/server/fishtest/templates/reset_password.mak
@@ -18,6 +18,7 @@
           id="password"
           name="password"
           placeholder="New Password"
+          pattern=".{8,}"
           title="Eight or more characters: a password too simple or trivial to guess will be rejected"
           autocomplete="new-password"
           required

--- a/server/fishtest/templates/reset_password.mak
+++ b/server/fishtest/templates/reset_password.mak
@@ -10,6 +10,7 @@
   </header>
 
   <form method="POST">
+    <input type="hidden" name="form_token" value="${form_token}">
     <div class="input-group mb-3">
       <div class="form-floating">
         <input

--- a/server/fishtest/templates/reset_password.mak
+++ b/server/fishtest/templates/reset_password.mak
@@ -1,0 +1,55 @@
+<%inherit file="base.mak"/>
+
+<script>
+  document.title = "Reset Password | Stockfish Testing";
+</script>
+
+<div class="col-limited-size">
+  <header class="text-md-center py-2">
+    <h2>Choose a new password</h2>
+  </header>
+
+  <form method="POST">
+    <div class="input-group mb-3">
+      <div class="form-floating">
+        <input
+          type="password"
+          class="form-control"
+          id="password"
+          name="password"
+          placeholder="New Password"
+          title="Eight or more characters: a password too simple or trivial to guess will be rejected"
+          autocomplete="new-password"
+          required
+          autofocus
+        >
+        <label for="password" class="d-flex align-items-end">New Password</label>
+      </div>
+      <span class="input-group-text toggle-password-visibility" role="button">
+        <i class="fa-solid fa-lg fa-eye pe-none" style="width: 30px"></i>
+      </span>
+    </div>
+
+    <div class="input-group mb-3">
+      <div class="form-floating">
+        <input
+          type="password"
+          class="form-control"
+          id="password2"
+          name="password2"
+          placeholder="Repeat Password"
+          autocomplete="new-password"
+          required
+        >
+        <label for="password2" class="d-flex align-items-end">Repeat Password</label>
+      </div>
+      <span class="input-group-text toggle-password-visibility" role="button">
+        <i class="fa-solid fa-lg fa-eye pe-none" style="width: 30px"></i>
+      </span>
+    </div>
+
+    <button type="submit" class="btn btn-primary w-100">Reset password</button>
+  </form>
+</div>
+
+<script src="${request.static_url('fishtest:static/js/toggle_password.js')}"></script>

--- a/server/fishtest/templates/reset_password.mak
+++ b/server/fishtest/templates/reset_password.mak
@@ -4,6 +4,11 @@
   document.title = "Reset Password | Stockfish Testing";
 </script>
 
+
+<%block name="head">
+  <script src='https://www.google.com/recaptcha/api.js'></script>
+</%block>
+
 <div class="col-limited-size">
   <header class="text-md-center py-2">
     <h2>Choose a new password</h2>
@@ -48,6 +53,9 @@
         <i class="fa-solid fa-lg fa-eye pe-none" style="width: 30px"></i>
       </span>
     </div>
+
+    <div class="g-recaptcha mb-3"
+         data-sitekey="6LePs8YUAAAAABMmqHZVyVjxat95Z1c_uHrkugZM"></div>
 
     <button type="submit" class="btn btn-primary w-100">Reset password</button>
   </form>

--- a/server/fishtest/templates/reset_password.mak
+++ b/server/fishtest/templates/reset_password.mak
@@ -4,11 +4,6 @@
   document.title = "Reset Password | Stockfish Testing";
 </script>
 
-
-<%block name="head">
-  <script src='https://www.google.com/recaptcha/api.js'></script>
-</%block>
-
 <div class="col-limited-size">
   <header class="text-md-center py-2">
     <h2>Choose a new password</h2>
@@ -53,9 +48,6 @@
         <i class="fa-solid fa-lg fa-eye pe-none" style="width: 30px"></i>
       </span>
     </div>
-
-    <div class="g-recaptcha mb-3"
-         data-sitekey="6LePs8YUAAAAABMmqHZVyVjxat95Z1c_uHrkugZM"></div>
 
     <button type="submit" class="btn btn-primary w-100">Reset password</button>
   </form>

--- a/server/fishtest/userdb.py
+++ b/server/fishtest/userdb.py
@@ -159,6 +159,19 @@ class UserDb:
             self.clear_cache()
         return result
 
+    def mark_password_reset_opened(self, user_id, token, opened_at):
+        result = self.users.update_one(
+            {
+                "_id": user_id,
+                "password_reset.token": token,
+                "password_reset.opened_at": {"$exists": False},
+            },
+            {"$set": {"password_reset.opened_at": opened_at}},
+        )
+        if result.modified_count:
+            self.clear_cache()
+        return result
+
     def remove_user(self, user, rejector):
         result = self.users.delete_one({"_id": user["_id"]})
         if result.deleted_count > 0:

--- a/server/fishtest/userdb.py
+++ b/server/fishtest/userdb.py
@@ -172,6 +172,33 @@ class UserDb:
             self.clear_cache()
         return result
 
+    def set_password_reset_form_token(self, user_id, token, form_token, opened_at):
+        result = self.users.update_one(
+            {
+                "_id": user_id,
+                "password_reset.token": token,
+                "password_reset.form_token": {"$exists": False},
+            },
+            {
+                "$set": {
+                    "password_reset.form_token": form_token,
+                    "password_reset.opened_at": opened_at,
+                }
+            },
+        )
+        if result.modified_count:
+            self.clear_cache()
+        return result
+
+    def update_password_with_reset_form_token(self, user_id, form_token, new_password):
+        result = self.users.update_one(
+            {"_id": user_id, "password_reset.form_token": form_token},
+            {"$set": {"password": new_password}, "$unset": {"password_reset": ""}},
+        )
+        if result.modified_count:
+            self.clear_cache()
+        return result
+
     def remove_user(self, user, rejector):
         result = self.users.delete_one({"_id": user["_id"]})
         if result.deleted_count > 0:

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -158,6 +158,10 @@ def login(request):
     request_method=("GET", "POST"),
 )
 def forgot_password(request):
+    userid = request.authenticated_userid
+    if userid:
+        return home(request)
+
     if request.method == "POST":
         email = request.POST.get("email", "").strip()
         email_is_valid, validated_email = email_valid(email)

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -100,6 +100,7 @@ def run_captcha(request):
             request.session.flash("Captcha failed", "error")
             return False
         return True
+    return True
 
 
 @notfound_view_config(renderer="notfound.mak")
@@ -187,6 +188,9 @@ def forgot_password(request):
         return home(request)
 
     if request.method == "POST":
+        if not run_captcha(request):
+            return {}
+
         email = request.POST.get("email", "").strip()
         email_is_valid, validated_email = email_valid(email)
         if not email_is_valid:
@@ -262,9 +266,6 @@ def reset_password(request):
         )
         if not strong_password:
             request.session.flash("Error! Weak password: " + password_err, "error")
-            return {"token": token}
-
-        if not run_captcha(request):
             return {"token": token}
 
         update_result = request.userdb.update_password_with_reset_token(

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -223,9 +223,7 @@ def forgot_password(request):
             except Exception as e:
                 print(f"failed to send password reset email to {validated_email}: {e}")
 
-        request.session.flash(
-            "If that email exists, a reset link has been sent.", "info"
-        )
+        request.session.flash("If that email exists, a reset link has been sent.")
     return {}
 
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -175,7 +175,11 @@ def forgot_password(request):
             body = (
                 "We received a request to reset your Fishtest password.\n\n"
                 f"Reset link: {reset_url}\n\n"
-                "If you did not request a reset, you can ignore this email."
+                "This link will expire in 1 hour.\n"
+                "For your security, do not share this link with anyone, as it can "
+                "be used to change your password.\n\n"
+                "If you did not request a password reset, you can ignore this "
+                "email or contact the site administrators for assistance."
             )
             try:
                 request.email_sender.send(

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -226,7 +226,7 @@ def forgot_password(request):
         request.session.flash(
             "If that email exists, a reset link has been sent, please check your inbox."
         )
-        return HTTPFound(location=request.route_url("home"))
+        return HTTPFound(location=request.route_url("tests"))
     return {}
 
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -223,7 +223,10 @@ def forgot_password(request):
             except Exception as e:
                 print(f"failed to send password reset email to {validated_email}: {e}")
 
-        request.session.flash("If that email exists, a reset link has been sent.")
+        request.session.flash(
+            "If that email exists, a reset link has been sent, please check your inbox."
+        )
+        return HTTPFound(location=request.route_url("home"))
     return {}
 
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -216,7 +216,10 @@ def reset_password(request):
         if expired_cleanup.matched_count:
             request.session.flash("Reset link has expired.", "error")
             return HTTPFound(location=request.route_url("forgot_password"))
-        request.session.flash("Invalid or expired reset link.", "error")
+        request.session.flash(
+            "Invalid reset link. It may have been replaced by a newer reset request.",
+            "error",
+        )
         return HTTPFound(location=request.route_url("login"))
 
     if request.method == "POST":

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -212,7 +212,6 @@ def forgot_password(request):
             )
             try:
                 request.email_sender.send(
-                    user["username"],
                     user["email"],
                     "Fishtest password reset",
                     body,

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -185,12 +185,7 @@ def forgot_password(request):
                     body,
                 )
             except Exception as e:
-                print("failed to send email")
-                print(e)
-                request.session.flash(
-                    "Unable to send reset email. Please try again later.", "error"
-                )
-                return {}
+                print(f"failed to send password reset email to {validated_email}: {e}")
 
         request.session.flash(
             "If that email exists, a reset link has been sent.", "info"

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -235,7 +235,10 @@ class ForgotResetPasswordTest(unittest.TestCase):
         self.assertEqual(response.location, request.route_url("forgot_password"))
         user = self.rundb.userdb.find_by_email(self.test_user["email"])
         self.assertNotIn("password_reset", user)
-        self.assertIn("Reset link has expired.", request.session.pop_flash("error")[0])
+        self.assertIn(
+            "Unable to reset password. The reset link may have expired or already been used.",
+            request.session.pop_flash("error")[0],
+        )
 
     def test_reset_password_invalid_token(self):
         token = secrets.token_urlsafe(32)

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -1,8 +1,9 @@
+import secrets
 import unittest
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import util
-from fishtest.views import login, signup
+from fishtest.views import forgot_password, login, reset_password, signup
 from pyramid import testing
 
 
@@ -107,6 +108,167 @@ class Create90APITest(unittest.TestCase):
         self.rundb.userdb.users.delete_many({"username": "JoeUser"})
         self.rundb.userdb.user_cache.delete_many({"username": "JoeUser"})
         testing.tearDown()
+
+
+class _DummyEmailSender:
+    def __init__(self, should_fail=False):
+        self.should_fail = should_fail
+        self.sent = []
+
+    def send(self, username, to_email, subject, text, html=None, reply_to=None):
+        if self.should_fail:
+            raise Exception("boom")
+        self.sent.append(
+            {
+                "username": username,
+                "to_email": to_email,
+                "subject": subject,
+                "text": text,
+                "html": html,
+                "reply_to": reply_to,
+            }
+        )
+        return {"ok": True}
+
+
+class ForgotResetPasswordTest(unittest.TestCase):
+    def setUp(self):
+        self.rundb = util.get_rundb()
+        self.config = testing.setUp()
+        self.config.add_route("forgot_password", "/forgot_password")
+        self.config.add_route("reset_password", "/reset_password/{token}")
+        self.config.add_route("login", "/login")
+        self.test_user = {
+            "username": "ResetUser",
+            "password": "secret",
+            "email": "reset@user.net",
+            "tests_repo": "https://github.com/official-stockfish/Stockfish",
+        }
+        self.rundb.userdb.create_user(**self.test_user)
+
+    def tearDown(self):
+        self.rundb.userdb.users.delete_many({"username": self.test_user["username"]})
+        self.rundb.userdb.user_cache.delete_many(
+            {"username": self.test_user["username"]}
+        )
+        testing.tearDown()
+
+    def test_forgot_password_valid_email(self):
+        email_sender = _DummyEmailSender()
+        request = testing.DummyRequest(
+            userdb=self.rundb.userdb,
+            email_sender=email_sender,
+            method="POST",
+            params={"email": self.test_user["email"]},
+        )
+        forgot_password(request)
+        self.assertEqual(len(email_sender.sent), 1)
+        user = self.rundb.userdb.find_by_email(self.test_user["email"])
+        self.assertIn("password_reset", user)
+        self.assertIn("token", user["password_reset"])
+        self.assertIn("expires_at", user["password_reset"])
+        self.assertTrue(user["password_reset"]["expires_at"] > datetime.now(UTC))
+        self.assertTrue(
+            "If that email exists, a reset link has been sent."
+            in request.session.pop_flash("info")
+        )
+
+    def test_forgot_password_invalid_email(self):
+        email_sender = _DummyEmailSender()
+        request = testing.DummyRequest(
+            userdb=self.rundb.userdb,
+            email_sender=email_sender,
+            method="POST",
+            params={"email": "not-an-email"},
+        )
+        forgot_password(request)
+        self.assertEqual(len(email_sender.sent), 0)
+        self.assertTrue(
+            "Error! Invalid email:" in request.session.pop_flash("error")[0]
+        )
+
+    def test_forgot_password_email_send_error(self):
+        email_sender = _DummyEmailSender(should_fail=True)
+        request = testing.DummyRequest(
+            userdb=self.rundb.userdb,
+            email_sender=email_sender,
+            method="POST",
+            params={"email": self.test_user["email"]},
+        )
+        forgot_password(request)
+        user = self.rundb.userdb.find_by_email(self.test_user["email"])
+        self.assertIn("password_reset", user)
+        self.assertTrue(
+            "If that email exists, a reset link has been sent."
+            in request.session.pop_flash("info")
+        )
+
+    def test_reset_password_expired_token(self):
+        token = secrets.token_urlsafe(16)
+        user = self.rundb.userdb.find_by_email(self.test_user["email"])
+        expires_at = datetime.now(UTC) - timedelta(minutes=1)
+        self.rundb.userdb.set_password_reset(user, token, expires_at)
+        request = testing.DummyRequest(
+            userdb=self.rundb.userdb,
+            method="GET",
+            matchdict={"token": token},
+        )
+        response = reset_password(request)
+        self.assertEqual(response.location, request.route_url("forgot_password"))
+        user = self.rundb.userdb.find_by_email(self.test_user["email"])
+        self.assertNotIn("password_reset", user)
+        self.assertTrue(
+            "Reset link has expired." in request.session.pop_flash("error")[0]
+        )
+
+    def test_reset_password_token_invalid_after_use(self):
+        token = secrets.token_urlsafe(16)
+        user = self.rundb.userdb.find_by_email(self.test_user["email"])
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+        self.rundb.userdb.set_password_reset(user, token, expires_at)
+        new_password = "CorrectHorseBatteryStaple123!@#"
+        request = testing.DummyRequest(
+            userdb=self.rundb.userdb,
+            method="POST",
+            matchdict={"token": token},
+            params={"password": new_password, "password2": new_password},
+        )
+        response = reset_password(request)
+        self.assertEqual(response.location, request.route_url("login"))
+        user = self.rundb.userdb.find_by_email(self.test_user["email"])
+        self.assertNotIn("password_reset", user)
+        self.assertEqual(user["password"], new_password)
+
+        request = testing.DummyRequest(
+            userdb=self.rundb.userdb,
+            method="GET",
+            matchdict={"token": token},
+        )
+        response = reset_password(request)
+        self.assertEqual(response.location, request.route_url("login"))
+        self.assertTrue(
+            "Invalid reset link. It may have been replaced by a newer reset request."
+            in request.session.pop_flash("error")[0]
+        )
+
+    def test_reset_password_weak_password(self):
+        token = "weak-token"
+        user = self.rundb.userdb.find_by_email(self.test_user["email"])
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+        self.rundb.userdb.set_password_reset(user, token, expires_at)
+        request = testing.DummyRequest(
+            userdb=self.rundb.userdb,
+            method="POST",
+            matchdict={"token": token},
+            params={"password": "short", "password2": "short"},
+        )
+        response = reset_password(request)
+        self.assertEqual(response, {"token": token})
+        user = self.rundb.userdb.find_by_email(self.test_user["email"])
+        self.assertIn("password_reset", user)
+        self.assertTrue(
+            "Error! Weak password:" in request.session.pop_flash("error")[0]
+        )
 
 
 if __name__ == "__main__":

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -116,12 +116,11 @@ class _DummyEmailSender:
         self.should_fail = should_fail
         self.sent = []
 
-    def send(self, username, to_email, subject, text, html=None, reply_to=None):
+    def send(self, to_email, subject, text, html=None, reply_to=None):
         if self.should_fail:
             raise Exception("boom")
         self.sent.append(
             {
-                "username": username,
                 "to_email": to_email,
                 "subject": subject,
                 "text": text,
@@ -161,6 +160,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             email_sender=email_sender,
             method="POST",
             params={"email": self.test_user["email"]},
+            remote_addr="127.0.0.1",
         )
         forgot_password(request)
         self.assertEqual(len(email_sender.sent), 1)
@@ -181,6 +181,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             email_sender=email_sender,
             method="POST",
             params={"email": "not-an-email"},
+            remote_addr="127.0.0.1",
         )
         forgot_password(request)
         self.assertEqual(len(email_sender.sent), 0)
@@ -193,6 +194,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             email_sender=email_sender,
             method="POST",
             params={"email": "missing-user@example.net"},
+            remote_addr="127.0.0.1",
         )
         with patch(
             "fishtest.views.email_valid",
@@ -212,6 +214,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             email_sender=email_sender,
             method="POST",
             params={"email": self.test_user["email"]},
+            remote_addr="127.0.0.1",
         )
         forgot_password(request)
         user = self.rundb.userdb.find_by_email(self.test_user["email"])
@@ -230,6 +233,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             userdb=self.rundb.userdb,
             method="GET",
             matchdict={"token": token},
+            remote_addr="127.0.0.1",
         )
         response = reset_password(request)
         self.assertEqual(response.location, request.route_url("forgot_password"))
@@ -246,6 +250,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             userdb=self.rundb.userdb,
             method="GET",
             matchdict={"token": token},
+            remote_addr="127.0.0.1",
         )
         response = reset_password(request)
         self.assertEqual(response.location, request.route_url("login"))
@@ -265,6 +270,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             method="POST",
             matchdict={"token": token},
             params={"password": new_password, "password2": new_password},
+            remote_addr="127.0.0.1",
         )
         response = reset_password(request)
         self.assertEqual(response.location, request.route_url("login"))
@@ -276,6 +282,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             userdb=self.rundb.userdb,
             method="GET",
             matchdict={"token": token},
+            remote_addr="127.0.0.1",
         )
         response = reset_password(request)
         self.assertEqual(response.location, request.route_url("login"))
@@ -294,6 +301,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             method="POST",
             matchdict={"token": token},
             params={"password": "short", "password2": "short"},
+            remote_addr="127.0.0.1",
         )
         response = reset_password(request)
         self.assertEqual(response, {"token": token})
@@ -311,6 +319,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
             method="POST",
             matchdict={"token": token},
             params={"password": "MismatchPassword123!", "password2": "Different123!"},
+            remote_addr="127.0.0.1",
         )
         response = reset_password(request)
         self.assertEqual(response, {"token": token})

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -171,7 +171,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
         self.assertGreater(user["password_reset"]["expires_at"], datetime.now(UTC))
         self.assertIn(
             "If that email exists, a reset link has been sent.",
-            request.session.pop_flash("info")[0],
+            request.session.pop_flash()[0],
         )
 
     def test_forgot_password_invalid_email(self):
@@ -204,7 +204,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
         self.assertEqual(len(email_sender.sent), 0)
         self.assertIn(
             "If that email exists, a reset link has been sent.",
-            request.session.pop_flash("info")[0],
+            request.session.pop_flash()[0],
         )
 
     def test_forgot_password_email_send_error(self):
@@ -221,7 +221,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
         self.assertIn("password_reset", user)
         self.assertIn(
             "If that email exists, a reset link has been sent.",
-            request.session.pop_flash("info")[0],
+            request.session.pop_flash()[0],
         )
 
     def test_reset_password_expired_token(self):

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -236,7 +236,7 @@ class ForgotResetPasswordTest(unittest.TestCase):
         user = self.rundb.userdb.find_by_email(self.test_user["email"])
         self.assertNotIn("password_reset", user)
         self.assertIn(
-            "Unable to reset password. The reset link may have expired or already been used.",
+            "Reset link has expired.",
             request.session.pop_flash("error")[0],
         )
 


### PR DESCRIPTION
Tested with `https://resend.com/home` which offers a generous free term of 3000 emails per month (100 per day) maybe @ppigazzini prefers a different provider though, but if I find resend quite nice.

Sends an email with a reset token and invalidates the token after use.

Needs
- FISHTEST_RESEND_API_KEY
- FISHTEST_RESEND_FROM_EMAIL
- FISHTEST_RESEND_FROM_NAME

env vars
FISHTEST_RESEND_FROM_EMAIL, is for example fishtest@resend.dev
FISHTEST_RESEND_FROM_NAME, just Fishtest

<img width="808" height="469" alt="grafik" src="https://github.com/user-attachments/assets/5c5582a2-fa24-42ba-9dbb-99a9aec6507d" />

reset page, from email

<img width="625" height="336" alt="grafik" src="https://github.com/user-attachments/assets/a3df01a5-e50c-4b16-8e94-944ac75bf84f" />

reset email (can be improved)

<img width="797" height="225" alt="Screenshot 2025-12-28 160002" src="https://github.com/user-attachments/assets/d7822238-5a50-4d24-939b-2315845c55d0" />

