### PR TITLE
fix(ui): keep summary card values readable on small screens

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -60,6 +60,12 @@ button.notifications:focus-visible {
     font-size: 14px;
   }
 
+  .summary-card-value {
+    font-size: clamp(1.0625rem, 3.8vw, 1.125rem);
+    line-height: 1.1;
+    white-space: nowrap;
+  }
+
   .run-table .run-button,
   .run-table .run-date,
   .run-table .run-user,

--- a/server/fishtest/templates/contributors.html.j2
+++ b/server/fishtest/templates/contributors.html.j2
@@ -18,10 +18,10 @@
 
 <div class="row g-3 mb-3">
   <div class="col-6 col-sm">
-    <div class="card card-lg-sm text-center">
+    <div class="card card-lg-sm text-center h-100">
       <div class="card-header text-nowrap" title="Testers">Testers</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">
+        <h4 class="card-title mb-0 monospace summary-card-value">
           {{ summary.testers }}
         </h4>
       </div>
@@ -29,10 +29,10 @@
   </div>
 
   <div class="col-6 col-sm">
-    <div class="card card-lg-sm text-center">
+    <div class="card card-lg-sm text-center h-100">
       <div class="card-header text-nowrap" title="Developers">Developers</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">
+        <h4 class="card-title mb-0 monospace summary-card-value">
           {{ summary.developers }}
         </h4>
       </div>
@@ -40,10 +40,10 @@
   </div>
 
   <div class="col-6 col-sm">
-    <div class="card card-lg-sm text-center">
+    <div class="card card-lg-sm text-center h-100">
       <div class="card-header text-nowrap" title="Active testers">Active testers</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">
+        <h4 class="card-title mb-0 monospace summary-card-value">
           {{ summary.active_testers }}
         </h4>
       </div>
@@ -51,10 +51,10 @@
   </div>
 
   <div class="col-6 col-sm">
-    <div class="card card-lg-sm text-center">
+    <div class="card card-lg-sm text-center h-100">
       <div class="card-header text-nowrap" title="CPU years">CPU years</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">
+        <h4 class="card-title mb-0 monospace summary-card-value">
           {{ "{0:.2f}".format(summary.cpu_hours / (24 * 365)) }}
         </h4>
       </div>
@@ -62,10 +62,10 @@
   </div>
 
   <div class="col-6 col-sm">
-    <div class="card card-lg-sm text-center">
+    <div class="card card-lg-sm text-center h-100">
       <div class="card-header text-nowrap" title="Games played">Games played</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">
+        <h4 class="card-title mb-0 monospace summary-card-value">
           {{ summary.games }}
         </h4>
       </div>
@@ -73,10 +73,10 @@
   </div>
 
   <div class="col-6 col-sm">
-    <div class="card card-lg-sm text-center">
+    <div class="card card-lg-sm text-center h-100">
       <div class="card-header text-nowrap" title="Tests submitted">Tests submitted</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">
+        <h4 class="card-title mb-0 monospace summary-card-value">
           {{ summary.tests }}
         </h4>
       </div>

--- a/server/fishtest/templates/homepage_stats_fragment.html.j2
+++ b/server/fishtest/templates/homepage_stats_fragment.html.j2
@@ -4,7 +4,7 @@
       <div class="card card-lg-sm text-center">
         <div class="card-header text-nowrap" title="Cores">Cores</div>
         <div class="card-body">
-          <h4 class="card-title mb-0 monospace">{{ cores }}</h4>
+          <h4 class="card-title mb-0 monospace summary-card-value">{{ cores }}</h4>
         </div>
       </div>
     </div>
@@ -12,7 +12,7 @@
       <div class="card card-lg-sm text-center">
         <div class="card-header text-nowrap" title="Nodes per second">Nodes / sec</div>
         <div class="card-body">
-          <h4 class="card-title mb-0 monospace">{{ nps_m }}</h4>
+          <h4 class="card-title mb-0 monospace summary-card-value">{{ nps_m }}</h4>
         </div>
       </div>
     </div>
