### PR TITLE
Match backend with frontend for valid usernames.

### DIFF
--- a/server/fishtest/__init__.py
+++ b/server/fishtest/__init__.py
@@ -5,6 +5,7 @@ import threading
 import traceback
 
 import fishtest.github_api as gh
+import fishtest.schemas as schemas
 from fishtest.routes import setup_routes
 from fishtest.rundb import RunDb
 from pyramid.authentication import AuthTktAuthenticationPolicy
@@ -85,6 +86,7 @@ def main(global_config, **settings):
             # - uses the network;
             # - accesses the db;
             # - starts new threads.
+            schemas.legacy_usernames = set(rundb.kvstore.get("legacy_usernames", []))
             gh.init(rundb.kvstore, rundb.actiondb)
             rundb.update_aggregated_data()
             rundb.schedule_tasks()

--- a/server/fishtest/rundb.py
+++ b/server/fishtest/rundb.py
@@ -43,6 +43,7 @@ from fishtest.schemas import (
 from fishtest.stats.stat_util import SPRT_elo
 from fishtest.userdb import UserDb
 from fishtest.util import (
+    FISHTEST,
     GeneratorAsFileReader,
     count_games,
     crash_or_time,
@@ -61,7 +62,7 @@ from vtjson import ValidationError, validate
 
 
 class RunDb:
-    def __init__(self, db_name="fishtest_new", port=-1, is_primary_instance=True):
+    def __init__(self, db_name=FISHTEST, port=-1, is_primary_instance=True):
         # MongoDB server is assumed to be on the same machine, if not user should
         # use ssh with port forwarding to access the remote host.
         self.conn = MongoClient("localhost")

--- a/server/fishtest/templates/signup.mak
+++ b/server/fishtest/templates/signup.mak
@@ -1,5 +1,9 @@
 <%inherit file="base.mak"/>
 
+<%
+from fishtest.util import VALID_USERNAME_PATTERN
+%>
+
 <script>
   document.title = "Register | Stockfish Testing";
 </script>
@@ -30,7 +34,7 @@
         id="username"
         name="username"
         placeholder="Username"
-        pattern="[A-Za-z0-9]{2,}"
+        pattern="${VALID_USERNAME_PATTERN}"
         title="Only letters and digits and at least 2 long"
         required
         autofocus

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -12,7 +12,9 @@ import scipy.stats
 from email_validator import EmailNotValidError, caching_resolver, validate_email
 from zxcvbn import zxcvbn
 
+FISHTEST = "fishtest_new"
 PASSWORD_MAX_LENGTH = 72
+VALID_USERNAME_PATTERN = "[A-Za-z0-9]{2,}"
 
 
 class GeneratorAsFileReader:

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "requests>=2.32.5",
     "scipy>=1.17.0",
     "setuptools>=61,<81",
-    "vtjson>=2.2.7",
+    "vtjson>=2.2.8",
     "waitress>=3.0.2",
     "zxcvbn>=4.5.0",
 ]

--- a/server/tests/test_kvstore.py
+++ b/server/tests/test_kvstore.py
@@ -104,6 +104,17 @@ class CreateKeyValueStoreTest(unittest.TestCase):
         self.kvstore["b"] = 2
         self.assertEqual(set(self.kvstore.items()), {("a", 1), ("b", 2)})
 
+    def test_kvstore_invalid_input(self):
+        o = object()
+        with self.assertRaisesRegex(ValueError, "not a string"):
+            self.kvstore[o]
+        with self.assertRaisesRegex(ValueError, "not a string"):
+            self.kvstore[o] = "dummy"
+        with self.assertRaisesRegex(ValueError, "cannot be converted to bson"):
+            self.kvstore["dummy"] = o
+        with self.assertRaisesRegex(ValueError, "not a string"):
+            del self.kvstore[o]
+
     @classmethod
     def tearDownClass(cls):
         cls.kvstore.drop()

--- a/server/utils/userdb.py
+++ b/server/utils/userdb.py
@@ -1,0 +1,30 @@
+import atexit
+import re
+
+from fishtest.rundb import RunDb
+from fishtest.util import FISHTEST, VALID_USERNAME_PATTERN
+
+
+def get_rundb():
+    rundb = RunDb(db_name=FISHTEST)
+    atexit.register(rundb.conn.close)
+    return rundb
+
+
+def store_legacy_usernames(rundb):
+    valid_user_regex = re.compile(VALID_USERNAME_PATTERN)
+    users = rundb.userdb.users
+    usernames = (doc["username"] for doc in users.find({}, {"username": 1, "_id": 0}))
+    legacy_usernames = list(
+        filter(lambda x: not valid_user_regex.fullmatch(x), usernames)
+    )
+    rundb.kvstore["legacy_usernames"] = legacy_usernames
+    return legacy_usernames
+
+
+if __name__ == "__main__":
+    rundb = get_rundb()
+    legacy_usernames = store_legacy_usernames(rundb)
+    print("The following legacy usernames were found and stored:")
+    for name in legacy_usernames:
+        print(name)

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -141,7 +141,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "scipy", specifier = ">=1.17.0" },
     { name = "setuptools", specifier = ">=61,<81" },
