### PR TITLE
chore(deps): update fastapi to 0.138.0 and use httpx2

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 dependencies = [
     "awscli>=1.45.22",
     "email-validator>=2.3.0",
-    "fastapi>=0.136.3",
+    "fastapi>=0.138.0",
     "itsdangerous>=2.2.0",
     "jinja2>=3.1.6",
     "numpy>=2.4.6",
@@ -39,7 +39,7 @@ dependencies = [
 
 [dependency-groups]
 test = [
-    "httpx>=0.28.1",
+    "httpx2>=2.4.0",
 ]
 
 [project.urls]

--- a/server/tests/test_views_routes.py
+++ b/server/tests/test_views_routes.py
@@ -53,7 +53,7 @@ class TestViewRouteMethods(unittest.TestCase):
     def setUpClass(cls):
         test_support.require_fastapi()
         try:
-            from fastapi.routing import APIRoute
+            from fastapi.routing import APIRoute, iter_route_contexts
 
             from fishtest.views import _VIEW_ROUTES
         except ModuleNotFoundError as exc:  # pragma: no cover
@@ -62,6 +62,10 @@ class TestViewRouteMethods(unittest.TestCase):
             )
 
         cls.APIRoute = APIRoute
+        # FastAPI 0.137.0 stores included routers as a tree in ``app.routes``;
+        # ``iter_route_contexts`` is the supported way to walk it back to the
+        # underlying routes.
+        cls.iter_route_contexts = staticmethod(iter_route_contexts)
         cls.declared_view_paths = {path for _fn, path, _cfg in _VIEW_ROUTES}
         cls.rundb = test_support.get_rundb()
 
@@ -83,10 +87,10 @@ class TestViewRouteMethods(unittest.TestCase):
             include_views=True,
         )
         route_methods = {
-            route.path: set(route.methods or set())
-            for route in app.routes
-            if isinstance(route, self.APIRoute)
-            and route.path in self.declared_view_paths
+            ctx.path: set(ctx.methods or set())
+            for ctx in self.iter_route_contexts(app.routes)
+            if isinstance(ctx.original_route, self.APIRoute)
+            and ctx.path in self.declared_view_paths
         }
         self.assertSetEqual(set(route_methods), self.declared_view_paths)
         return route_methods

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.138.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -176,9 +176,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
 ]
 
 [[package]]
@@ -204,14 +204,14 @@ dependencies = [
 
 [package.dev-dependencies]
 test = [
-    { name = "httpx" },
+    { name = "httpx2" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "awscli", specifier = ">=1.45.22" },
     { name = "email-validator", specifier = ">=2.3.0" },
-    { name = "fastapi", specifier = ">=0.136.3" },
+    { name = "fastapi", specifier = ">=0.138.0" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "numpy", specifier = ">=2.4.6" },
@@ -226,7 +226,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-test = [{ name = "httpx", specifier = ">=0.28.1" }]
+test = [{ name = "httpx2", specifier = ">=2.4.0" }]
 
 [[package]]
 name = "h11"
@@ -238,31 +238,31 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
     { name = "h11" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/9b/2b1d1833a58236d1f6ee755e027a3917da0db59cc9708554cefc440ee8b6/httpcore2-2.4.0.tar.gz", hash = "sha256:3093a8ab8980d9f910b9cb4351df9186a0ad2350a6284a9107ac9a362a584422", size = 64618, upload-time = "2026-06-11T06:35:53.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/72/4fdf2306143a92a471fad9f3655aa542d43aa9188a7c9534e82c9aecf837/httpcore2-2.4.0-py3-none-any.whl", hash = "sha256:5218779da5d6e3c2013ac706121abfb3815d450e0613495c0de50264dce58242", size = 80151, upload-time = "2026-06-11T06:35:50.89Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
+    { name = "httpcore2" },
     { name = "idna" },
+    { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/60/b43ced4ccf26e95b396dbf67051d3e5042b645917d4da0469dd82a3bdd4f/httpx2-2.4.0.tar.gz", hash = "sha256:32e0734b61eb0824b3f56a9e98d6d92d381a3ef12c0045aa917ee63df6c411ef", size = 81691, upload-time = "2026-06-11T06:35:54.538Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/29/45/82bc57c3d9c3314f663b67cc057f1c017a6450685dde513f4f8db5cf431f/httpx2-2.4.0-py3-none-any.whl", hash = "sha256:425acd99297829599decf6701386dd84db3542597d36d3e2e4def930ecd57fd9", size = 74941, upload-time = "2026-06-11T06:35:52.235Z" },
 ]
 
 [[package]]
@@ -644,6 +644,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Move the server FastAPI floor from 0.136.3 to 0.138.0 and refresh the lock so installs resolve the current upstream release. Starlette is already at 1.3.1, the latest upstream, and needs no change.

The 0.137.0 route refactor turns app and included-router routes into a tree. Production code is unaffected: _derive_worker_api_paths reads the directly decorated api_router.routes, which stays a flat list of APIRoute. Update test_views_routes to enumerate UI routes through iter_route_contexts instead of scanning app.routes for APIRoute, which no longer matches the included router under the tree.

Move the server test group from httpx to httpx2 and refresh the lock. Starlette 1.3.x selects httpx2 for its TestClient and warns when only the legacy httpx is installed; httpx2 is the maintained continuation with a compatible ASGI transport.

The repository uses httpx only through fastapi.testclient.TestClient, so the swap removes the StarletteDeprecationWarning without any test-code change.