### PR TITLE
Use list of valid arches on server

### DIFF
--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 
 import fishtest.stats.stat_util
 from bson.objectid import ObjectId
+from fishtest.util import supported_arches
 from vtjson import (
     anything,
     at_least_one_of,
@@ -49,7 +50,7 @@ short_worker_name = regex(r".*-[\d]+cores-[a-zA-Z0-9]{2,8}", name="short_worker_
 long_worker_name = regex(
     r".*-[\d]+cores-[a-zA-Z0-9]{2,8}-[a-f0-9]{4}\*?", name="long_worker_name"
 )
-worker_arch = intersect(str, size(0, 30))
+worker_arch = set_name(union(*supported_arches), "valid_worker_arch")
 username = regex(r"[!-~][ -~]{0,30}[!-~]", name="username")
 net_name = regex(r"nn-[a-f0-9]{12}.nnue", name="net_name")
 tc = regex(r"([1-9]\d*/)?\d+(\.\d+)?(\+\d+(\.\d+)?)?", name="tc")

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -1,6 +1,7 @@
 <%inherit file="base.mak"/>
 
 <%!
+  import json
   from fishtest.util import format_bounds
   elo_model = "normalized"
   fb = lambda e0, e1: format_bounds(elo_model, e0, e1)
@@ -608,14 +609,20 @@
             </div>
 
             <div id="arch-filter" class="mb-2" style="display: none;">
-              <div class="row gx-1">
+              <div class="row gx-2 mb-2">
                 <div class="col">
                   <label for="arch-filter" class="form-label">Arch filter (regular expression)</label>
                   <input
+                    id="arch-filter-input"
+                    autocomplete="off"
                     name="arch-filter"
                     class="form-control"
                     value='${arch_filter|h}'
                   >
+                </div>
+              </div>
+              <div class="row gx-2">
+                <div id="supported-arches" class="col">
                 </div>
               </div>
             </div>
@@ -1045,9 +1052,31 @@
     }
   }
 
+  function updateSupportedArches() {
+    const errorCSS = "color: red;";
+    const supportedArches = ${json.dumps(supported_arches)|n};
+    const archFilterInputElement = document.getElementById('arch-filter-input');
+    let filteredArches;
+    try {
+      const archFilter = new RegExp(archFilterInputElement.value);
+      filteredArches = supportedArches.filter(str => archFilter.test(str));
+      if(filteredArches.length === 0) {
+        archFilterInputElement.style.cssText = errorCSS;
+      } else {
+        archFilterInputElement.style.cssText = "";
+      }
+    } catch(e) {
+      archFilterInputElement.style.cssText = errorCSS;
+      return;
+    }
+    const supportedArchesElement = document.getElementById('supported-arches');
+    supportedArchesElement.innerText = filteredArches.join(", ");
+  }
+
   function toggleArchFilter(checkbox) {
     if (checkbox.checked) {
       document.getElementById('arch-filter').style.display = "";
+      updateSupportedArches();
     } else {
       document.getElementById('arch-filter').style.display = "none";
     }
@@ -1059,6 +1088,10 @@
 
   document.getElementById('checkbox-arch-filter').addEventListener("change", (e) => {
     toggleArchFilter(e.target);
+  });
+
+  document.getElementById('arch-filter-input').addEventListener("input", (e) => {
+    updateSupportedArches();
   });
 </script>
 

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -624,3 +624,45 @@ def reasonable_run_hashes(run):
     new_hash = get_hash(run["args"]["new_options"])
     tc_ratio = get_tc_ratio(run["args"]["tc"], run["args"]["threads"])
     return ok_hash(tc_ratio, base_hash) and ok_hash(tc_ratio, new_hash)
+
+
+# The list below has been extracted from the output of "make help"
+# in the src directory of the SF source code.
+# However not all arches supported by the makefile are actually
+# used by the workers since they use "make ARCH=native" for compilation
+# and this means the arch is determined by the output of the
+# script/get_native_properties.sh in the SF source code.
+# The unused arches have been commented out.
+
+supported_arches = [
+    "apple-silicon",
+    "armv7",
+    "armv7-neon",
+    "armv8",
+    "armv8-dotprod",
+    #    "e2k",
+    #    "general-32",
+    #    "general-64",
+    "loongarch64",
+    "loongarch64-lasx",
+    "loongarch64-lsx",
+    #    "ppc-32",
+    "ppc-64",
+    "ppc-64-altivec",
+    "ppc-64-vsx",
+    #    "riscv64",
+    "x86-32",
+    #    "x86-32-sse2",
+    #    "x86-32-sse41-popcnt",
+    "x86-64",
+    "x86-64-avx2",
+    "x86-64-avx512",
+    "x86-64-avxvnni",
+    "x86-64-bmi2",
+    #    "x86-64-modern",
+    #    "x86-64-sse3-popcnt",
+    "x86-64-sse41-popcnt",
+    #    "x86-64-ssse3",
+    "x86-64-vnni512",
+    "x86-64-avx512icl",
+]

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -190,6 +190,21 @@ class TestApi(unittest.TestCase):
             }
         )
 
+    def test_invalid_arch(self):
+        worker_info = copy.deepcopy(self.worker_info)
+        worker_info["worker_arch"] = "bad_arch"
+        request = self.build_json_request(
+            {
+                "password": self.password,
+                "worker_info": worker_info,
+            }
+        )
+        with self.assertRaises(HTTPBadRequest) as cm:
+            WorkerApi(request).request_task()
+
+        self.assertIn("error", str(cm.exception))
+        self.assertIn("bad_arch", str(cm.exception))
+
     def test_get_active_runs(self):
         run_id = new_run(self)
         request = DummyRequest(rundb=self.rundb)


### PR DESCRIPTION
We equip the server with a hard coded list of valid arches (later we can generate this list dynamically by parsing the SF makefile).

We use this list in two ways

- For validation of the arch sent by the worker.
- To preview the selected arches on the test creation page.

<img width="684" height="280" alt="image" src="https://github.com/user-attachments/assets/30b5fc4c-d287-4c5f-a820-830df86d0cba" />

@ppigazzini I guess some of the arches shown by `make help` cannot actually be generated by your script. Do you know which ones? 
