### PR TITLE
fix(templates): harden Jinja templates, JS bindings, and docs

### DIFF
--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -36,8 +36,8 @@ and `http/jinja.py`.
 | `display_residual(r)` | `util.py` | Chi-squared residual display |
 | `is_active_sprt_ltc(run)` | `util.py` | Checks if run is active SPRT LTC |
 | `is_elo_pentanomial_run(run)` | `template_helpers.py` | Checks pentanomial display |
-| `nelo_pentanomial_summary(...)` | `template_helpers.py` | Pentanomial ELO summary |
-| `results_pre_attrs(...)` | `template_helpers.py` | HTML attributes for results display |
+| `nelo_pentanomial_summary(...)` | `template_helpers.py` | Pentanomial ELO summary (returns `Markup`) |
+| `results_pre_attrs(...)` | `template_helpers.py` | HTML attributes for results display (returns `Markup`) |
 | `run_tables_prefix(username)` | `template_helpers.py` | Toggle prefix for run tables |
 | `tests_run_setup(...)` | `template_helpers.py` | Test form default values |
 | `tests_repo(run)` | `util.py` | Extract tests repo URL from run |
@@ -437,6 +437,23 @@ Each blocked worker row: `worker_name`, `last_updated_label`, `actions_url`,
 
 6. **Request object**: not used directly in templates except via `url_for`
    and `static_url` helpers.
+
+7. **Escaping boundary**: view handlers pass raw strings. Jinja2 autoescape
+   handles HTML-escaping at render time. Do not pre-escape values into plain
+   strings with `html.escape()` in Python — that causes double-escaping.
+   Escaping in Python is appropriate when constructing a `Markup` value
+   (escape untrusted input first, then wrap).
+
+8. **`|safe` filter**: use only on values already typed as `Markup`, or
+   after an explicit `|e` escape followed by controlled transformations
+   (e.g., `{{ value | e | replace("\n", "<br>") | safe }}`).
+
+9. **External links**: every `target="_blank"` anchor must include
+   `rel="noopener noreferrer"` to prevent reverse-tabnabbing.
+
+10. **No inline event handlers**: use unobtrusive JavaScript (`addEventListener`
+    or delegated listeners) instead of `onclick`, `onsubmit`, or similar HTML
+    attributes.
 
 ## Adding a new template
 

--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -9,6 +9,20 @@
   --scroll-bar-width: 16px;
 }
 
