### PR TITLE
Do not start worker if determining arch fails

### DIFF
--- a/worker/sri.txt
+++ b/worker/sri.txt
@@ -1,1 +1,1 @@
-{"__version": 307, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "ynidLqL9iyd0rsGT7J3QGBKXhvm0mV5uyPoC9Kcpz4+JUIqvdBYXKUA53vYsSlzu", "games.py": "2uTRYtzETBm3Y8NLfqsZas/AWEdrdvTZD/OIHQ+VpPoqx/N19QTiNSqmk4JWOCMB"}
+{"__version": 307, "updater.py": "eDDBPKA/vrTCadgtEJFdL06vSoiysF0JhiHKdEnjQv3zS4kfdOAqnco/DJpDWbvh", "worker.py": "CoNoHLLmi9bp5CdgNhi47Y9w2WZkJGY230xcIFMjUTKGWaYhSGl8g2ao4Vt/TQtp", "games.py": "2uTRYtzETBm3Y8NLfqsZas/AWEdrdvTZD/OIHQ+VpPoqx/N19QTiNSqmk4JWOCMB"}

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -1188,8 +1188,7 @@ def get_worker_arch(worker_dir):
         print(f"Worker arch determined to be: {arch}")
     except Exception as e:
         print(f"Exception obtaining worker arch:\n{e}", file=sys.stderr)
-        print('Unable to determine worker arch. Setting it to "unknown"')
-        arch = "unknown"
+        return None
     finally:
         os.chdir(working_dir)
     return arch
@@ -1548,6 +1547,11 @@ def worker():
     if not verify_toolchain():
         return 1
 
+    # Make sure we can determine the worker arch
+    worker_arch = get_worker_arch(worker_dir)
+    if worker_arch is None:
+        return 1
+
     # Make sure we have a working fastchess
     if not setup_fastchess(
         worker_dir, compiler, options.concurrency, options.global_cache, tests=True
@@ -1581,7 +1585,7 @@ def worker():
         "compiler": compiler,
         "unique_key": get_uuid(options),
         "modified": not unmodified,
-        "worker_arch": get_worker_arch(worker_dir),
+        "worker_arch": worker_arch,
         "ARCH": "?",
         "nps": 0.0,
         "near_github_api_limit": False,


### PR DESCRIPTION
Currently the arch is set to "unknown" if determining it fails. However after the tightening of the worker api schema in #2439 this is rejected by the server. We could of course fix this server side by relaxing the worker api schema but this seems overkill for something that happens at most very rarely (I have never seen it).

Besides: if determining the arch fail then it can be for two reasons: network failure, or being unable to run the script "get_native_properties.sh" from SF master.
In both cases the worker will not work properly anyway.