### PR TITLE
fix(auth): stop logging passwords and harden authenticate() error protocol

### DIFF
--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -382,9 +382,10 @@ def login(request):
             next_page = request.params.get("next") or came_from
             return RedirectResponse(url=next_page, status_code=302)
         message = token["error"]
-        if "Account pending for user:" in message:
+        # `error_code` is a stable contract from `UserDb.authenticate()`.
+        if token.get("error_code") == "pending":
             message += (
-                " . If you recently registered to fishtest, "
+                " If you recently registered to fishtest, "
                 "a person will now manually approve your new account, to avoid spam. "
                 "This is usually quick, but sometimes takes a few hours. "
                 "Thank you!"


### PR DESCRIPTION
Remove credential exposure from UserDb.authenticate() log statements. Return a structured `error_code` so downstream consumers (views.py login, api.py) can branch on a stable key instead of brittle substring matching on user-facing text.

Security improvements:
- Plaintext passwords no longer printed to stdout.
- Same user-facing message for unknown-user and wrong-password (mitigates username enumeration).
- Server-side logs still distinguish the failure reason without including credentials.

Other fixes:
- views.py: use `error_code == "pending"` instead of substring match; fix double-period punctuation.
- tests: add direct authenticate() branch-coverage tests (unknown, blocked, pending) with a shared _check_auth_with_flag() helper that restores the original field value; move `if __name__` to EOF.