+button.notifications {
+  color: inherit;
+  font: inherit;
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
+button.notifications:focus-visible {
+  outline: 2px solid var(--bs-link-focus-color);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 @media (max-width: 575.98px) {
   body {
     font-size: 14px;

--- a/server/fishtest/static/js/application.js
+++ b/server/fishtest/static/js/application.js
@@ -50,6 +50,9 @@ function protectForms() {
   ];
 
   document.querySelectorAll("form[method='POST']")?.forEach((form) => {
+    if (form.querySelector("input[name='csrf_token']")) {
+      return;
+    }
     const input = document.createElement("input");
     input["type"] = "hidden";
     input["name"] = "csrf_token";

--- a/server/fishtest/static/js/calc.js
+++ b/server/fishtest/static/js/calc.js
@@ -40,6 +40,11 @@ google.charts.setOnLoadCallback(function () {
   mouseScreen.addEventListener("mouseleave", handleTooltips, true);
   setFields();
   drawCharts(false);
+
+  document
+    .getElementById("sprt-calc-calculate")
+    ?.addEventListener("click", () => drawCharts(false));
+
   window.onresize = function () {
     clearTimeout(resizeTimeout);
     resizeTimeout = setTimeout(() => drawCharts(true), 100);

--- a/server/fishtest/templates/base.html.j2
+++ b/server/fishtest/templates/base.html.j2
@@ -35,7 +35,6 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.8/css/bootstrap.min.css"
       integrity="sha512-2bBQCjcnw658Lho4nlXJcc6WkV/UxpE/sAokbXPxQNGqmNdQrWqtw26Ns9kFF/yG792pKR1Sx8/Y1Lf1XN4GKA=="
       crossorigin="anonymous"
-      crossorigin="anonymous"
       referrerpolicy="no-referrer"
     >
 
@@ -61,7 +60,6 @@
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.8/js/bootstrap.bundle.min.js"
       integrity="sha512-HvOjJrdwNpDbkGJIG2ZNqDlVqMo77qbs4Me4cah0HoDrfhrbA+8SBlZn1KrvAQw7cILLPFJvdwIgphzQmMm+Pw=="
-      crossorigin="anonymous"
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>
@@ -94,7 +92,7 @@
         <a
           class="navbar-brand p-0 me-0 me-lg-2 d-flex align-items-center"
           href="{{ home_url }}"
-          aria-label="Bootstrap"
+          aria-label="Home"
         >
           <div class="brand-logo d-inline me-lg-2"></div>
           <p class="d-none d-lg-inline h-5 mb-0">Stockfish Testing Framework</p>
@@ -332,7 +330,7 @@
                       <a
                         href="https://stockfishchess.org/download/"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded release"
                         >Official Releases</a
                       >
@@ -341,7 +339,7 @@
                       <a
                         href="https://github.com/official-stockfish/Stockfish/releases?q=prerelease%3Atrue"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded release"
                         >Prereleases</a
                       >
@@ -350,7 +348,7 @@
                       <a
                         href="https://stockfishchess.org/get-involved/"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded get-involved"
                         >Contribute</a
                       >
@@ -359,7 +357,7 @@
                       <a
                         href="https://github.com/official-stockfish/Stockfish/wiki/Regression-Tests"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded regression"
                         >Progress</a
                       >
@@ -382,7 +380,7 @@
                       <a
                         href="https://discord.gg/awnh2qZfTT"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded discord"
                         >Discord</a
                       >
@@ -391,7 +389,7 @@
                       <a
                         href="https://github.com/official-stockfish/fishtest/wiki"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded wiki"
                         >Fishtest Wiki</a
                       >
@@ -400,7 +398,7 @@
                       <a
                         href="https://github.com/official-stockfish/Stockfish/wiki"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded wiki"
                         >Stockfish Wiki</a
                       >
@@ -409,7 +407,7 @@
                       <a
                         href="https://github.com/official-stockfish/nnue-pytorch/wiki"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded wiki"
                         >NN Trainer Wiki</a
                       >
@@ -437,7 +435,7 @@
                       <a
                         href="https://github.com/official-stockfish/Stockfish"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded stockfish-repo"
                         >Stockfish</a
                       >
@@ -446,7 +444,7 @@
                       <a
                         href="https://github.com/official-stockfish/fishtest"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded"
                         >Fishtest</a
                       >
@@ -455,7 +453,7 @@
                       <a
                         href="https://github.com/official-stockfish/nnue-pytorch"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded"
                         >NN Trainer</a
                       >
@@ -464,7 +462,7 @@
                       <a
                         href="https://github.com/official-stockfish/books"
                         target="_blank"
-                        rel="noopener"
+                        rel="noopener noreferrer"
                         class="links-link rounded"
                         >Books</a
                       >

--- a/server/fishtest/templates/contributors.html.j2
+++ b/server/fishtest/templates/contributors.html.j2
@@ -145,7 +145,7 @@
             <a href="{{ user.tests_user_url }}">{{ user.tests }} </a>
           </td>
           <td class="user-repo">
-            <a href="{{ user.tests_repo_url }}" target="_blank" rel="noopener">{{ user.tests_repo_url }}</a>
+            <a href="{{ user.tests_repo_url }}" target="_blank" rel="noopener noreferrer">{{ user.tests_repo_url }}</a>
           </td>
         </tr>
       {% else %}

--- a/server/fishtest/templates/elo_results.html.j2
+++ b/server/fishtest/templates/elo_results.html.j2
@@ -16,14 +16,14 @@
     <div style="margin-left:90px;">
   {% endif %}
 {% endif %}
-<pre {{ results_pre_attrs(results_info, run) | safe }}>
+<pre {{ results_pre_attrs(results_info, run) }}>
   {% for value in info %}
     {{ value.replace("ELO", "Elo") if elo_ptnml_run and loop.index0 == 0 else value }}
     {% if not loop.last %} <br> {% endif %}
   {% endfor %}
   {% if nelo_summary %}
     <br>
-    {{ nelo_summary | safe }}
+    {{ nelo_summary }}
   {% endif %}
 </pre>
 {% if show_gauge %}

--- a/server/fishtest/templates/nn_upload.html.j2
+++ b/server/fishtest/templates/nn_upload.html.j2
@@ -63,7 +63,6 @@
         type="checkbox"
         class="form-check-input"
         id="terms-checkbox"
-        onclick="doLicense()"
       >
     </div>
 
@@ -79,12 +78,24 @@
 </div>
 
 <script>
-  function doLicense() {
-    if (document.getElementById("terms-checkbox").checked) {
-      document.getElementById("upload-button").removeAttribute("disabled");
+  function updateLicenseState() {
+    const checkbox = document.getElementById("terms-checkbox");
+    const uploadButton = document.getElementById("upload-button");
+    if (!checkbox || !uploadButton) {
+      return;
+    }
+    if (checkbox.checked) {
+      uploadButton.removeAttribute("disabled");
     } else {
-      document.getElementById("upload-button").setAttribute("disabled", "");
+      uploadButton.setAttribute("disabled", "");
     }
   }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    document
+      .getElementById("terms-checkbox")
+      ?.addEventListener("change", updateLicenseState);
+    updateLicenseState();
+  });
 </script>
 {% endblock %}

--- a/server/fishtest/templates/rate_limits.html.j2
+++ b/server/fishtest/templates/rate_limits.html.j2
@@ -27,7 +27,7 @@
   <p>
     If you are frequently hitting the client rate limit then it is recommended to
     install a
-    <a href="https://github.com/settings/personal-access-tokens" target="_blank">
+    <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer">
     GitHub personal access token
     </a>
     in your

--- a/server/fishtest/templates/run_table.html.j2
+++ b/server/fishtest/templates/run_table.html.j2
@@ -17,6 +17,11 @@
       document.cookie =
         "{{ cookie_name }}" + "=" + button.textContent.trim() + "; max-age={{ 60 * 60 * 24 * 365 * 10 }}; SameSite=Lax";
     }
+
+    document.addEventListener("DOMContentLoaded", () => {
+      const button = document.getElementById("{{ toggle }}-button");
+      button?.addEventListener("click", () => toggle{{ toggle | capitalize }}());
+    });
   </script>
 {% endif %}
 
@@ -24,7 +29,7 @@
 {% if toggle %}
   <a id="{{ toggle }}-button" class="btn btn-sm btn-light border"
      data-bs-toggle="collapse" href="#{{ toggle }}" role="button" aria-expanded="false"
-      aria-controls="{{ toggle }}" onclick="toggle{{ toggle | capitalize }}()">
+      aria-controls="{{ toggle }}">
   {{ 'Hide' if toggle_state == 'Hide' else 'Show' }}
   </a>
 {% endif %}
@@ -65,7 +70,7 @@
                       action="/tests/delete"
                       method="POST"
                       style="display: inline;"
-                      onsubmit="handleStopDeleteButton({{ row.run_id | tojson }}); return true;"
+                      data-stop-delete-run-id="{{ row.run_id }}"
                     >
                       <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                       <input type="hidden" name="run-id" value="{{ row.run_id }}">
@@ -88,8 +93,13 @@
             </td>
             {% if not row.is_finished %}
               <td class="run-notification" style="width:3em;text-align:center;">
-                <div id=notification_{{ row.run_id }} class='notifications' onclick='handleNotification(this)' style='display:inline-block;cursor:pointer;'>
-                </div>
+                <button
+                  id="notification_{{ row.run_id }}"
+                  class="notifications"
+                  type="button"
+                  aria-label="Toggle notifications"
+                  style="display:inline-block;cursor:pointer;"
+                ></button>
                 <script>
                   setNotificationStatus_({{ row.run_id | tojson }});   // no broadcast since this is at initialization
                 </script>
@@ -100,7 +110,7 @@
             </td>
 
             <td style="width: 2%;" class="run-diff">
-              <a href="{{ row.diff_url }}" target="_blank" rel="noopener">diff</a>
+              <a href="{{ row.diff_url }}" target="_blank" rel="noopener noreferrer">diff</a>
             </td>
 
             <td style="width: 1%;" class="run-elo">
@@ -112,7 +122,7 @@
             <td style="width: 13%;" class="run-live">
               <span class="{{ 'rounded ltc-highlight me-1' if is_active_sprt_ltc(row.run) else 'me-1' }}">
               {% if row.live_url %}
-                <a href="{{ row.live_url }}" target="_blank">{{ row.live_label }}</a>
+                <a href="{{ row.live_url }}" target="_blank" rel="noopener noreferrer">{{ row.live_label }}</a>
               {% else %}
                 {{ row.live_label }}
               {% endif %}
@@ -126,7 +136,7 @@
             </td>
 
             <td class="run-info">
-              {{ row.info_html | safe }}
+              {{ row.info_html }}
             </td>
           </tr>
         {% endfor %}

--- a/server/fishtest/templates/sprt_calc.html.j2
+++ b/server/fishtest/templates/sprt_calc.html.j2
@@ -59,10 +59,10 @@
   </div>
   <div class="col-12 col-md-auto mb-3 d-flex align-items-end">
     <input
+      id="sprt-calc-calculate"
       class="btn btn-success w-100"
       type="button"
       value="Calculate"
-      onclick="drawCharts()"
     >
   </div>
 </form>

--- a/server/fishtest/templates/tests_run.html.j2
+++ b/server/fishtest/templates/tests_run.html.j2
@@ -498,10 +498,11 @@
                         <a
                           href="https://github.com/vdbergh/spsa_simul/blob/master/doc/theoretical_basis.pdf"
                           target="_blank"
+                          rel="noopener noreferrer"
                         >
                           https://github.com/vdbergh/spsa_simul/blob/master/doc/theoretical_basis.pdf</a
                         >. The formulas can be checked by simulation which is done here:
-                        <a href="https://github.com/vdbergh/spsa_simul" target="_blank">
+                        <a href="https://github.com/vdbergh/spsa_simul" target="_blank" rel="noopener noreferrer">
                           https://github.com/vdbergh/spsa_simul</a
                         >. Currently this option should be used with the book
                         'UHO_4060_v4.epd' and in addition the option should not be used with
@@ -880,7 +881,14 @@
 
         if (name === "PT" || name === "PT SMP") {
           let info = (name === "PT SMP") ? "SMP " : "";
-          info += 'Progression test of "{{ master_info["message"] | safe }}" of {{ master_info["date"] | safe }} vs {{ pt_version | safe }}.';
+          info +=
+            "Progression test of \"" +
+            {{ master_info["message"] | tojson }} +
+            "\" of " +
+            {{ master_info["date"] | tojson }} +
+            " vs " +
+            {{ pt_version | tojson }} +
+            ".";
           document.getElementById("run-info").value = info;
         }
 

--- a/server/fishtest/templates/tests_view.html.j2
+++ b/server/fishtest/templates/tests_view.html.j2
@@ -3,7 +3,10 @@
 {% block title %}{{ page_title }} | Stockfish Testing{% endblock %}
 
 {% block body %}
-{% set run_id = run["_id"] %}
+{% set run_id = run["_id"] | string %}
+<script>
+  const runId = {{ run_id | tojson }};
+</script>
 <script
   src="https://cdnjs.cloudflare.com/ajax/libs/jsdiff/8.0.2/diff.min.js"
   integrity="sha512-8pp155siHVmN5FYcqWNSFYn8Efr61/7mfg/F15auw8MCL3kvINbNT7gT8LldYPq3i/GkSADZd4IcUXPBoPP8gA=="
@@ -28,15 +31,15 @@
   <script>
     (async () => {
       await DOMContentLoaded();
-      await followRun("{{ run_id }}");
-      setNotificationStatus("{{ run_id }}");
+      await followRun(runId);
+      setNotificationStatus(runId);
     })();
   </script>
 {% else %}
   <script>
     (async () => {
       await DOMContentLoaded();
-      setNotificationStatus_("{{ run_id }}");
+      setNotificationStatus_(runId);
     })();
   </script>
 {% endif %}
@@ -58,10 +61,10 @@
   </script>
 {% endif %}
 
-<div id="enclosure"{{ " style=\"visibility:hidden;\"" if show_task >= 0 else "" | safe }}>
+<div id="enclosure"{% if show_task >= 0 %} style="visibility:hidden;"{% endif %}>
   <h2>
     <span>{{ page_title }}</span>
-    <a href="{{ diff_url(run, master_check=allow_github_api_calls) }}" target="_blank" rel="noopener">diff</a>
+    <a href="{{ diff_url(run, master_check=allow_github_api_calls) }}" target="_blank" rel="noopener noreferrer">diff</a>
   </h2>
 
   <div class="elo-results-top">
@@ -78,7 +81,7 @@
           <a
             href="{{ diff_url(run, master_check=allow_github_api_calls) }}"
             class="btn btn-primary bg-light-primary border-0 mb-2"
-            target="_blank" rel="noopener"
+            target="_blank" rel="noopener noreferrer"
           >
             View on GitHub
           </a>
@@ -158,8 +161,8 @@
                     {% elif arg[0] == "itp" %}
                       <td>{{ "{0:.2f}".format(arg[1] | float) }}</td>
                     {% else %}
-                      <td {{ "class=\"run-info\"" if arg[0] == "info" else "" | safe }}>
-                        {{ arg[1].replace("\n", "<br>") | safe }}
+                      <td{% if arg[0] == "info" %} class="run-info"{% endif %}>
+                        {{ arg[1] | e | replace("\n", "<br>") | safe }}
                       </td>
                     {% endif %}
                   </tr>
@@ -167,8 +170,8 @@
                   <tr>
                     <td>{{ arg[0] }}</td>
                     <td>
-                      <a href="{{ arg[2] }}" target="_blank" rel="noopener">
-                        {{ arg[1] | safe }}
+                      <a href="{{ arg[2] }}" target="_blank" rel="noopener noreferrer">
+                        {{ arg[1] }}
                       </a>
                     </td>
                   </tr>
@@ -214,7 +217,7 @@
               <form
                 action="/tests/stop"
                 method="POST"
-                onsubmit="handleStopDeleteButton('{{ run_id }}'); return true;"
+                data-stop-delete-run-id="{{ run_id }}"
               >
                 <input type="hidden" name="run-id" value="{{ run_id }}">
                 <button type="submit" class="btn btn-danger w-100">
@@ -257,7 +260,7 @@
       {% if warnings != [] %}
         <div class="alert alert-danger">
           {% for warning in warnings %}
-            Warning: {{ warning | safe }}
+            Warning: {{ warning }}
             {% if not loop.last %}
               <hr style="margin: 0.4em auto;">
             {% endif %}
@@ -268,7 +271,7 @@
       {% if notes != [] %}
         <div class="alert alert-info">
           {% for note in notes %}
-            Note: {{ note | safe }}
+            Note: {{ note }}
             {% if not loop.last %}
               <hr style="margin: 0.4em auto;">
             {% endif %}
@@ -379,7 +382,6 @@
         <button
           id="follow_button_{{ run_id }}"
           class="btn btn-primary col-12 col-md-auto"
-          onclick="handleFollowButton(this)"
           style="display:none; margin-top:0.2em;"></button>
         <hr style="visibility:hidden;">
       {% endif %}
@@ -539,7 +541,7 @@
     const button = e.currentTarget;
     button.textContent = "Downloading...";
     try {
-      const response = await fetch(`/api/run_pgns/{{ run_id }}.pgn.gz`);
+      const response = await fetch(`/api/run_pgns/${runId}.pgn.gz`);
       if (!response.ok) {
         if (response.status === 404) {
           alertError("No games found for this run");
@@ -580,7 +582,7 @@
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `{{ run_id }}.pgn.gz`;
+      a.download = `${runId}.pgn.gz`;
       document.body.append(a);
       a.click();
       document.body.removeChild(a);
@@ -606,13 +608,20 @@
        await renderTasks();
   }
 
+  const followButton = document.getElementById("follow_button_" + runId);
+  followButton?.addEventListener("click", (e) => {
+    handleFollowButton(e.currentTarget);
+  });
+
   async function renderTasks() {
     await DOMContentLoaded();
     if (fetchedTasksBefore)
       return Promise.resolve();
     const tasksBody = document.getElementById("tasks-body");
     try {
-      const html = await fetchText(`/tests/tasks/{{ run_id }}?show_task={{ show_task }}`);
+      const showTask = {{ show_task | tojson }};
+      const tasksUrl = `/tests/tasks/${encodeURIComponent(runId)}?show_task=${encodeURIComponent(showTask)}`;
+      const html = await fetchText(tasksUrl);
       tasksBody.innerHTML = html;
       fetchedTasksBefore = true;
     } catch (error) {
@@ -810,7 +819,7 @@
       copyDiffBtn = null;
     }
 
-    const diffApiUrl = "{{ diff_url(run, master_check=allow_github_api_calls) }}".replace(
+    const diffApiUrl = {{ diff_url(run, master_check=allow_github_api_calls) | tojson }}.replace(
       "//github.com/",
       "//api.github.com/repos/"
     );
@@ -824,7 +833,7 @@
       }
     } : {};
 
-    const testRepo = "{{ tests_repo(run) }}";
+    const testRepo = {{ tests_repo(run) | tojson }};
     const apiUrlNew = testRepo.replace(
       "//github.com/",
       "//api.github.com/repos/"
@@ -847,17 +856,19 @@
     let localStorageDiffs = JSON.parse(localStorage.getItem("localStorageDiffs")) || [];
     localStorageDiffs = localStorageDiffs.filter(diff => diff?.timeStamp >= oneDayAgo);
 
-    let run = localStorageDiffs.find(diff => diff["id"] === "{{ run_id }}" && !diff["masterVsBase"]);
-    let text = run?.text;
-    let count = run?.lines || 0;
+    const cachedRun = localStorageDiffs.find(diff => diff["id"] === runId && !diff["masterVsBase"]);
+    let text = cachedRun?.text;
+    let count = cachedRun?.lines || 0;
 
     try {
       loadingButton();
       if (!text) {
-        if (dots === 2)
+        let diffs;
+        if (dots === 2) {
           diffs = await fetchDiffTwoDots(apiUrlNew, apiUrlBase, diffNew, diffBase, options);
-        else if (dots === 3)
+        } else if (dots === 3) {
           diffs = await fetchDiffThreeDots(diffApiUrl);
+        }
 
         text = diffs.text || "No diff available";
         count = diffs.count || 0;
@@ -865,7 +876,7 @@
         // Try to save the diff in localStorage
         // It can throw an exception if there is not enough space
         try {
-          localStorageDiffs.push({id:"{{ run_id }}", text: text, lines: count, masterVsBase: false, timeStamp: currentTime});
+          localStorageDiffs.push({id: runId, text: text, lines: count, masterVsBase: false, timeStamp: currentTime});
           localStorage.setItem("localStorageDiffs", JSON.stringify(localStorageDiffs));
         } catch (e) {
           console.warn("Could not save diff in localStorage");
@@ -890,11 +901,11 @@
           text += `<br>Note: Apparently you are not allowed to use the GitHub API.
                   This may be caused by an expired, revoked or otherwise invalid
                   <a href='https://github.com/settings/personal-access-tokens'
-                  target='_blank'>GitHub personal access token</a> in your <a href='/user'>profile</a>.`
+                  target='_blank' rel='noopener noreferrer'>GitHub personal access token</a> in your <a href='/user'>profile</a>.`
         } else if(remainingApiCalls(response) === 0) {
           text += `<br>Note: Apparently the <a href='/rate_limits'>GitHub API rate limit</a> was exceeded.
                   Try to add a <a href='https://github.com/settings/personal-access-tokens'
-                  target='_blank'>GitHub personal access token</a> to your <a href='/user'>profile</a>
+                  target='_blank' rel='noopener noreferrer'>GitHub personal access token</a> to your <a href='/user'>profile</a>
                   or else use 'View on GitHub'.`
         }
       }

--- a/server/fishtest/templates/user.html.j2
+++ b/server/fishtest/templates/user.html.j2
@@ -182,7 +182,7 @@
               <p>The purpose of this token is to authenticate your requests to GitHub's API,
               which has a rate limit of 60 requests per hour for unauthenticated users. By using this token,
               you can increase this limit to 5000 requests per hour. More information about GitHub's rate limits can be found
-              <a href="https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting" target="_blank">here</a>.
+              <a href="https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting" target="_blank" rel="noopener noreferrer">here</a>.
               </p>
 
               <!-- Information about storage -->
@@ -200,7 +200,7 @@
               <!-- Instructions on how to obtain the token -->
               <h4>Instructions for generating a new token:</h4>
               <ol>
-                <li>Access the <a href="https://github.com/settings/personal-access-tokens" target="_blank">Github link</a> (login if required).</li>
+                <li>Access the <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer">GitHub link</a> (login if required).</li>
                 <li>Press "Generate a new token".</li>
                 <li>Set a "Token name".</li>
                 <li>Set your preferred "Expiration" time.</li>


### PR DESCRIPTION
Templates
- Fix base template markup (duplicate attributes and extra closing tag)
- Add rel="noopener noreferrer" to every target="_blank" link
- Escape template values before inserting controlled HTML
- Use |tojson for JS interpolation; stringify ObjectId first
- Replace notification <div> with accessible <button>

JavaScript
- Make protectForms() skip forms that already contain csrf_token
- Remove inline onclick/onsubmit; use delegated listeners instead
- Add defensive id parsing; avoid Array.prototype.at for compat
- Use void for fire-and-forget async in delegated handlers

Python (views + template_helpers)
- Stop pre-escaping run_args with html.escape (rely on autoescape)
- Return Markup from results_pre_attrs, nelo_pentanomial_summary, info_html
- Wrap HTML-containing warnings with Markup so they render under autoescape
- Validate CSS color values before emitting them into attributes

Docs
- Annotate Markup return types in the global functions table
- Add authoring rules: escaping boundary, |safe policy, rel="noopener noreferrer", no inline event handlers