### PR TITLE
Implement lru_cache decorator and use it for most caches

### DIFF
--- a/server/fishtest/github_api.py
+++ b/server/fishtest/github_api.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import requests
-from fishtest.lru_cache import LRUCache
+from fishtest.lru_cache import LRUCache, lru_cache
 from fishtest.schemas import sha as sha_schema
 from fishtest.schemas import str_int, uint
 from vtjson import ValidationError, union, validate
@@ -379,13 +379,8 @@ def get_master_repo(
             r = r["parent"]
 
 
-normalize_repo_cache = LRUCache(size=128, expiration=600)
-
-
+@lru_cache(maxsize=128, expiration=600, refresh=False)
 def normalize_repo(repo):
-    cached_url = normalize_repo_cache.get(repo, refresh=False)
-    if cached_url is not None:
-        return cached_url
     r = call(
         repo,
         _method="HEAD",
@@ -394,7 +389,6 @@ def normalize_repo(repo):
         _ignore_rate_limit=True,
     )
     r.raise_for_status()
-    normalize_repo_cache[repo] = r.url
     return r.url
 
 

--- a/server/fishtest/lru_cache.py
+++ b/server/fishtest/lru_cache.py
@@ -1,3 +1,4 @@
+import functools
 import threading
 import time
 from collections import OrderedDict
@@ -5,13 +6,22 @@ from collections.abc import MutableMapping
 
 
 class LRUCache(MutableMapping):
-    def __init__(self, size=None, expiration=None, refresh_on_access=True):
-        if size is not None and size < 0:
-            raise ValueError("size must be >= 0 or None (default)")
-        self.__size = size
+    __slots__ = (
+        "__size",
+        "__expiration",
+        "__refresh",
+        "__data",
+        "__lock",
+        "__lock_depth",
+    )
+
+    def __init__(self, maxsize=None, expiration=None, refresh=True):
+        if maxsize is not None and maxsize < 0:
+            raise ValueError("maxsize must be >= 0 or None (default)")
+        self.__size = maxsize
         self.__expiration = expiration
-        self.__refresh_on_access = refresh_on_access
-        self.__dict = OrderedDict()
+        self.__refresh = refresh
+        self.__data = OrderedDict()
 
         # The internal state of the object is protected by this lock.
         # The lock can be acquired externally by using self (or equivalently
@@ -54,44 +64,44 @@ class LRUCache(MutableMapping):
     def __getitem__(self, key):
         with self.__lock:
             current_time = time.monotonic()
-            v, atime = self.__dict[key]
+            v, atime = self.__data[key]
             if self.__expiration is not None and self.__lock_depth == 0:
                 if atime < current_time - self.__expiration:
-                    del self.__dict[key]
+                    del self.__data[key]
                     raise KeyError(key)
-            if self.__refresh_on_access:
-                self.__dict.move_to_end(key)
-                self.__dict[key] = (v, current_time)
+            if self.__refresh:
+                self.__data.move_to_end(key)
+                self.__data[key] = (v, current_time)
             return v
 
     def __setitem__(self, key, value):
         with self.__lock:
-            self.__dict[key] = (value, time.monotonic())
-            self.__dict.move_to_end(key)
+            self.__data[key] = (value, time.monotonic())
+            self.__data.move_to_end(key)
             self.__purge()
 
     def __delitem__(self, key):
         with self.__lock:
-            del self.__dict[key]
+            del self.__data[key]
 
     def __len__(self):
         with self.__lock:
             self.__purge()
-            return len(self.__dict)
+            return len(self.__data)
 
     def get(self, *args, refresh=True, **kw):
         with self.__lock:
-            saved_refresh_on_access = self.__refresh_on_access
-            self.__refresh_on_access = refresh
+            saved_refresh = self.__refresh
+            self.__refresh = refresh
             try:
                 return super().get(*args, **kw)
             finally:
-                self.__refresh_on_access = saved_refresh_on_access
+                self.__refresh = saved_refresh
 
     # the default implementation is very inefficient
     def clear(self):
         with self.__lock:
-            self.__dict.clear()
+            self.__data.clear()
 
     # the default implementation of __contains__ calls
     # self.__getitem__ and hence it modifies the access time,
@@ -99,34 +109,34 @@ class LRUCache(MutableMapping):
     # check
     def __contains__(self, key):
         with self.__lock:
-            if key not in self.__dict:
+            if key not in self.__data:
                 return False
             if self.__expiration is not None and self.__lock_depth == 0:
                 current_time = time.monotonic()
-                v, atime = self.__dict[key]
+                v, atime = self.__data[key]
                 if atime < current_time - self.__expiration:
-                    del self.__dict[key]
+                    del self.__data[key]
                     return False
             return True
 
     def __iter__(self):
         with self.__lock:
             self.__purge()
-            return iter(list(self.__dict))
+            return iter(list(self.__data))
 
     # we cannot use the default implementation of values() and items()
-    # since these modify self.__dict during iteration (via the
+    # since these modify self.__data during iteration (via the
     # calls to self.__getitem__)
 
     def values(self):
         with self.__lock:
             self.__purge()
-            return iter([v[0] for v in self.__dict.values()])
+            return iter([v[0] for v in self.__data.values()])
 
     def items(self):
         with self.__lock:
             self.__purge()
-            return iter([(k, v[0]) for (k, v) in self.__dict.items()])
+            return iter([(k, v[0]) for (k, v) in self.__data.items()])
 
     def purge(self):
         with self.__lock:
@@ -136,28 +146,28 @@ class LRUCache(MutableMapping):
         # Helper method. Not synchronized!
         if self.__lock_depth == 0:
             if self.__size is not None:
-                while len(self.__dict) > self.__size:
-                    self.__dict.popitem(last=False)
+                while len(self.__data) > self.__size:
+                    self.__data.popitem(last=False)
             if self.__expiration is not None:
                 expired = []
                 cutoff_time = time.monotonic() - self.__expiration
-                for k, v in self.__dict.items():
+                for k, v in self.__data.items():
                     atime = v[1]
                     if atime >= cutoff_time:
                         break
                     expired.append(k)
                 for k in expired:
-                    del self.__dict[k]
+                    del self.__data[k]
 
     @property
-    def size(self):
+    def maxsize(self):
         with self.__lock:
             return self.__size
 
-    @size.setter
-    def size(self, val):
+    @maxsize.setter
+    def maxsize(self, val):
         if val is not None and val < 0:
-            raise ValueError("size must be >= 0 or None (default)")
+            raise ValueError("maxsize must be >= 0 or None (default)")
         with self.__lock:
             self.__size = val
             self.__purge()
@@ -174,14 +184,14 @@ class LRUCache(MutableMapping):
             self.__purge()
 
     @property
-    def refresh_on_access(self):
+    def refresh(self):
         with self.__lock:
-            return self.__refresh_on_access
+            return self.__refresh
 
-    @refresh_on_access.setter
-    def refresh_on_access(self, val):
+    @refresh.setter
+    def refresh(self, val):
         with self.__lock:
-            self.__refresh_on_access = val
+            self.__refresh = val
 
     # The "lock" property is an alias for self
     # so it is purely cosmetic. However writing:
@@ -196,3 +206,62 @@ class LRUCache(MutableMapping):
     @property
     def lock(self):
         return self
+
+
+# This mimics to some extent the decorator "functools.lru_cache". It has however
+# the extra options "expiration" and "refresh". Furthermore it is possible
+# to use a previously defined LRUCache object as cache. The "key" parameter
+# allows customizing how cache keys are constructed from (f, args, kw), and the
+# "filter" parameter controls, based on (f, args, kw, val), whether a computed
+# result should be stored in the cache.
+class lru_cache:
+    def __init__(
+        self,
+        maxsize=None,
+        expiration=None,
+        refresh=None,
+        cache=None,
+        key=lambda f, args, kw: (f, tuple(kw.items())) + args,
+        filter=lambda f, args, kw, val: True,
+    ):
+        if cache is not None:
+            if any((x is not None for x in (maxsize, expiration, refresh))):
+                raise ValueError(
+                    "You cannot specify maxsize, expiration or "
+                    "refresh for a pre-constructed LRUCache object",
+                )
+            self.__cache = cache
+        else:
+            if refresh is None:
+                refresh = True
+            self.__cache = LRUCache(
+                maxsize=maxsize, expiration=expiration, refresh=refresh
+            )
+        self.__key = key
+        self.__filter = filter
+
+    def __call__(self, f):
+        @functools.wraps(f)
+        def wrapper(*args, **kw):
+            key = self.__key(f, args, kw)
+            try:
+                return self.__cache[key]
+            except KeyError:
+                pass
+            ret = f(*args, **kw)
+            with self.__cache.lock:
+                try:
+                    return self.__cache[key]
+                except KeyError:
+                    pass
+                if self.__filter(f, args, kw, ret):
+                    self.__cache[key] = ret
+                return ret
+
+        wrapper.lock = self.__cache.lock
+        wrapper.cache = self.__cache
+
+        # for compatibility with the built-in functools.lru_cache
+        wrapper.cache_clear = self.__cache.clear
+        wrapper.__wrapped__ = f
+        return wrapper

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -19,7 +19,7 @@ from bson.codec_options import CodecOptions
 from bson.objectid import ObjectId
 from fishtest.actiondb import ActionDb
 from fishtest.kvstore import KeyValueStore
-from fishtest.lru_cache import LRUCache
+from fishtest.lru_cache import lru_cache
 from fishtest.run_cache import Prio
 from fishtest.scheduler import Scheduler
 from fishtest.schemas import (
@@ -116,17 +116,10 @@ class RunDb:
 
         self.spsa_handler = fishtest.spsa_handler.SPSAHandler(self)
 
-        self.compiled_regex_cache = LRUCache(1000)
-
+    @lru_cache(maxsize=1000)
     def compile_regex(self, pattern):
-        try:
-            return self.compiled_regex_cache[pattern]
-        except KeyError:
-            pass
         # pattern is already known to compile
-        compiled_pattern = regex.compile(pattern)
-        self.compiled_regex_cache[pattern] = compiled_pattern
-        return compiled_pattern
+        return regex.compile(pattern)
 
     def get_run(self, run_id):
         if self.__is_primary_instance:

--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -6,7 +6,6 @@
 
 import copy
 import math
-import threading
 from datetime import UTC, datetime
 
 import fishtest.stats.stat_util
@@ -38,9 +37,6 @@ from vtjson import (
     set_name,
     size,
     union,
-)
-from vtjson import (
-    filter as filter_,
 )
 
 run_id = intersect(str, set_name(ObjectId.is_valid, "valid_object_id"))
@@ -874,16 +870,6 @@ connections_counter_schema = {
 unfinished_runs_schema = {
     run_id,
 }
-
-# threading.RLock is a factory function!
-_RLock = type(threading.RLock())
-
-active_runs_schema = filter_(
-    dict,
-    {
-        run_id: _RLock,
-    },
-)
 
 worker_runs_schema = {
     short_worker_name: {

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -672,7 +672,7 @@ def user(request):
                 + " user "
                 + user_name
             )
-            request.userdb.blocked.clear()
+            request.userdb.clear_cache()
             request.userdb.save_user(user_data)
             request.actiondb.block_user(
                 username=userid,
@@ -681,7 +681,7 @@ def user(request):
             )
 
         elif "pending" in request.POST and user_data["pending"]:
-            request.userdb.pending.clear()
+            request.userdb.clear_cache()
             if request.POST["pending"] == "0":
                 user_data["pending"] = False
                 request.userdb.save_user(user_data)

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -158,7 +158,7 @@ class TestApi(unittest.TestCase):
         cls.rundb.scheduler.stop()
         cls.rundb.runs.delete_many({})
         cls.rundb.userdb.users.delete_many({"username": cls.username})
-        cls.rundb.userdb.cache.clear()
+        cls.rundb.userdb.clear_cache()
         cls.rundb.userdb.user_cache.delete_many({"username": cls.username})
         cls.rundb.runs.drop()
 
@@ -544,7 +544,7 @@ class TestRunFinished(unittest.TestCase):
     def tearDownClass(cls):
         cls.rundb.scheduler.stop()
         cls.rundb.userdb.users.delete_many({"username": cls.username})
-        cls.rundb.userdb.cache.clear()
+        cls.rundb.userdb.clear_cache()
         cls.rundb.userdb.user_cache.delete_many({"username": cls.username})
         cls.rundb.runs.drop()
 


### PR DESCRIPTION
Our `lru_cache` decorator mimics to some extent the built-in `functools.lru_cache` but it allows time based expiration and it has configurable refresh on access behavior. In addition it is possible to use a previously created `LRUCache` object as cache. In this way different functions can share the same cache.