@@ -20,7 +20,7 @@
       <div class="card card-lg-sm text-center">
         <div class="card-header text-nowrap" title="Games per minute">Games / min</div>
         <div class="card-body">
-          <h4 class="card-title mb-0 monospace">{{ games_per_minute }}</h4>
+          <h4 class="card-title mb-0 monospace summary-card-value">{{ games_per_minute }}</h4>
         </div>
       </div>
     </div>
@@ -28,7 +28,7 @@
       <div class="card card-lg-sm text-center">
         <div class="card-header text-nowrap" title="Time remaining">Time remaining</div>
         <div class="card-body">
-          <h4 class="card-title mb-0 monospace">{{ pending_hours }}h</h4>
+          <h4 class="card-title mb-0 monospace summary-card-value">{{ pending_hours }}h</h4>
         </div>
       </div>
     </div>

--- a/server/fishtest/templates/nns_content_fragment.html.j2
+++ b/server/fishtest/templates/nns_content_fragment.html.j2
@@ -28,7 +28,7 @@
     <div class="card card-lg-sm text-center">
       <div class="card-header text-nowrap" title="Total nets">Nets</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">{{ nns_summary.nets }}</h4>
+        <h4 class="card-title mb-0 monospace summary-card-value">{{ nns_summary.nets }}</h4>
       </div>
     </div>
   </div>
@@ -37,7 +37,7 @@
     <div class="card card-lg-sm text-center">
       <div class="card-header text-nowrap" title="Total master nets">Master nets</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">{{ nns_summary.master_nets }}</h4>
+        <h4 class="card-title mb-0 monospace summary-card-value">{{ nns_summary.master_nets }}</h4>
       </div>
     </div>
   </div>
@@ -46,7 +46,7 @@
     <div class="card card-lg-sm text-center">
       <div class="card-header text-nowrap" title="Total contributors">Contributors</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">{{ nns_summary.contributors }}</h4>
+        <h4 class="card-title mb-0 monospace summary-card-value">{{ nns_summary.contributors }}</h4>
       </div>
     </div>
   </div>
@@ -55,7 +55,7 @@
     <div class="card card-lg-sm text-center">
       <div class="card-header text-nowrap" title="Total downloads">Downloads</div>
       <div class="card-body">
-        <h4 class="card-title mb-0 monospace">{{ nns_summary.downloads }}</h4>
+        <h4 class="card-title mb-0 monospace summary-card-value">{{ nns_summary.downloads }}</h4>
       </div>
     </div>
   </div>

--- a/server/fishtest/templates/user_management.html.j2
+++ b/server/fishtest/templates/user_management.html.j2
@@ -10,7 +10,7 @@
       <div class="card card-lg-sm text-center">
         <div class="card-header text-nowrap" title="All Users">All</div>
         <div class="card-body">
-          <h4 class="card-title mb-0 monospace">{{ all_count }}</h4>
+          <h4 class="card-title mb-0 monospace summary-card-value">{{ all_count }}</h4>
         </div>
       </div>
     </div>
@@ -18,7 +18,7 @@
       <div class="card card-lg-sm text-center">
         <div class="card-header text-nowrap" title="Pending Users">Pending</div>
         <div class="card-body">
-          <h4 class="card-title mb-0 monospace">{{ pending_count }}</h4>
+          <h4 class="card-title mb-0 monospace summary-card-value">{{ pending_count }}</h4>
         </div>
       </div>
     </div>
@@ -26,7 +26,7 @@
       <div class="card card-lg-sm text-center">
         <div class="card-header text-nowrap" title="Blocked users">Blocked</div>
         <div class="card-body">
-          <h4 class="card-title mb-0 monospace">{{ blocked_count }}</h4>
+          <h4 class="card-title mb-0 monospace summary-card-value">{{ blocked_count }}</h4>
         </div>
       </div>
     </div>
