### PR TITLE
Fix small error in default key for lru_cache decorator

### DIFF
--- a/server/fishtest/lru_cache.py
+++ b/server/fishtest/lru_cache.py
@@ -221,7 +221,7 @@ class lru_cache:
         expiration=None,
         refresh=None,
         cache=None,
-        key=lambda f, args, kw: (f, tuple(kw.items())) + args,
+        key=lambda f, args, kw: (f, frozenset(kw.items())) + args,
         filter=lambda f, args, kw, val: True,
     ):
         if cache is not None:


### PR DESCRIPTION
The default key incorporates keyword arguments (this was a feature request by copilot). However currently it is sensitive to the order of the keywords. This PR fixes this and adds the appropriate unittest.

Also: fix the names of some unittests.

Also: this fix exposed a bug with an unreleased lock in one of the tests. We fix that also.