### PR TITLE
fix(mako): small fixes in templates

### DIFF
--- a/server/fishtest/templates/elo_results.mak
+++ b/server/fishtest/templates/elo_results.mak
@@ -66,7 +66,7 @@
   % endfor
   % if elo_ptnml_run:
     <br>
-    ${f"nElo: {nelo5:.2f} ± {nelo5_delta:.1f} (95%) PairsRatio: {results5_pairs_ratio:.2f}"}
+    ${f"nElo: {nelo5:.2f} &plusmn; {nelo5_delta:.1f} (95%) PairsRatio: {results5_pairs_ratio:.2f}"|n}
   % endif
 </%def>
 

--- a/server/fishtest/templates/tests.mak
+++ b/server/fishtest/templates/tests.mak
@@ -2,7 +2,7 @@
 
 <link
   rel="stylesheet"
-  href="${request.static_url('fishtest:static/css/flags.css')}}"
+  href="${request.static_url('fishtest:static/css/flags.css')}"
 >
 
 <h2>Stockfish Testing Queue</h2>

--- a/server/fishtest/templates/tests_run.mak
+++ b/server/fishtest/templates/tests_run.mak
@@ -761,14 +761,14 @@
     if (!ltcTestRadio.checked) return;
 
     if (spsaRadio.checked) {
-      // Case: LTC + SPSA → set recommended 50% throughput.
+      // Case: LTC + SPSA -> set recommended 50% throughput.
       if ([...throughputSelect.options].some(o => o.value === "50")) {
         throughputSelect.value = "50";
       }
       return;
     }
 
-    // Case: LTC without SPSA → restore LTC default from its data-options.
+    // Case: LTC without SPSA -> restore LTC default from its data-options.
     try {
       const ltcOptions = JSON.parse(ltcTestRadio.dataset.options || "{}");
       if (ltcOptions.throughput) {

--- a/server/fishtest/templates/tests_view.mak
+++ b/server/fishtest/templates/tests_view.mak
@@ -407,7 +407,7 @@
       Gaussian Kernel Smoother&nbsp;&nbsp;
       <div class="btn-group">
         <button id="btn_smooth_plus" class="btn">&nbsp;&nbsp;&nbsp;+&nbsp;&nbsp;&nbsp;</button>
-        <button id="btn_smooth_minus" class="btn">&nbsp;&nbsp;&nbsp;−&nbsp;&nbsp;&nbsp;</button>
+        <button id="btn_smooth_minus" class="btn">&nbsp;&nbsp;&nbsp;&minus;&nbsp;&nbsp;&nbsp;</button>
       </div>
 
       <div class="btn-group">
@@ -474,7 +474,7 @@
       </thead>
       <tbody id="tasks-body"></tbody>
     </table>
-  </div>
+  </section>
 ## End of enclosing div to be able to make things invisible.
 </div>
 

--- a/server/fishtest/templates/workers.mak
+++ b/server/fishtest/templates/workers.mak
@@ -102,7 +102,7 @@
     type="button"
     data-bs-toggle="dropdown"
     aria-expanded="false"
-  >Modified &#8804; 5 days ago</span></button>
+  >Modified &#8804; 5 days ago</button>
 
   <ul class="dropdown-menu">
     <li><span class="dropdown-item" data-handle-target-custom="all-workers">All</span></li>


### PR DESCRIPTION
- Fix incorrect HTML tag nesting and syntax errors (extra closing tags, wrong tag types, extra braces)
- Replace non-ASCII unicode symbols with HTML entities in button labels and output text
- Replace unicode arrows with ASCII arrows in JavaScript comments