### PR TITLE
docs: correct user-facing docs drift and fix mermaid

### DIFF
--- a/docs/1-architecture.md
+++ b/docs/1-architecture.md
@@ -114,7 +114,7 @@ Starlette threadpool via `run_in_threadpool()`.
 | Connection capacity | 9,400+ concurrent workers proven in production |
 | Blocking I/O | Occupies a threadpool slot only during the blocking call |
 | Memory per connection | Coroutine frame (~KBs), not a full thread stack |
-| Overload behavior | Connections queue in the kernel backlog (`--backlog 8192`) |
+| Overload behavior | Connections queue in the kernel backlog (`--backlog 16384`) |
 
 All blocking work (MongoDB queries, file I/O, CPU-bound stats, GitHub API
 calls) is offloaded to the threadpool. The event loop stays free to accept
@@ -226,7 +226,7 @@ headers for dynamic content and should not add `proxy_cache` in front of UI
 routes. Aggressive proxy/browser caching remains appropriate for immutable
 static assets only.
 
-**Server-authoritative table state.** Newer htmx list pages (`/nns`,
+**Server-authoritative table state.** The htmx list pages (`/nns`,
 `/contributors`, `/user_management`, `/workers/show`, `/tests/machines`) keep
 sort, search, page, and view state in the URL and render the active control
 state server-side on every response. Where the htmx target contains stateful

--- a/docs/2-threading-model.md
+++ b/docs/2-threading-model.md
@@ -105,7 +105,7 @@ Async generators that yield chunks, with each chunk read in the threadpool.
 | Component | Domain | Notes |
 |-----------|--------|-------|
 | `_dispatch_view()` | `[LOOP]` | Form parsing, CSRF check, then `run_in_threadpool` |
-| All 30 view handler bodies | `[THREAD]` | Via `_dispatch_view` |
+| All UI view handler bodies (every route except direct `home`) | `[THREAD]` | Via `_dispatch_view` |
 | Template rendering | `[THREAD]` | Inside handler body, `render_template_to_response` |
 
 ### Error handlers (`http/errors.py`)

--- a/docs/4-ui-reference.md
+++ b/docs/4-ui-reference.md
@@ -650,7 +650,7 @@ The blocked-workers table supports URL-driven server-authoritative state.
 
 Behavior notes:
 
-- `filter` keeps the server-side time-window behavior from H6.
+- `filter` keeps the server-side time-window behavior.
 - Sorting is server-authoritative and stable with worker-name tie-breaks.
 - Pagination uses page size `25` in paged view.
 - `view=all` returns all matching rows up to a hard cap (`5000`) and hides
@@ -677,7 +677,7 @@ URL-driven state for server sorting, search, paging, full view, and rank jump.
 | Parameter | Values | Default |
 |-----|-----|-----|
 | `search` | one-shot go-to query (exact username first, then first substring match) | empty |
-| `sort` | `cpu_hours`, `username`, `last_updated`, `games_per_hour`, `games`, `tests` | `cpu_hours` |
+| `sort` | `cpu_hours`, `username`, `last_updated`, `games_per_hour`, `games`, `tests`, `tests_repo` | `cpu_hours` |
 | `order` | `asc`, `desc` | column default |
 | `page` | integer `>= 1` | `1` |
 | `view` | `paged`, `all` | `paged` |
@@ -842,7 +842,7 @@ Behavior notes:
   by run id.
 - `text` performs a case-insensitive MongoDB `$text` query against the last-column
    run info text on finished runs only.
-- `/actions`, `/tests/finished`, and `/tests/user/{username}` now use the
+- `/actions`, `/tests/finished`, and `/tests/user/{username}` share the
    same `max_count` query parameter for result caps.
 - Anonymous search requests use the anonymous finished-run search cap.
    Authenticated search requests use the authenticated finished-run default.

--- a/docs/5-templates.md
+++ b/docs/5-templates.md
@@ -232,7 +232,7 @@ Design rules:
    or a page-specific `cookie_max_age` context instead of introducing alternate
    aliases or literals.
 
-Known gaps documented for future iterations:
+Known limitations:
 
 - Workers and user_management have zero cookie persistence for filter/sort
   state (user resets to defaults on page reload).

--- a/docs/6-worker.md
+++ b/docs/6-worker.md
@@ -273,7 +273,7 @@ key.
 |----------|--------|-------|---------|
 | `/api/request_version` | POST | Setup | Check worker version, trigger update |
 | `/api/request_task` | POST | Setup | Request a task assignment |
-| `/api/nn/{nnue}` | GET | Setup | Download a neural network file |
+| `/api/nn/{id}` | GET | Setup | Download a neural network file |
 | `/api/update_task` | POST | Main loop | Report game results (batch updates) |
 | `/api/request_spsa` | POST | Main loop | Get SPSA tuning parameters |
 | `/api/beat` | POST | Heartbeat | Keep task lease alive (every 120 s) |

--- a/docs/8-deployment.md
+++ b/docs/8-deployment.md
@@ -64,7 +64,7 @@ flowchart LR
         primary[8000 primary]
         tests[8001 tests homepage]
         readonly[8002 read-only UI and API]
-        pgn[8003 upload_pgn (3 workers)]
+        pgn["8003 upload_pgn (3 workers)"]
     end
     nginx -->|Worker API| primary
     nginx -->|/tests| tests

--- a/docs/9-references.md
+++ b/docs/9-references.md
@@ -308,7 +308,7 @@ Fragment templates are standalone `.html.j2` files that do not extend
 `base.html.j2`. This avoids partial-block rendering complexity and keeps
 fragments self-contained.
 
-**Content fragments for stateful tables**: newer list pages do not return only
+**Content fragments for stateful tables**: stateful list pages do not return only
 row fragments. They return content fragments (`contributors_content_fragment`,
 `user_management_content_fragment`, `workers_content_fragment`) so that view
 toggles, truncation banners, pagination, and sort state remain synchronized


### PR DESCRIPTION
Reconcile the architecture overload row to the authoritative deployment backlog value of 16384. Add the missing tests_repo contributors sort value, which is a live sortable column. Generalize the threadpool view-handler description instead of pinning an incorrect count. Align the worker neural network endpoint path with the api/nn/{id} route.
Quote the label so the parentheses are treated as literal text in mermaid chart.