### PR TITLE
Make `arch_filter` an optional field in the run object.

### DIFF
--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -567,7 +567,7 @@ class RunDb:
         throughput=100,
         priority=0,
         adjudication=True,
-        arch_filter="",
+        arch_filter=None,
     ):
         if start_time is None:
             start_time = datetime.now(UTC)
@@ -599,11 +599,13 @@ class RunDb:
             "itp": 100,  # internal throughput
             "priority": priority,
             "adjudication": adjudication,
-            "arch_filter": arch_filter,
         }
 
         if master_repo is not None:
             run_args["master_repo"] = master_repo
+
+        if arch_filter is not None:
+            run_args["arch_filter"] = arch_filter
 
         if sprt is not None:
             run_args["sprt"] = sprt

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -724,7 +724,7 @@ runs_schema = intersect(
                 "itp": unumber,
                 "priority": number,
                 "adjudication": bool,
-                "arch_filter": regex_pattern,
+                "arch_filter?": regex_pattern,
                 "sprt?": intersect(
                     {
                         "alpha": 0.05,

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -622,67 +622,56 @@
 
             <div><hr></div>
 
-            <div class="mb-2">
-              <div class="row g-3">
-                <div class="col-12 col-md-6 col-lg-4 text-nowrap">
-                  <div class="mb-2 form-check">
-                    <label class="form-check-label" for="checkbox-auto-purge">Auto-purge</label>
-                    <input
-                      type="checkbox"
-                      class="form-check-input"
-                      id="checkbox-auto-purge"
-                      name="auto-purge"
-                      checked
-                    >
-                  </div>
-                  <div class="mb-2 form-check">
-                    <label class="form-check-label" for="checkbox-arch-filter">Arch filter</label>
-                    <input
-                      type="checkbox"
-                      class="form-check-input"
-                      name="checkbox-arch-filter"
-                      id="checkbox-arch-filter"
-                      ${'checked' if arch_filter != '' else ''}
-                    >
-                  </div>
-                </div>
-
-
-
-                <div class="col-12 col-md-6 col-lg-4 text-nowrap">
-                  <div class="mb-2 form-check">
-                    <label class="form-check-label" for="checkbox-time-odds">Time odds</label>
-                    <input
-                      type="checkbox"
-                      class="form-check-input"
-                      id="checkbox-time-odds"
-                      name="odds"
-                      ${'checked' if is_odds else ''}
-                    >
-                  </div>
-                  <div class="mb-2 form-check">
-                    <label class="form-check-label" for="checkbox-book-visibility">Custom book</label>
-                    <input
-                      type="checkbox"
-                      class="form-check-input"
-                      id="checkbox-book-visibility"
-                      ${'checked' if default_book != test_book else ''}
-                    >
-                  </div>
-                </div>
-
-                <div class="col-12 col-md-6 col-lg-4 text-nowrap">
-                  <div class="mb-2 form-check">
-                    <label class="form-check-label" for="checkbox-adjudication">No adjudication</label>
-                    <input
-                      type="checkbox"
-                      class="form-check-input"
-                      id="checkbox-adjudication"
-                      name="adjudication"
-                      ${'checked' if not args.get("adjudication", True) else ''}
-                    >
-                  </div>
-                </div>
+            <!-- Check boxes for advanced options -->
+            <div class="row gx-0">
+              <div class="col-6 col-lg-4 mb-2 form-check">
+                <label class="form-check-label" for="checkbox-auto-purge">Auto-purge</label>
+                <input
+                  type="checkbox"
+                  class="form-check-input"
+                  id="checkbox-auto-purge"
+                  name="auto-purge"
+                  checked
+                >
+              </div>
+              <div class="col-6 col-lg-4 mb-2 form-check">
+                <label class="form-check-label" for="checkbox-arch-filter">Arch filter</label>
+                <input
+                  type="checkbox"
+                  class="form-check-input"
+                  name="checkbox-arch-filter"
+                  id="checkbox-arch-filter"
+                  ${'checked' if arch_filter != '' else ''}
+                >
+              </div>
+              <div class="col-6 col-lg-4 mb-2 form-check">
+                <label class="form-check-label" for="checkbox-time-odds">Time odds</label>
+                <input
+                  type="checkbox"
+                  class="form-check-input"
+                  id="checkbox-time-odds"
+                  name="odds"
+                  ${'checked' if is_odds else ''}
+                >
+              </div>
+              <div class="col-6 col-lg-4 mb-2 form-check">
+                <label class="form-check-label" for="checkbox-book-visibility">Custom book</label>
+                <input
+                  type="checkbox"
+                  class="form-check-input"
+                  id="checkbox-book-visibility"
+                  ${'checked' if default_book != test_book else ''}
+                >
+              </div>
+              <div class="col-6 col-lg-4 mb-2 form-check">
+                <label class="form-check-label" for="checkbox-adjudication">No adjudication</label>
+                <input
+                  type="checkbox"
+                  class="form-check-input"
+                  id="checkbox-adjudication"
+                  name="adjudication"
+                  ${'checked' if not args.get("adjudication", True) else ''}
+                >
               </div>
             </div>
           </div>

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -974,9 +974,13 @@ def validate_form(request):
     if checkbox_arch_filter == "off":
         data["arch_filter"] = ""
 
+    if data["arch_filter"] == "":
+        del data["arch_filter"]
+
     # check if arch filter is a valid regular expression
     try:
-        regex.compile(data["arch_filter"])
+        if "arch_filter" in data:
+            regex.compile(data["arch_filter"])
     except regex.error as e:
         raise Exception(f"Invalid arch filter: {e}") from e
 
@@ -1032,8 +1036,8 @@ def validate_form(request):
         data["base_signature"] = data["new_signature"]
 
     for k, v in data.items():
-        if len(v) == 0 and k != "arch_filter":
-            raise Exception("Missing required option: {}".format(k))
+        if len(v) == 0:
+            raise Exception(f"Missing required option: {k}")
 
     # Handle boolean options
     data["auto_purge"] = request.POST.get("auto-purge") is not None


### PR DESCRIPTION
`arch_filter` is almost always empty. In such a case the convention is that the field should be optional.

Also: Improve layout of check boxes on mobile.