-    { name = "vtjson", specifier = ">=2.2.7" },
+    { name = "vtjson", specifier = ">=2.2.8" },
     { name = "waitress", specifier = ">=3.0.2" },
     { name = "zxcvbn", specifier = ">=4.5.0" },
 ]
@@ -593,7 +593,7 @@ wheels = [
 
 [[package]]
 name = "vtjson"
-version = "2.2.7"
+version = "2.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dnspython" },
@@ -602,9 +602,9 @@ dependencies = [
     { name = "python-magic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/28/b7308a4d26640a85aa8867062549570794ff4ff94a55c42e836f98a7db74/vtjson-2.2.7.tar.gz", hash = "sha256:e1f0a72df7e1a1dc790c6afe3233777eec96561c70e64d3904beaa02f3b2bcad", size = 27388, upload-time = "2026-01-24T07:45:48.546Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/19/3ee669449212031bc1ae3d10e90073d51a5261e09e01de445f0c8b0dad30/vtjson-2.2.8.tar.gz", hash = "sha256:a89ae77870d04d8c51df5b121cc2abdbf85a2fe0bf4b4022db81ada780bd5895", size = 27410, upload-time = "2026-02-06T11:49:47.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/f9/78abeb90f55f57d3a0982f650a8c1893228156197303a769816b06db8e58/vtjson-2.2.7-py3-none-any.whl", hash = "sha256:bdbd164d034b1a804925164e49914983d82d0f7cb633092bca81f601a12aed3d", size = 18650, upload-time = "2026-01-24T07:45:47.097Z" },
+    { url = "https://files.pythonhosted.org/packages/91/b8/354dd9233f10eb36c7bf7c789eab79e81596153c47861ab03495dd035cac/vtjson-2.2.8-py3-none-any.whl", hash = "sha256:b6dee0114804933354a5b2e2e9038f0a9fcdeefda359c931359c5aa3965114fb", size = 18676, upload-time = "2026-02-06T11:49:45.935Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The frontend regex pattern is `^[a-zA-Z0-9]{2,}`. We now enforce this also in the user schema.

However there are some usernames already in the system not matching this pattern. To deal with this we provide a script `utils/userdb.py` (that has to be run once) that finds the list of legacy usernames and stores it in the key-value store. The new user schema continues to allow these legacy usernames.

While working on this we discovered a bug in vtjson: the schema `union()` which should match nothing, matched in fact everything. So vtjson should be upgraded to 2.2.8.

We also discovered that the error messages from `KeyValueStore` objects were not very friendly. So we now do stricter input verification.

Some new unittests are provided for the new user schema and the added input verification for the kvstore.