### PR TITLE
Enforce in schema that user group list can contain groups only once

### DIFF
--- a/server/fishtest/schemas.py
+++ b/server/fishtest/schemas.py
@@ -38,6 +38,7 @@ from vtjson import (
     set_name,
     size,
     union,
+    unique,
 )
 
 run_id = intersect(str, set_name(ObjectId.is_valid, "valid_object_id"))
@@ -108,7 +109,7 @@ user_schema = {
     "pending": bool,
     "blocked": bool,
     "email": email,
-    "groups": [str, ...],
+    "groups": intersect([str, ...], unique),
     "tests_repo": union(github_repo, ""),
     "machine_limit": uint,
 }
@@ -697,8 +698,8 @@ runs_schema = intersect(
             {
                 "base_tag": str,
                 "new_tag": str,
-                "base_nets": [net_name, ...],
-                "new_nets": [net_name, ...],
+                "base_nets": intersect([net_name, ...], unique),
+                "new_nets": intersect([net_name, ...], unique),
                 "num_games": intersect(uint, even),
                 "tc": tc,
                 "new_tc": tc,

--- a/server/fishtest/userdb.py
+++ b/server/fishtest/userdb.py
@@ -14,7 +14,7 @@ def validate_user(user):
     except ValidationError as e:
         message = f"The user object does not validate: {str(e)}"
         print(message, flush=True)
-        raise Exception(message)
+        raise ValidationError(message) from None
 
 
 class UserDb:

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -796,7 +796,9 @@ def get_nets(commit_sha, repo_url):
             if "EvalFileDefaultName" in line and "define" in line:
                 m = pattern.search(line)
                 if m:
-                    nets.append(m.group(0))
+                    net = m.group(0)
+                    if net not in nets:
+                        nets.append(net)
 
         if nets:
             return nets
@@ -808,7 +810,9 @@ def get_nets(commit_sha, repo_url):
             if "EvalFile" in line and "Option" in line:
                 m = pattern.search(line)
                 if m:
-                    nets.append(m.group(0))
+                    net = m.group(0)
+                    if net not in nets:
+                        nets.append(net)
         return nets
     except Exception as e:
         raise Exception(f"Unable to access developer repository {repo_url}: {str(e)}")

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "requests>=2.32.5",
     "scipy>=1.17.0",
     "setuptools>=61,<81",
-    "vtjson>=2.2.6",
+    "vtjson>=2.2.7",
     "waitress>=3.0.2",
     "zxcvbn>=4.5.0",
 ]

--- a/server/tests/test_users.py
+++ b/server/tests/test_users.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 import util
 from fishtest.views import login, signup
 from pyramid import testing
+from vtjson import ValidationError
 
 
 class Create10UsersTest(unittest.TestCase):
@@ -33,6 +34,13 @@ class Create10UsersTest(unittest.TestCase):
         )
         response = signup(request)
         self.assertTrue("The resource was found at", response)
+
+    def test_add_user_group(self):
+        self.rundb.userdb.create_user("JoeUser", "xxx", "JoeUser@gmail.com", "")
+        self.rundb.userdb.add_user_group("JoeUser", "approvers")
+        self.rundb.userdb.add_user_group("JoeUser", "dummy")
+        with self.assertRaises(ValidationError):
+            self.rundb.userdb.add_user_group("JoeUser", "approvers")
 
 
 class Create50LoginTest(unittest.TestCase):

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.14"
 
 [[package]]
 name = "awscli"
