### PR TITLE
feat(ui): add Open Graph previews for shared actions links

### DIFF
--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -64,7 +64,7 @@ but generic `OPTIONS` is not part of the UI route contract and returns `405`.
 | `/tests/live_elo_update/{id}` | GET | `live_elo_update` | `live_elo_fragment.html.j2` | Fragment-only (OOB) |
 | `/tests/finished` | GET | `tests_finished` | `tests_finished.html.j2` | HX: `tests_finished_content_fragment` |
 | `/tests/user/{username}` | GET | `tests_user` | `tests_user.html.j2` | HX: `tests_user_content_fragment`; page 1 live run tables poll the same route via `?live=run_tables` |
-| `/actions` | GET | `actions` | `actions.html.j2` | HX: `actions_content_fragment` |
+| `/actions` | GET | `actions` | `actions.html.j2` | Full page plus htmx content fragment; full-page responses render route-specific Open Graph metadata that preserves the current query string in `og:url` and summarizes the first visible action row |
 | `/contributors` | GET | `contributors` | `contributors.html.j2` | HX: `contributors_content_fragment`; paginated (100/page) |
 | `/contributors/monthly` | GET | `contributors_monthly` | `contributors.html.j2` | HX: `contributors_content_fragment`; paginated (100/page) |
 | `/user/{username}` | GET, POST | `user` | `user.html.j2` | CSRF |
@@ -787,6 +787,10 @@ Behavior notes:
    currently rendered.
 - The time link remains a normal anchor because it is a shareable deep link
    into the log timeline, not just a local fragment action.
+- Full-page `/actions` responses emit server-owned Open Graph metadata. Unlike
+   `/tests/view/{id}`, the preview keeps the current query string in `og:url`
+   because the filters, time cursor, and explicit `max_count` define the shared
+   log slice; the title and description summarize the first visible action row.
 
 ## Finished Tests (`/tests/finished`) query parameters
 

--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -95,9 +95,18 @@ For `/tests/view/{id}`, `open_graph['description']` is plain multi-line text so
 Discord link previews preserve the run summary layout, including pentanomial
 lines when present, without shipping literal backticks.
 
+For `/actions`, the full page overrides `open_graph` with the first visible
+action row. Its `og:url` keeps the current query string because filters,
+timeline cursors, and explicit `max_count` values define the shared events-log
+slice.
+
 Fragment-only templates do not own page-head metadata. The `/tests/view/{id}`
 detail page follows this rule: the full page renders the head tags, while the
 live `/tests/view/{id}/detail` fragment updates body content only.
+
+`actions_content_fragment.html.j2` follows the same rule: the full `/actions`
+page owns the Open Graph tags, while the htmx fragment updates only
+`#actions-content`.
 
 ### Navigation URLs (`urls` dict)
 
@@ -353,6 +362,10 @@ Each action row:
 | `target_name` | string |
 | `target_url` | string or None |
 | `message` | string |
+
+Full-page `/actions` responses may override the shared `open_graph` metadata
+with a summary of the first visible action row. htmx fragment responses do not
+render page-head tags.
 
 ### `contributors.html.j2`
 

--- a/server/fishtest/http/open_graph.py
+++ b/server/fishtest/http/open_graph.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, TypedDict
 from urllib.parse import urlsplit, urlunsplit
 
 from fishtest.http.template_helpers import nelo_pentanomial_summary_text
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 _SITE_NAME = "Stockfish Testing Framework"
 _DEFAULT_DESCRIPTION = "Distributed testing framework for the Stockfish chess engine."
@@ -23,25 +27,100 @@ class OpenGraphMetadata(TypedDict):
     url: str
 
 
+def open_graph_page_url(url: str, *, keep_query: bool = False) -> str:
+    """Return the URL rendered into `og:url` for a full page."""
+    parts = urlsplit(url)
+    query = parts.query if keep_query else ""
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, query, ""))
+
+
 def canonical_page_url(url: str) -> str:
     """Drop query and fragment parts from a page URL."""
-    parts = urlsplit(url)
-    return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    return open_graph_page_url(url)
 
 
-def default_open_graph(page_url: str) -> OpenGraphMetadata:
+def default_open_graph(
+    page_url: str,
+    *,
+    keep_query: bool = False,
+) -> OpenGraphMetadata:
     """Return default page metadata for full HTML responses."""
     return {
         "site_name": _SITE_NAME,
         "type": "website",
         "title": _SITE_NAME,
         "description": _DEFAULT_DESCRIPTION,
-        "url": canonical_page_url(page_url),
+        "url": open_graph_page_url(page_url, keep_query=keep_query),
     }
 
 
 def _normalize_metadata_text(text: str) -> str:
