### PR TITLE
feat: warn approvers when a test diff overflows its box

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -664,6 +664,33 @@ td {
   margin-bottom: 0 !important;
 }
 
+/* Approver-only cue: the diff box overflows its scroll region and must be
+   scrolled to be read in full. The ring is an outer box-shadow so the vertical
+   scrollbar cannot mask it, it pulses to catch the eye, and it adds no layout
+   box, so it does not change the scrollHeight/clientHeight overflow
+   measurement. */
+#diff-contents.diff-overflow-warning {
+  box-shadow: 0 0 0 3px var(--bs-warning);
+  animation: diff-overflow-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes diff-overflow-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px var(--bs-warning);
+  }
+
+  50% {
+    box-shadow: 0 0 0 6px var(--bs-warning);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #diff-contents.diff-overflow-warning {
+    animation: none;
+  }
+}
+
 #tasks {
   max-height: 60vh;
   margin-bottom: 12px;

--- a/server/fishtest/templates/tests_view.html.j2
+++ b/server/fishtest/templates/tests_view.html.j2
@@ -659,6 +659,38 @@
   const diffText = diffContents.querySelector("code");
   const toggleBtn = document.getElementById("diff-toggle");
 
+  const viewerIsApprover = {{ approver | tojson }};
+  // Latched once the approver scrolls an overflowing diff to its end, so the
+  // attention cue stops nagging after the full diff has actually been seen.
+  let diffReviewed = false;
+
+  function updateDiffOverflowWarning() {
+    // Nudge approvers when part of the diff is below the fold and must be
+    // scrolled into view. The cue is an outer pulsing ring (see CSS): drawn
+    // outside the box so the vertical scrollbar cannot mask it, and pulsing so
+    // it catches the eye. It is dropped once the diff is scrolled to the end.
+    if (!viewerIsApprover) return;
+    const visible =
+      diffContents.style.display !== "none" && diffContents.offsetParent !== null;
+    const overflowing = diffContents.scrollHeight > diffContents.clientHeight + 1;
+    if (visible && overflowing) {
+      const atBottom =
+        diffContents.scrollHeight - diffContents.scrollTop - diffContents.clientHeight <= 2;
+      if (atBottom) diffReviewed = true;
+    }
+    diffContents.classList.toggle(
+      "diff-overflow-warning",
+      visible && overflowing && !diffReviewed,
+    );
+  }
+
+  if (viewerIsApprover) {
+    window.addEventListener("resize", updateDiffOverflowWarning);
+    diffContents.addEventListener("scroll", updateDiffOverflowWarning, {
+      passive: true,
+    });
+  }
+
   async function fetchDiffTwoDots(apiUrlNew, apiUrlBase, diffNew, diffBase, options) {
     const [files1, files2] = await Promise.all([
       getFilesInBranch(apiUrlBase, diffBase, options),
@@ -846,6 +878,7 @@
     addDiff(diffText, text);
     showDiff(diffContents, diffText, count, copyDiffBtn, toggleBtn);
     hljs.highlightElement(diffText);
+    requestAnimationFrame(updateDiffOverflowWarning);
     toggleBtn.addEventListener("click", function () {
         diffContents.style.display =
           diffContents.style.display === "none" ? "" : "none";
@@ -854,6 +887,7 @@
             copyDiffBtn.style.display === "none" ? "" : "none";
         if (toggleBtn.textContent === "Hide") toggleBtn.textContent = "Show";
         else toggleBtn.textContent = "Hide";
+        updateDiffOverflowWarning();
       });
     document.getElementById("diff-section").style.display = "";
 

--- a/server/tests/test_views_detail.py
+++ b/server/tests/test_views_detail.py
@@ -1075,3 +1075,69 @@ class TestTestsViewTasks(UiUserTestCase):
             "--tasks-panel-max-height: calc(var(--machines-panel-max-height) + 6rem);",
             css_source,
         )
+
+
+class TestTestsViewDiffWarning(UiUserTestCase):
+    username = "DiffWarningUser"
+
+    def test_diff_overflow_warning_assets_are_present(self):
+        template_path = (
+            Path(__file__).resolve().parents[1]
+            / "fishtest"
+            / "templates"
+            / "tests_view.html.j2"
+        )
+        template_source = template_path.read_text(encoding="utf-8")
+        self.assertIn("function updateDiffOverflowWarning()", template_source)
+        self.assertIn(
+            "diffContents.scrollHeight > diffContents.clientHeight + 1",
+            template_source,
+        )
+        self.assertIn('"diff-overflow-warning",', template_source)
+        self.assertIn("visible && overflowing && !diffReviewed,", template_source)
+        # Listeners are registered only for approvers, not every viewer.
+        self.assertIn(
+            "if (viewerIsApprover) {\n"
+            '    window.addEventListener("resize", updateDiffOverflowWarning);',
+            template_source,
+        )
+        self.assertIn(
+            'diffContents.addEventListener("scroll", updateDiffOverflowWarning, {',
+            template_source,
+        )
+        self.assertIn(
+            "requestAnimationFrame(updateDiffOverflowWarning);", template_source
+        )
+
+        css_path = (
+            Path(__file__).resolve().parents[1]
+            / "fishtest"
+            / "static"
+            / "css"
+            / "application.css"
+        )
+        css_source = css_path.read_text(encoding="utf-8")
+        self.assertIn("#diff-contents.diff-overflow-warning {", css_source)
+        # Outer ring so the vertical scrollbar cannot mask it (no inset).
+        self.assertIn("box-shadow: 0 0 0 3px var(--bs-warning);", css_source)
+        self.assertNotIn("box-shadow: inset 0 0 0 3px var(--bs-warning);", css_source)
+        self.assertIn("@keyframes diff-overflow-pulse {", css_source)
+        self.assertIn("@media (prefers-reduced-motion: reduce) {", css_source)
+
+    def test_diff_overflow_warning_flag_is_true_for_approver(self):
+        run_id = self._create_run()
+        original_pending, original_groups = self._set_approver_state()
+        try:
+            self._login_user()
+            response = self.client.get(f"/tests/view/{run_id}")
+        finally:
+            self._restore_approver_state(original_pending, original_groups)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("const viewerIsApprover = true;", response.text)
+
+    def test_diff_overflow_warning_flag_is_false_for_non_approver(self):
+        run_id = self._create_run()
+        self._login_user()
+        response = self.client.get(f"/tests/view/{run_id}")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("const viewerIsApprover = false;", response.text)


### PR DESCRIPTION
Ring the diff box on the single test page when the rendered diff is taller than its scroll region, so an approver sees that the diff is only partially visible and must scroll to read it in full. Show the ring only to approvers and clear it once the diff is scrolled to its end.

Expose an approver flag in the tests_view render context from the existing approve_run permission. Add a client helper that toggles the warning class when the visible diff box overflows, re-evaluated after render, on the Show or Hide toggle, on viewport resize, and on diff scroll; a sticky flag drops the ring after the approver reaches the bottom. Paint the ring with an outer pulsing box-shadow in the Bootstrap warning color so the vertical scrollbar cannot mask it, it draws the eye, and it adds no layout box that would perturb the overflow measurement. Disable the pulse under prefers-reduced-motion.