### PR TITLE
fix(ui): disable auto-purge by default for PT presets

### DIFF
--- a/server/fishtest/templates/tests_run.html.j2
+++ b/server/fishtest/templates/tests_run.html.j2
@@ -63,6 +63,7 @@
                         "book": test_book,
                         "stop_rule": "stop-rule-sprt",
                         "bounds": "standard STC",
+                        "auto_purge": true,
                         "base_branch": base_branch,
                         "base_signature": latest_bench
                       } | tojson }}'
@@ -83,6 +84,7 @@
                         "options": "Hash=64",
                         "book": test_book,
                         "stop_rule": "stop-rule-sprt",
+                        "auto_purge": true,
                         "bounds": "standard LTC"
                       } | tojson }}'>
                     <label class="list-group-item rounded-3" for="ltc_test" title="Long time control | Single-threaded">
@@ -101,6 +103,7 @@
                         "options": "Hash=64",
                         "book": test_book,
                         "stop_rule": "stop-rule-sprt",
+                        "auto_purge": true,
                         "bounds": "standard STC"
                       } | tojson }}'>
                     <label class="list-group-item rounded-3" for="stc_smp_test" title="Short time control | Multi-threaded">
@@ -119,6 +122,7 @@
                         "options": "Hash=256",
                         "book": test_book,
                         "stop_rule": "stop-rule-sprt",
+                        "auto_purge": true,
                         "bounds": "standard LTC"
                       } | tojson }}'>
                     <label class="list-group-item rounded-3" for="ltc_smp_test" title="Long time control | Multi-threaded">
@@ -137,6 +141,7 @@
                         "options": "Hash=192",
                         "book": test_book,
                         "stop_rule": "stop-rule-sprt",
+                        "auto_purge": true,
                         "bounds": "standard STC"
                       } | tojson }}'>
                     <label class="list-group-item rounded-3" for="vltc_test" title="Very long time control | Single-threaded">
@@ -155,6 +160,7 @@
                         "options": "Hash=512",
                         "book": test_book,
                         "stop_rule": "stop-rule-sprt",
+                        "auto_purge": true,
                         "bounds": "standard LTC"
                       } | tojson }}'>
                     <label class="list-group-item rounded-3" for="vltc_smp_test" title="Very long time control | Multi-threaded">
@@ -173,6 +179,7 @@
                         "options": "Hash=64",
                         "book": pt_book,
                         "stop_rule": "stop-rule-games",
+                        "auto_purge": false,
                         "games": 60000,
                         "test_branch": "master",
                         "base_branch": pt_branch,
@@ -195,6 +202,7 @@
                         "options": "Hash=512",
                         "book": pt_book,
                         "stop_rule": "stop-rule-games",
+                        "auto_purge": false,
                         "games": 60000,
                         "test_branch": "master",
                         "base_branch": pt_branch,
@@ -645,7 +653,7 @@
                   class="form-check-input"
                   id="checkbox-auto-purge"
                   name="auto-purge"
-                  checked
+                  {{ "checked" if args.get("auto_purge", True) else "" }}
                 >
               </div>
               <div class="col-6 col-lg-4 mb-2 form-check">
@@ -829,6 +837,7 @@
           book,
           stop_rule,
           bounds,
+          auto_purge,
           games,
           test_branch,
           base_branch,
@@ -867,6 +876,10 @@
 
         if (games) {
           document.getElementById("num-games").value = games;
+        }
+
+        if (!isRun && typeof auto_purge === "boolean") {
+          document.getElementById("checkbox-auto-purge").checked = auto_purge;
         }
 
         if (!isRun) {

--- a/server/tests/test_views_run.py
+++ b/server/tests/test_views_run.py
@@ -426,6 +426,27 @@ class TemplateConstraintContractTests(unittest.TestCase):
             template_source,
         )
 
+    def test_tests_run_template_sets_auto_purge_defaults_by_test_type(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        template_source = (
+            repo_root / "fishtest" / "templates" / "tests_run.html.j2"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            '{{ "checked" if args.get("auto_purge", True) else "" }}',
+            template_source,
+        )
+        self.assertEqual(template_source.count('"auto_purge": true'), 6)
+        self.assertEqual(template_source.count('"auto_purge": false'), 2)
+        self.assertIn(
+            'if (!isRun && typeof auto_purge === "boolean") {',
+            template_source,
+        )
+        self.assertIn(
+            'document.getElementById("checkbox-auto-purge").checked = auto_purge;',
+            template_source,
+        )
+
 
 class RunPermissionTests(unittest.TestCase):
     def test_del_tasks_returns_deep_copy_without_tasks(self):


### PR DESCRIPTION
Keep Auto-purge enabled by default for standard run presets, but make PT and PT SMP start with Auto-purge disabled on the new-test page.

Render rerun pages from the stored auto_purge flag instead of a hardcoded checked checkbox, and lock the preset contract with a focused template test.