@@ -34,7 +34,7 @@
       <div class="card card-lg-sm text-center">
         <div class="card-header text-nowrap" title="Idle Users">Idle</div>
         <div class="card-body">
-          <h4 class="card-title mb-0 monospace">{{ idle_count }}</h4>
+          <h4 class="card-title mb-0 monospace summary-card-value">{{ idle_count }}</h4>
         </div>
       </div>
     </div>
@@ -42,7 +42,7 @@
       <div class="card card-lg-sm text-center">
         <div class="card-header text-nowrap" title="Approver Users">Approvers</div>
         <div class="card-body">
-          <h4 class="card-title mb-0 monospace">{{ approvers_count }}</h4>
+          <h4 class="card-title mb-0 monospace summary-card-value">{{ approvers_count }}</h4>
         </div>
       </div>
     </div>

--- a/server/tests/test_nn.py
+++ b/server/tests/test_nn.py
@@ -173,11 +173,11 @@ class TestNNViews(unittest.TestCase):
         self.assertNotIn(miss_name, response.text)
         self.assertRegex(
             response.text,
-            r'title="Total nets">Nets</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace">1</h4>',
+            r'title="Total nets">Nets</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace summary-card-value">1</h4>',
         )
         self.assertRegex(
             response.text,
-            r'title="Total downloads">Downloads</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace">8</h4>',
+            r'title="Total downloads">Downloads</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace summary-card-value">8</h4>',
         )
         self.assertNotIn("<!doctype html>", response.text.lower())
 
@@ -249,19 +249,19 @@ class TestNNViews(unittest.TestCase):
         )
         self.assertRegex(
             response.text,
-            r'title="Total nets">Nets</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace">3</h4>',
+            r'title="Total nets">Nets</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace summary-card-value">3</h4>',
         )
         self.assertRegex(
             response.text,
-            r'title="Total master nets">Master nets</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace">2</h4>',
+            r'title="Total master nets">Master nets</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace summary-card-value">2</h4>',
         )
         self.assertRegex(
             response.text,
-            r'title="Total contributors">Contributors</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace">2</h4>',
+            r'title="Total contributors">Contributors</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace summary-card-value">2</h4>',
         )
         self.assertRegex(
             response.text,
-            r'title="Total downloads">Downloads</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace">18</h4>',
+            r'title="Total downloads">Downloads</div>\s*<div class="card-body">\s*<h4 class="card-title mb-0 monospace summary-card-value">18</h4>',
         )
         self.assertIn("These networks are freely available for download", response.text)
         self.assertIn(

--- a/server/tests/test_views_contributors.py
+++ b/server/tests/test_views_contributors.py
@@ -384,6 +384,25 @@ class TestViewsContributors(UiUserTestCase):
         self.assertIn("static/js/contributors.js", response.text)
         self.assertNotIn('const FINDME_COOKIE = "contributors_findme"', response.text)
 
+    def test_contributors_summary_cards_keep_uniform_headers(self):
+        response = self.client.get("/contributors")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            'class="card card-lg-sm text-center h-100"',
+            response.text,
+        )
+        self.assertIn(
+            'class="card-header text-nowrap" title="Active testers">Active testers</div>',
+            response.text,
+        )
+        self.assertIn(
+            'class="card-header text-nowrap" title="Tests submitted">Tests submitted</div>',
+            response.text,
+        )
+        self.assertIn("card-title mb-0 monospace summary-card-value", response.text)
+        self.assertNotIn("summary-card-header", response.text)
+
     def test_contributors_sort_headers_use_hx_get_with_push_url(self):
         response = self.client.get("/contributors?sort=username&order=asc")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Keep contributors summary-card headers on one line so those cards stay the same height.

Use one shared summary-card value hook across contributors, homepage stats, neural networks, and user management, and size the metric line to a reduced mobile rule.

Preserve the existing route, fragment, and metric contracts.