### PR TITLE
Accept unknown arch in worker api schema.

### DIFF
--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -419,7 +419,7 @@ worker_info_schema_api = {
     "compiler": union("clang++", "g++"),
     "unique_key": uuid,
     "modified": bool,
-    "worker_arch": worker_arch,
+    "worker_arch": union(worker_arch, "unknown"),
     "ARCH": str,
     "nps": unumber,
     "near_github_api_limit": bool,

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -659,7 +659,6 @@ supported_arches = [
     "x86-64-avx512",
     "x86-64-avxvnni",
     "x86-64-bmi2",
-    #    "x86-64-modern",
     #    "x86-64-sse3-popcnt",
     "x86-64-sse41-popcnt",
     #    "x86-64-ssse3",


### PR DESCRIPTION
Also delete the (commented out) arch "x86-64-modern" from util.supported_arches since it is not a true arch but an alias.