-    return " ".join(text.replace(" ± ", " +/- ").split())
+    return " ".join(text.replace(" ± ", " +/- ").replace("\u2011", "-").split())
+
+
+def _metadata_lines(values: Iterable[object]) -> list[str]:
+    description_lines: list[str] = []
+    for value in values:
+        normalized_value = _normalize_metadata_text(str(value))
+        if normalized_value:
+            description_lines.append(normalized_value)
+    return description_lines
+
+
+def _labeled_metadata_lines(values: Iterable[tuple[str, object]]) -> list[str]:
+    description_lines: list[str] = []
+    for label, value in values:
+        normalized_value = _normalize_metadata_text(str(value or ""))
+        if normalized_value:
+            description_lines.append(f"{label}: {normalized_value}")
+    return description_lines
+
+
+def _truncate_metadata_text(text: str, *, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
+
+    truncated = text[: max_length - 3].rstrip()
+    if " " in truncated:
+        truncated = truncated.rsplit(" ", 1)[0]
+    return f"{truncated}..."
+
+
+def _join_description_lines(description_lines: Iterable[str]) -> str:
+    lines = [line for line in description_lines if line]
+    if not lines:
+        return _DEFAULT_DESCRIPTION
+    return "\n".join(lines)
+
+
+def _page_open_graph_title(page_title: str) -> str:
+    normalized_title = _normalize_metadata_text(page_title)
+    if not normalized_title:
+        return _SITE_NAME
+    return f"{normalized_title}{_TITLE_SUFFIX}"
+
+
+def _build_page_open_graph(
+    *,
+    page_url: str,
+    page_title: str,
+    description: str,
+    keep_query: bool = False,
+) -> OpenGraphMetadata:
+    open_graph = default_open_graph(page_url, keep_query=keep_query)
+    open_graph["title"] = _page_open_graph_title(page_title)
+    open_graph["description"] = description
+    return open_graph
+
+
+def _metadata_time_label(value: int | float | str | None) -> str:
+    if value is None:
+        return ""
+
+    try:
+        return datetime.fromtimestamp(float(value), UTC).strftime("%y-%m-%d %H:%M:%S")
+    except OverflowError, OSError, TypeError, ValueError:
+        return ""
 
 
 def _tests_view_description_lines(
@@ -52,17 +131,11 @@ def _tests_view_description_lines(
     if not isinstance(info, list):
         return []
 
-    description_parts: list[str] = []
-
-    for value in info:
-        line = str(value)
-        normalized_line = _normalize_metadata_text(line)
-        if normalized_line:
-            description_parts.append(normalized_line)
+    description_parts = _metadata_lines(info)
 
     nelo_summary = nelo_pentanomial_summary_text(run)
     if nelo_summary:
-        description_parts.append(_normalize_metadata_text(nelo_summary))
+        description_parts.extend(_metadata_lines([nelo_summary]))
 
     return description_parts
 
@@ -71,11 +144,7 @@ def _tests_view_description(
     run: dict[str, Any],
     results_info: dict[str, Any],
 ) -> str:
-    description_lines = _tests_view_description_lines(run, results_info)
-    if not description_lines:
-        return _DEFAULT_DESCRIPTION
-
-    return "\n".join(description_lines)
+    return _join_description_lines(_tests_view_description_lines(run, results_info))
 
 
 def _theme_color_from_results(results_info: dict[str, Any]) -> str | None:
@@ -89,17 +158,123 @@ def _theme_color_from_results(results_info: dict[str, Any]) -> str | None:
     return None
 
 
+def _actions_open_graph_title(action_row: dict[str, Any]) -> str:
+    event = _normalize_metadata_text(str(action_row.get("event") or "Events Log"))
+    target = _normalize_metadata_text(str(action_row.get("target_name") or ""))
+    agent = _normalize_metadata_text(str(action_row.get("agent_name") or ""))
+
+    if target:
+        return _truncate_metadata_text(f"{event} on {target}", max_length=90)
+    if agent:
+        return _truncate_metadata_text(f"{event} by {agent}", max_length=90)
+    return _truncate_metadata_text(f"Events Log - {event}", max_length=90)
+
+
+def _actions_open_graph_description(
+    action_row: dict[str, Any],
+    *,
+    num_actions: int,
+) -> str:
+    description_lines: list[str] = []
+
+    if num_actions > 1:
+        description_lines.append(f"1 of {num_actions} matching actions.")
+
+    time_label = _metadata_time_label(action_row.get("time"))
+    if time_label:
+        description_lines.append(f"Time: {time_label}")
+
+    description_lines.extend(
+        _labeled_metadata_lines(
+            (
+                ("Event", action_row.get("event")),
+                ("Source", action_row.get("agent_name")),
+                ("Target", action_row.get("target_name")),
+            ),
+        ),
+    )
+
+    message = _normalize_metadata_text(str(action_row.get("message") or ""))
+    if message:
+        description_lines.append(
+            "Comment: "
+            + _truncate_metadata_text(
+                message,
+                max_length=220,
+            ),
+        )
+
+    return _join_description_lines(description_lines)
+
+
+def _actions_no_results_description(
+    *,
+    filters: dict[str, str],
+    run_id_filter: str,
+) -> str:
+    filter_parts = _metadata_lines(
+        [
+            f"event={filters.get('action', '')}" if filters.get("action") else "",
+            f"user={filters.get('username', '')}" if filters.get("username") else "",
+            f"text={filters.get('text', '')}" if filters.get("text") else "",
+            f"run={run_id_filter}" if run_id_filter else "",
+        ],
+    )
+
+    if not filter_parts:
+        return "Events log results. No actions matched."
+
+    filters_text = _truncate_metadata_text(
+        ", ".join(filter_parts),
+        max_length=180,
+    )
+    return f"No actions matched the current filters: {filters_text}"
+
+
+def build_actions_open_graph(
+    *,
+    page_url: str,
+    actions: list[dict[str, Any]],
+    num_actions: int,
+    filters: dict[str, str],
+    run_id_filter: str,
+) -> OpenGraphMetadata:
+    """Return Open Graph metadata for `/actions` full-page responses."""
+    if not actions:
+        return _build_page_open_graph(
+            page_url=page_url,
+            page_title="Events Log",
+            description=_actions_no_results_description(
+                filters=filters,
+                run_id_filter=run_id_filter,
+            ),
+            keep_query=True,
+        )
+
+    return _build_page_open_graph(
+        page_url=page_url,
+        page_title=_actions_open_graph_title(actions[0]),
+        description=_actions_open_graph_description(
+            actions[0],
+            num_actions=num_actions,
+        ),
+        keep_query=True,
+    )
+
+
 def build_tests_view_open_graph(
     *,
-    host_url: str,
+    page_url: str,
     run: dict[str, Any],
     page_title: str,
     results_info: dict[str, Any],
 ) -> tuple[OpenGraphMetadata, str | None]:
     """Return Open Graph metadata and theme color for `/tests/view/{id}`."""
-    open_graph = default_open_graph(f"{host_url.rstrip('/')}/tests/view/{run['_id']}")
-    open_graph["title"] = f"{page_title}{_TITLE_SUFFIX}"
-    open_graph["description"] = _tests_view_description(run, results_info)
+    open_graph = _build_page_open_graph(
+        page_url=page_url,
+        page_title=page_title,
+        description=_tests_view_description(run, results_info),
+    )
     return (
         open_graph,
         _theme_color_from_results(results_info),
@@ -108,6 +283,7 @@ def build_tests_view_open_graph(
 
 __all__ = [
     "OpenGraphMetadata",
+    "build_actions_open_graph",
     "build_tests_view_open_graph",
     "canonical_page_url",
     "default_open_graph",

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -52,7 +52,10 @@ from fishtest.http.dependencies import (
     get_userdb,
     get_workerdb,
 )
-from fishtest.http.open_graph import build_tests_view_open_graph
+from fishtest.http.open_graph import (
+    build_actions_open_graph,
+    build_tests_view_open_graph,
+)
 from fishtest.http.settings import (
     ACTIONS_PAGE_SIZE,
     CONTRIBUTORS_MAX_ALL,
@@ -1482,10 +1485,19 @@ def actions(request: _ViewContext) -> dict[str, Any] | RedirectResponse | Respon
     result = _actions_impl(request, page_size=ACTIONS_PAGE_SIZE)
     if isinstance(result, RedirectResponse):
         return result
-    return (
-        _render_hx_fragment(request, "actions_content_fragment.html.j2", result)
-        or result
+
+    fragment = _render_hx_fragment(request, "actions_content_fragment.html.j2", result)
+    if fragment is not None:
+        return fragment
+
+    result["open_graph"] = build_actions_open_graph(
+        page_url=f"{_host_url(request)}{_path_qs(request)}",
+        actions=result["actions"],
+        num_actions=result["num_actions"],
+        filters=result["filters"],
+        run_id_filter=result["run_id_filter"],
     )
+    return result
 
 
 # === Users ===
@@ -3540,7 +3552,7 @@ def tests_view(request: _ViewContext) -> dict[str, Any] | RedirectResponse:  # n
     results_info = format_results(run)
     detail_context = _build_tests_view_detail_context(request, run)
     open_graph, theme_color = build_tests_view_open_graph(
-        host_url=_host_url(request),
+        page_url=f"{_host_url(request)}/tests/view/{run['_id']}",
         run=run,
         page_title=page_title,
         results_info=results_info,

--- a/server/tests/test_http_open_graph.py
+++ b/server/tests/test_http_open_graph.py
@@ -1,8 +1,10 @@
 """Test Open Graph metadata helpers."""
 
 import unittest
+from datetime import UTC, datetime
 
 from fishtest.http.open_graph import (
+    build_actions_open_graph,
     build_tests_view_open_graph,
     canonical_page_url,
     default_open_graph,
@@ -31,6 +33,17 @@ class OpenGraphTests(unittest.TestCase):
         )
         self.assertEqual(open_graph["url"], "https://example.org/tests/view/123")
 
+    def test_default_open_graph_can_preserve_query_for_shared_page_urls(self):
+        open_graph = default_open_graph(
+            "https://example.org/actions?max_count=1&before=1775675144.80333#fragment",
+            keep_query=True,
+        )
+
+        self.assertEqual(
+            open_graph["url"],
+            "https://example.org/actions?max_count=1&before=1775675144.80333",
+        )
+
     def test_build_tests_view_open_graph_uses_supplied_results_info(self):
         run = {
             "_id": "69d12ae19caf4559aa7ada3e",
@@ -45,7 +58,7 @@ class OpenGraphTests(unittest.TestCase):
         }
 
         open_graph, theme_color = build_tests_view_open_graph(
-            host_url="https://example.org",
+            page_url="https://example.org/tests/view/69d12ae19caf4559aa7ada3e",
             run=run,
             page_title="400 games - master vs master",
             results_info=results_info,
@@ -78,7 +91,7 @@ class OpenGraphTests(unittest.TestCase):
         }
 
         open_graph, theme_color = build_tests_view_open_graph(
-            host_url="https://example.org",
+            page_url="https://example.org/tests/view/69d12ae09caf4559aa7ada3c",
             run=run,
             page_title="400 games - master vs master",
             results_info=format_results(run),
@@ -92,3 +105,77 @@ class OpenGraphTests(unittest.TestCase):
         self.assertIn("\n", open_graph["description"])
         self.assertNotIn("```", open_graph["description"])
         self.assertIsNone(theme_color)
+
+    def test_build_actions_open_graph_preserves_query_and_describes_first_match(
+        self,
+    ):
+        open_graph = build_actions_open_graph(
+            page_url=(
+                "https://example.org/actions?max_count=1&before=1775675144.80333"
+                "#fragment"
+            ),
+            actions=[
+                {
+                    "time": datetime(2026, 4, 8, 19, 5, 44, tzinfo=UTC).timestamp(),
+                    "event": "failed_task",
+                    "agent_name": "maximmasiutin-12cores-d5026b78-d515",
+                    "target_name": "mp-offense-56d4b82/315",
+                    "message": "clang++ link failed after profile-build",
+                },
+                {
+                    "time": datetime(2026, 4, 8, 19, 7, 44, tzinfo=UTC).timestamp(),
+                    "event": "worker_log",
+                    "agent_name": "another-worker",
+                    "target_name": "other-run/1",
+                    "message": "later event on a different page or sort order",
+                },
+            ],
+            num_actions=2,
+            filters={"action": "", "username": "", "text": "", "run_id": ""},
+            run_id_filter="",
+        )
+
+        self.assertEqual(open_graph["site_name"], "Stockfish Testing Framework")
+        self.assertEqual(open_graph["type"], "website")
+        self.assertEqual(
+            open_graph["title"],
+            "failed_task on mp-offense-56d4b82/315 | Stockfish Testing",
+        )
+        self.assertEqual(
+            open_graph["url"],
+            "https://example.org/actions?max_count=1&before=1775675144.80333",
+        )
+        self.assertEqual(
+            open_graph["description"],
+            "1 of 2 matching actions.\n"
+            "Time: 26-04-08 19:05:44\n"
+            "Event: failed_task\n"
+            "Source: maximmasiutin-12cores-d5026b78-d515\n"
+            "Target: mp-offense-56d4b82/315\n"
+            "Comment: clang++ link failed after profile-build",
+        )
+        self.assertNotIn("Most recent of", open_graph["description"])
+
+    def test_build_actions_open_graph_no_results_mentions_active_filters(self):
+        open_graph = build_actions_open_graph(
+            page_url="https://example.org/actions?user=alice",
+            actions=[],
+            num_actions=0,
+            filters={
+                "action": "worker_log",
+                "username": "alice",
+                "text": "clang",
+                "run_id": "",
+            },
+            run_id_filter="69d12ae19caf4559aa7ada3e",
+        )
+
+        self.assertEqual(open_graph["title"], "Events Log | Stockfish Testing")
+        self.assertEqual(open_graph["url"], "https://example.org/actions?user=alice")
+        self.assertIn(
+            "No actions matched the current filters:", open_graph["description"]
+        )
+        self.assertIn("event=worker_log", open_graph["description"])
+        self.assertIn("user=alice", open_graph["description"])
+        self.assertIn("text=clang", open_graph["description"])
+        self.assertIn("run=69d12ae19caf4559aa7ada3e", open_graph["description"])

--- a/server/tests/test_views_actions.py
+++ b/server/tests/test_views_actions.py
@@ -2,6 +2,7 @@
 
 import unittest
 from datetime import UTC, datetime
+from html import unescape
 
 import test_support
 from fastapi.responses import RedirectResponse
@@ -410,6 +411,70 @@ class TestActionsViews(unittest.TestCase):
         self.assertEqual(fragment_response.status_code, 200)
         self.assertIn("Bestmove warning", fragment_response.text)
         self.assertNotIn("Generic server log", fragment_response.text)
+
+    def test_actions_full_page_renders_query_preserving_open_graph_preview(self):
+        event_time = datetime(2026, 4, 8, 19, 5, 44, tzinfo=UTC).timestamp()
+        self.rundb.actiondb.actions.insert_one(
+            {
+                "action": "failed_task",
+                "username": "TestActionsRouteUser",
+                "worker": "h23-worker-16cores-zz-1a2b",
+                "run_id": self.run_id,
+                "run": "h23-actions-run-abcdef0",
+                "task_id": 7,
+                "message": "clang++ link failed after profile-build",
+                "time": event_time,
+            },
+        )
+        self.rundb.actiondb.actions.insert_one(
+            {
+                "action": "failed_task",
+                "username": "TestActionsRouteUser",
+                "worker": "h23-worker-16cores-zz-1a2b",
+                "run_id": self.run_id,
+                "run": "h23-actions-run-abcdef0",
+                "task_id": 8,
+                "message": "second matching action",
+                "time": event_time - 60,
+            },
+        )
+
+        response = self.client.get(
+            f"/actions?user=TestActionsRouteUser&action=failed_task&run_id={self.run_id}&max_count=2"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            test_support.extract_meta_content(
+                response.text,
+                property_name="og:title",
+            ),
+            "failed_task on h23-actions-run-abcdef0/7 | Stockfish Testing",
+        )
+        self.assertEqual(
+            unescape(
+                test_support.extract_meta_content(
+                    response.text,
+                    property_name="og:url",
+                ),
+            ),
+            "http://testserver/actions?user=TestActionsRouteUser&action=failed_task"
+            f"&run_id={self.run_id}&max_count=2",
+        )
+
+        og_description = test_support.extract_meta_content(
+            response.text,
+            property_name="og:description",
+        )
+        self.assertNotIn("Most recent of", og_description)
+        self.assertIn("1 of 2 matching actions.", og_description)
+        self.assertIn("Time: 26-04-08 19:05:44", og_description)
+        self.assertIn("Event: failed_task", og_description)
+        self.assertIn("Source: h23-worker-16cores-zz-1a2b", og_description)
+        self.assertIn("Target: h23-actions-run-abcdef0/7", og_description)
+        self.assertIn(
+            "Comment: clang++ link failed after profile-build", og_description
+        )
 
     def test_actions_username_filter_matches_partial_substrings(self):
         self.rundb.actiondb.insert_action(


### PR DESCRIPTION
Add route-specific Open Graph metadata to the canonical /actions page so shared events-log URLs preview the first visible action instead of the generic site description.

Preserve the current query string in og:url because filters, time cursors, and explicit max_count values define the shared log slice, while keeping htmx fragments body-only.

Add helper and route coverage for the new metadata contract and sync the UI and HTMX reference docs with the full-page ownership model.