### PR TITLE
Let the worker determine its own arch.

### DIFF
--- a/server/fishtest/api.py
+++ b/server/fishtest/api.py
@@ -36,7 +36,7 @@ Proper configuration of `nginx` is crucial for this, and should be done
 according to the route/URL mapping defined in `__init__.py`.
 """
 
-WORKER_VERSION = 305
+WORKER_VERSION = 306
 
 
 @exception_view_config(HTTPException)

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -420,6 +420,7 @@ worker_info_schema_api = {
     "compiler": union("clang++", "g++"),
     "unique_key": uuid,
     "modified": bool,
+    "worker_arch?": str,  # can become mandatory after worker upgrade
     "ARCH": str,
     "nps": unumber,
     "near_github_api_limit": bool,

--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 305, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "Y0kkVAk+3q3+HuWmVqgcPx7/h+CoLyPihLUszUGrvphfzNn55qXwqC+xh0fPz/Zt", "games.py": "uUpIoWu/jB6IoWN4aqSmRvtb7chhVswcFqIiT+G/cKNUWTam8ARxMZARNmTqGQ9p"}
+{"__version": 306, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "gIMF2QwjYqz0vh3H3NgpKgo/1otFfDV2sjrDmBLmgoq4gp2Tm5FW7I0zp+CrZnhO", "games.py": "uUpIoWu/jB6IoWN4aqSmRvtb7chhVswcFqIiT+G/cKNUWTam8ARxMZARNmTqGQ9p"}

--- a/worker/tests/test_worker.py
+++ b/worker/tests/test_worker.py
@@ -37,6 +37,10 @@ class WorkerTest(unittest.TestCase):
             pass
         self.assertIsNotNone(blob)
 
+    def test_get_worker_arch(self):
+        arch = worker.get_worker_arch(self.worker_dir)
+        self.assertNotEqual(arch, "unknown")
+
     def test_config_setup(self):
         sys.argv = [sys.argv[0], "user", "pass", "--no_validation"]
         worker.CONFIGFILE = str(self.tempdir / "foo.txt")


### PR DESCRIPTION
This arch can then be used in a filter specified during test creation (using a regular expression) to avoid stuff like this

https://tests.stockfishchess.org/actions?run_id=69509e5c572093c1986d7a0a

(many many pages of failed tasks in the event log).

I have not yet coded the latter part since I would first like to get some feedback on the method of getting the worker architecture.

The approach is simply to download ./get_native_properties.sh from the current SF master and run it...