### PR TITLE
chore(ui): bump htmx and jsdiff CDN assets

### DIFF
--- a/docs/0-README.md
+++ b/docs/0-README.md
@@ -43,7 +43,7 @@ validation rules, see
 | Web framework | FastAPI + Starlette (ASGI) |
 | Application server | Uvicorn |
 | Templates | Jinja2 (`.html.j2`, `StrictUndefined`) |
-| Client interactivity | htmx 2.0.8 (CDN, fragment polling/swaps, OOB updates) |
+| Client interactivity | htmx 2.0.10 (CDN, fragment polling/swaps, OOB updates) |
 | Session management | itsdangerous `TimestampSigner` cookie sessions |
 | Database | MongoDB (pymongo) |
 | Validation | vtjson (schema-first validation; no Pydantic) |

--- a/docs/1-architecture.md
+++ b/docs/1-architecture.md
@@ -188,9 +188,10 @@ Client -> nginx -> Uvicorn -> ASGI middleware stack -> FastAPI router
 
 ### htmx integration
 
-UI templates load htmx 2.0.8 from CDN in `base.html.j2`. The server remains
-fully server-rendered (Jinja2 + HTML responses). htmx adds three capabilities
-without client-side rendering or a JavaScript build step:
+UI templates load htmx 2.0.10 from CDN in `base.html.j2`. The server remains
+fully server-rendered (Jinja2 + HTML responses). The test detail page also
+loads a page-scoped diff renderer for the inline Diff panel. htmx adds three
+capabilities without client-side rendering or a JavaScript build step:
 
 | Capability | Mechanism |
 |------------|-----------|

--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -163,6 +163,10 @@ The full `/tests/view/{id}` page also remembers the `% c` checkbox with a
 browser cookie, so the checkbox reopens in its previous mode while live detail
 polling continues to update only the embedded SPSA data node.
 
+The full `/tests/view/{id}` page also loads a dedicated client-side diff
+renderer for the inline Diff panel. That asset is page-scoped and is not part
+of the `/tests/view/{id}/detail` fragment contract.
+
 The request submits the page's current canonical `expected` state from a
 server-owned hidden input:
 

--- a/docs/9-references.md
+++ b/docs/9-references.md
@@ -249,12 +249,23 @@ must use `{{ value|safe }}` or `{% autoescape false %}`.
 
 ### Project patterns
 
-**CDN loading**: htmx 2.0.8 is loaded from `cdn.jsdelivr.net` in
+**CDN loading**: htmx 2.0.10 is loaded from `cdn.jsdelivr.net` in
 `base.html.j2` with an SRI integrity hash. No npm build step.
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js"
-    integrity="sha256-Iig+9oy3VFkU8KiKG97cclanA9HVgMHSVSF9ClDTExM="
+<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.10/dist/htmx.min.js"
+    integrity="sha256-cepnGFv6jJjDnTFxfG/OXYUjcPzf0SnbRUN3TTFFwN4="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"></script>
+```
+
+**Detail-page diff renderer**: `/tests/view/{id}` loads jsdiff from
+`cdn.jsdelivr.net` in `tests_view.html.j2` for the inline Diff panel. The
+asset is pinned and protected with SRI.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/diff@9.0.0/dist/diff.min.js"
+    integrity="sha256-tRqdKIXywJDcl7mBAnOV9+fmVYpGx1rjdH2yZ5E6ias="
     crossorigin="anonymous"
     referrerpolicy="no-referrer"></script>
 ```

--- a/server/fishtest/templates/base.html.j2
+++ b/server/fishtest/templates/base.html.j2
@@ -87,8 +87,8 @@
     ></script>
 
     <script
-      src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js"
-      integrity="sha256-Iig+9oy3VFkU8KiKG97cclanA9HVgMHSVSF9ClDTExM="
+      src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.10/dist/htmx.min.js"
+      integrity="sha256-cepnGFv6jJjDnTFxfG/OXYUjcPzf0SnbRUN3TTFFwN4="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     ></script>

--- a/server/fishtest/templates/tests_view.html.j2
+++ b/server/fishtest/templates/tests_view.html.j2
@@ -8,8 +8,8 @@
   const runId = {{ run_id | tojson }};
 </script>
 <script
-  src="https://cdn.jsdelivr.net/npm/diff@8.0.3/dist/diff.min.js"
-  integrity="sha256-g/bQGN3C0H+2VSdJbQs3iUM/y+M5E+qqBok29ZjwTWQ="
+  src="https://cdn.jsdelivr.net/npm/diff@9.0.0/dist/diff.min.js"
+  integrity="sha256-tRqdKIXywJDcl7mBAnOV9+fmVYpGx1rjdH2yZ5E6ias="
   crossorigin="anonymous"
   referrerpolicy="no-referrer"
 ></script>


### PR DESCRIPTION
Upgrade the shared htmx bundle to 2.0.10 and the test detail page jsdiff bundle to 9.0.0, keeping the pinned CDN URLs and SRI hashes.

Sync the public docs references with the shipped asset versions, integrity hashes, and the detail-page diff note.