### PR TITLE
Now also use a lru_cache decorator for the github_api cache.

### DIFF
--- a/server/fishtest/lru_cache.py
+++ b/server/fishtest/lru_cache.py
@@ -260,8 +260,9 @@ class lru_cache:
 
         wrapper.lock = self.__cache.lock
         wrapper.cache = self.__cache
+        wrapper.key = self.__key
+        wrapper.filter = self.__filter
 
         # for compatibility with the built-in functools.lru_cache
         wrapper.cache_clear = self.__cache.clear
-        wrapper.__wrapped__ = f
         return wrapper


### PR DESCRIPTION
Note that we deleted the ugly error detection code. It has served its purpose:

https://tests.stockfishchess.org/actions?max_actions=1&before=1767274733.476365

This means that the current github_api cache contains invalid entries. So we raised the version. This essentially means that the cache will be cleared on server start. This will slow down test viewing a bit until the cache fills up again.