-version = "1.44.20"
+version = "1.44.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -14,23 +14,23 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/c4/25281e3de2b9764e845ec08e1b8db0ab4c56f415aed70f618de674be8167/awscli-1.44.20.tar.gz", hash = "sha256:4bdb0729bc3d1c6878a11989c3c9c37b6f23a64d8784fc2f62f04f986910bc95", size = 1888720, upload-time = "2026-01-16T20:37:20.006Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/86/148804a8b33d21c7224ce160a3bf6be931d20fad32f9d6b016ae1c89f73c/awscli-1.44.24.tar.gz", hash = "sha256:e546857ab585127628d5545a03c3f377ee3ad249439d6960ec591d2c5d913c2a", size = 1888967, upload-time = "2026-01-23T20:29:43.866Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/bd/0ce7c7511a8af63ea952d1c4c94ed095e687142e4438b6bfae1132f642f7/awscli-1.44.20-py3-none-any.whl", hash = "sha256:5eabf33997ee6c78216211b6176e5d0c990e306c22a119190006baa31cf6f2c9", size = 4640518, upload-time = "2026-01-16T20:37:17.932Z" },
+    { url = "https://files.pythonhosted.org/packages/68/e5/1922e731e69cfaa25c3ff0ff57c275624b7f0b2718df30d80ea041db79d3/awscli-1.44.24-py3-none-any.whl", hash = "sha256:48c76c4d88f041b30204c6ce2187ba223a088264418cfad8d348aad4aaad984f", size = 4641152, upload-time = "2026-01-23T20:29:42.156Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.30"
+version = "1.42.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/38/23862628a0eb044c8b8b3d7a9ad1920b3bfd6bce6d746d5a871e8382c7e4/botocore-1.42.30.tar.gz", hash = "sha256:9bf1662b8273d5cc3828a49f71ca85abf4e021011c1f0a71f41a2ea5769a5116", size = 14891439, upload-time = "2026-01-16T20:37:13.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/f0/5702b704844e8920e01ce865cde0da574827163fbd7c0207d351ff6eea2c/botocore-1.42.34.tar.gz", hash = "sha256:92e44747da7890270d8dcc494ecc61fc315438440c55e00dc37a57d402b1bb66", size = 14907713, upload-time = "2026-01-23T20:29:38.193Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/8d/6d7b016383b1f74dd93611b1c5078bbaddaca901553ab886dcda87cae365/botocore-1.42.30-py3-none-any.whl", hash = "sha256:97070a438cac92430bb7b65f8ebd7075224f4a289719da4ee293d22d1e98db02", size = 14566340, upload-time = "2026-01-16T20:37:10.94Z" },
+    { url = "https://files.pythonhosted.org/packages/29/99/226fb4b2d141d7ac59465e3cdd2ca3a9a2917d85e1a3160884a78b097bbb/botocore-1.42.34-py3-none-any.whl", hash = "sha256:94099b5d09d0c4bfa6414fb3cffd54275ce6e51d7ba016f17a0e79f9274f68f7", size = 14579956, upload-time = "2026-01-23T20:29:29.038Z" },
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "scipy", specifier = ">=1.17.0" },
     { name = "setuptools", specifier = ">=61,<81" },
-    { name = "vtjson", specifier = ">=2.2.6" },
+    { name = "vtjson", specifier = ">=2.2.7" },
     { name = "waitress", specifier = ">=3.0.2" },
     { name = "zxcvbn", specifier = ">=4.5.0" },
 ]
@@ -166,11 +166,11 @@ wheels = [
 
 [[package]]
 name = "jmespath"
-version = "1.0.1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -539,11 +539,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.9.0"
+version = "80.10.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/ff/f75651350db3cf2ef767371307eb163f3cc1ac03e16fdf3ac347607f7edb/setuptools-80.10.1.tar.gz", hash = "sha256:bf2e513eb8144c3298a3bd28ab1a5edb739131ec5c22e045ff93cd7f5319703a", size = 1229650, upload-time = "2026-01-21T09:42:03.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/76/f963c61683a39084aa575f98089253e1e852a4417cb8a3a8a422923a5246/setuptools-80.10.1-py3-none-any.whl", hash = "sha256:fc30c51cbcb8199a219c12cc9c281b5925a4978d212f84229c909636d9f6984e", size = 1099859, upload-time = "2026-01-21T09:42:00.688Z" },
 ]
 
 [[package]]
@@ -593,7 +593,7 @@ wheels = [
 
 [[package]]
 name = "vtjson"
-version = "2.2.6"
+version = "2.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dnspython" },
@@ -602,9 +602,9 @@ dependencies = [
     { name = "python-magic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/129fcbe5f33da00773c2c7299bf97d21c834d4cfa16758cd184ebc5e09c7/vtjson-2.2.6.tar.gz", hash = "sha256:a16ddcbc248034e33e536a64100147ed54f5ca835d58bb40e68f03475b48088c", size = 26255, upload-time = "2026-01-09T18:17:10.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/28/b7308a4d26640a85aa8867062549570794ff4ff94a55c42e836f98a7db74/vtjson-2.2.7.tar.gz", hash = "sha256:e1f0a72df7e1a1dc790c6afe3233777eec96561c70e64d3904beaa02f3b2bcad", size = 27388, upload-time = "2026-01-24T07:45:48.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/87/9bfce6abffcb1d272c485eab54763d2b271728f6acb4a0615e610c3f857c/vtjson-2.2.6-py3-none-any.whl", hash = "sha256:63147073b9eae2f61a6cd8bf674d3ab8980261edb95a439cb60c51c19f789b41", size = 18209, upload-time = "2026-01-09T18:17:09.036Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f9/78abeb90f55f57d3a0982f650a8c1893228156197303a769816b06db8e58/vtjson-2.2.7-py3-none-any.whl", hash = "sha256:bdbd164d034b1a804925164e49914983d82d0f7cb633092bca81f601a12aed3d", size = 18650, upload-time = "2026-01-24T07:45:47.097Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Requires vtjson >= 2.2.7

There is a unit test `test_add_user_group` that checks that it works.

Also: make `base_nets` and `new_nets` (the net names used by SF) similarly have unique entries.
