### PR TITLE
chore: type annotations for workerdb module

### DIFF
--- a/server/fishtest/workerdb.py
+++ b/server/fishtest/workerdb.py
@@ -1,19 +1,22 @@
 from datetime import UTC, datetime
+from typing import Any
 
+from pymongo.collection import Collection
+from pymongo.database import Database
 from vtjson import validate
 
 from fishtest.schemas import worker_schema
 
 
 class WorkerDb:
-    def __init__(self, db):
-        self.db = db
-        self.workers = self.db["workers"]
+    def __init__(self, db: Database[dict[str, Any]]) -> None:
+        self.db: Database[dict[str, Any]] = db
+        self.workers: Collection[dict[str, Any]] = self.db["workers"]
 
     def get_worker(
         self,
-        worker_name,
-    ):
+        worker_name: str,
+    ) -> dict[str, Any]:
         q = {"worker_name": worker_name}
         r = self.workers.find_one(
             q,
@@ -28,7 +31,12 @@ class WorkerDb:
         else:
             return r
 
-    def update_worker(self, worker_name, blocked=None, message=None):
+    def update_worker(
+        self,
+        worker_name: str,
+        blocked: bool | None = None,
+        message: str | None = None,
+    ) -> None:
         r = {
             "worker_name": worker_name,
             "blocked": blocked,
@@ -38,6 +46,6 @@ class WorkerDb:
         validate(worker_schema, r, "worker")  # may throw exception
         self.workers.replace_one({"worker_name": worker_name}, r, upsert=True)
 
-    def get_blocked_workers(self):
+    def get_blocked_workers(self) -> list[dict[str, Any]]:
         q = {"blocked": True}
         return list(self.workers.find(q))


### PR DESCRIPTION
This is a first incremental installment toward #2140 (type annotations in Fishtest), covering the `server/fishtest/workerdb.py` module.

## What changed
- Added complete type hints to the `WorkerDb` class:
  - `__init__` now annotates the `db` parameter as `pymongo.database.Database[dict[str, Any]]` and the `self.db` / `self.workers` attributes (the latter as `pymongo.collection.Collection[dict[str, Any]]`).
  - `get_worker` is annotated `(worker_name: str) -> dict[str, Any]`.
  - `update_worker` is annotated `(worker_name: str, blocked: bool | None = None, message: str | None = None) -> None`.
  - `get_blocked_workers` is annotated `() -> list[dict[str, Any]]`.

## Notes
- Behavior is unchanged; this is annotations only.
- `ty check` passes cleanly on the file, as do `ruff check` and `ruff format --check`.
- Kept the change small and self-contained to one module, matching the existing typing style used elsewhere (e.g. `userdb.py`, modern PEP 604 unions, no `from __future__` needed under the py3.14 target).

Refs #2140
