### PR TITLE
docs: add mermaid runtime diagrams to core guides

### DIFF
--- a/docs/1-architecture.md
+++ b/docs/1-architecture.md
@@ -176,8 +176,17 @@ None use Starlette's `BaseHTTPMiddleware`.
 
 ## Request flow
 
-```
-Client -> nginx -> Uvicorn -> ASGI middleware stack -> FastAPI router
+High-level request path:
+
+```mermaid
+flowchart LR
+      client[Client] --> nginx[nginx]
+      nginx --> uvicorn[Uvicorn]
+      uvicorn --> middleware[ASGI middleware stack]
+      middleware --> router[FastAPI router]
+      router -->|HTML pages and fragments| ui[views_router]
+      router -->|Worker and user API| api[api_router]
+      router -->|/static| static[StaticFiles]
 ```
 
 - **Worker API**: `api_router` handles all `/api/*` endpoints. Worker

--- a/docs/2-threading-model.md
+++ b/docs/2-threading-model.md
@@ -157,6 +157,18 @@ while blocked on the mutex.
 
 ### Call chain (per request)
 
+```mermaid
+flowchart TD
+    loop[Event loop] --> offload[Offload request_task to threadpool]
+    offload --> token[One AnyIO token is held]
+    token --> gate[task_semaphore gate]
+    gate --> lock[request_task_lock mutex]
+    lock --> work[sync_request_task]
+    work --> data[MongoDB plus task iteration]
+```
+
+Exact call chain:
+
 ```
 event loop  ->  run_in_threadpool(api.request_task)   [1 AnyIO token]
   threadpool  ->  task_semaphore.acquire(False)       [non-blocking gate]

--- a/docs/3-api-reference.md
+++ b/docs/3-api-reference.md
@@ -12,7 +12,7 @@ These invariants apply to every worker API endpoint:
   also includes `duration`.
 - Content-Type is always `application/json`.
 - The current worker protocol version is defined by `WORKER_VERSION` in
-  `api.py` (currently 317).
+  `api.py` (currently 322).
 
 ## Authentication
 
@@ -26,6 +26,51 @@ Workers authenticate via `username` and `password` fields in the
 ## Protocol lifecycle
 
 A worker's interaction with the server follows this sequence:
+
+```mermaid
+sequenceDiagram
+  actor W as Worker
+  participant S as Fishtest server
+  participant F as Fastchess
+
+  W->>S: POST /api/request_version
+  alt Newer version available
+    S-->>W: version > local
+    W->>W: Self-update and restart
+  else Current version
+    S-->>W: version 322
+    W->>S: POST /api/request_task
+    alt No task ready
+      S-->>W: task_waiting false
+      W->>W: Backoff and retry
+    else Task assigned
+      S-->>W: run and task_id
+      W->>W: Build engines and stage inputs
+      par Task execution
+        loop Each batch
+          opt SPSA run
+            W->>S: POST /api/request_spsa
+            S-->>W: tuning parameters
+          end
+          W->>F: Run games
+          F-->>W: WLD and pentanomial results
+          W->>S: POST /api/update_task
+          S-->>W: duration or task_alive false
+        end
+      and Heartbeat
+        loop Every 120s while task active
+          W->>S: POST /api/beat
+          S-->>W: task_alive
+        end
+      end
+      alt Task completed
+        W->>S: POST /api/upload_pgn
+      else Task failed or run stopped
+        W->>S: POST /api/failed_task or /api/stop_run
+      end
+    end
+  end
+```
 
 1. **Version check** -- `POST /api/request_version`. If the server returns
    a newer version, the worker self-updates and restarts.
@@ -85,7 +130,7 @@ to check if they need to upgrade.
 
 **Response**:
 ```json
-{ "version": 317, "duration": 0.001 }
+{ "version": 322, "duration": 0.001 }
 ```
 
 ---

--- a/docs/6-worker.md
+++ b/docs/6-worker.md
@@ -20,8 +20,8 @@ Source files:
 
 | Constant | Value | Location |
 |----------|-------|----------|
-| `WORKER_VERSION` | 317 | `worker.py` |
-| `FASTCHESS_SHA` | `1525c4b17e009e4c94c313f5a3f6fa2cf299171a` | `worker.py` |
+| `WORKER_VERSION` | 322 | `worker.py` |
+| `FASTCHESS_SHA` | `3de44228aec904e688a4ad71c554eb9d461a5a2a` | `worker.py` |
 | `HTTP_TIMEOUT` | 30.0 s | `worker.py`, `games.py` |
 | `INITIAL_RETRY_TIME` | 15.0 s | `worker.py` |
 | `MAX_RETRY_TIME` | 900 s (15 min) | `worker.py` |
@@ -31,12 +31,24 @@ Source files:
 
 ## Control flow
 
-```
-worker.py : worker()
-worker.py :    fetch_and_handle_task()            [in loop]
-games.py  :       run_games()
-games.py  :          launch_fastchess()           [in loop for spsa]
-games.py  :             parse_fastchess_output()
+High-level worker control flow:
+
+```mermaid
+flowchart TD
+   start[worker] --> init[Setup parameters and verify worker]
+   init --> toolchain[Verify toolchain and setup fastchess]
+   toolchain --> heartbeat[Start heartbeat thread]
+   heartbeat --> fetch[fetch_and_handle_task]
+   fetch --> assigned{Task assigned}
+   assigned -- No --> retry[Wait and retry] --> fetch
+   assigned -- Yes --> prep[Build engines and stage inputs]
+   prep --> batch[Run fastchess batch]
+   batch --> report[POST /api/update_task]
+   report --> more{More games needed}
+   more -- Yes --> batch
+   more -- No, success --> upload[POST /api/upload_pgn] --> fetch
+   prep -- Failure --> stop[POST /api/failed_task or /api/stop_run] --> fetch
+   batch -- Failure --> stop
 ```
 
 ### `worker()` -- entry point

--- a/docs/8-deployment.md
+++ b/docs/8-deployment.md
@@ -54,6 +54,24 @@ internal process manager distributes PGN upload requests across the workers.
 The extra workers absorb the long-tail latency of large PGN writes
 (p95 approx 30 s at peak load).
 
+High-level routing topology:
+
+```mermaid
+flowchart LR
+    clients[Browsers and workers] --> nginx[nginx reverse proxy]
+    nginx -->|/static and /nn| static[Direct file serving]
+    subgraph cluster[Uvicorn cluster]
+        primary[8000 primary]
+        tests[8001 tests homepage]
+        readonly[8002 read-only UI and API]
+        pgn[8003 upload_pgn (3 workers)]
+    end
+    nginx -->|Worker API| primary
+    nginx -->|/tests| tests
+    nginx -->|Read-only UI and API| readonly
+    nginx -->|/api/upload_pgn| pgn
+```
+
 ## Starting the server
 
 Managed via a systemd service template (one unit per port):


### PR DESCRIPTION
Add GitHub-safe Mermaid diagrams to the architecture, threading, worker API, worker, and deployment guides where the docs already describe ordered runtime flows. Refresh stale worker version and fastchess constants so the touched pages match the current implementation.