### PR TITLE
Display a warning on the test page for tests with fastchess warnings

### DIFF
--- a/server/fishtest/actiondb.py
+++ b/server/fishtest/actiondb.py
@@ -300,7 +300,7 @@ class ActionDb:
                 action["task_id"] = task_id
         self.insert_action(**action)
 
-    def count_fastchess_warnings(self, run_id=None):
+    def count_fastchess_warnings(self, run_id):
         # Count worker_log actions for this run whose message reports a
         # fastchess warning (i.e. contains both "fastchess" and "Warning").
         q = {

--- a/server/fishtest/actiondb.py
+++ b/server/fishtest/actiondb.py
@@ -300,6 +300,23 @@ class ActionDb:
                 action["task_id"] = task_id
         self.insert_action(**action)
 
+    def count_fastchess_warnings(self, run_id=None):
+        # Count worker_log actions for this run whose message reports a
+        # fastchess warning (i.e. contains both "fastchess" and "Warning").
+        q = {
+            "action": "worker_log",
+            "run_id": str(run_id),
+            "$and": [
+                {"message": {"$regex": "fastchess"}},
+                {"message": {"$regex": "Warning"}},
+            ],
+        }
+        try:
+            return self.actions.count_documents(q, hint="actions_run_time_id")
+        except OperationFailure:
+            # Be resilient if indexes haven't been created yet (bad hint).
+            return self.actions.count_documents(q)
+
     def insert_action(self, **action):
         if "run_id" in action:
             action["run_id"] = str(action["run_id"])

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -3594,6 +3594,21 @@ def tests_view(request: _ViewContext) -> dict[str, Any] | RedirectResponse:  # n
         warnings.append(
             "the developer repository is not forked from official-stockfish/Stockfish",
         )
+    fastchess_warnings = request.actiondb.count_fastchess_warnings(run_id=run["_id"])
+    if fastchess_warnings > 0:
+        # Link to the event log filtered on this run so the warnings can be inspected.
+        # Build as Markup so the anchor tag is not escaped under Jinja autoescape.
+        event_log = Markup(
+            '<a class="alert-link" href="/actions?run_id={}"'
+            ' target="_blank" rel="noopener noreferrer">event log</a>',
+        ).format(run["_id"])
+        warnings.append(
+            Markup("this test has {} fastchess {} in the {}").format(
+                fastchess_warnings,
+                plural(fastchess_warnings, "warning"),
+                event_log,
+            ),
+        )
 
     def allow_github_api_calls() -> bool:
         # Avoid making pointless GitHub api calls on behalf of


### PR DESCRIPTION
## What

Surfaces a warning on the test page (`/tests/view/{id}`) whenever a test
has fastchess warnings recorded in the event log.

## Why

Per #2538: now that workers post fastchess warnings to the event log, a
test with such warnings can otherwise go unnoticed unless someone opens
the event log manually. This makes the condition visible directly on the
test page.

## How

- `ActionDb.count_fastchess_warnings(run_id)` counts `worker_log` actions
  for the run whose message contains both `"fastchess"` and `"Warning"`
  (the format produced by `post_to_worker_log` in `worker/games.py`,
  e.g. `fastchess says: 'Warning; Engine ... is not responsive'`). It
  uses the existing `actions_run_time_id` index with a graceful fallback.
- `tests_view` adds a warning to the existing `warnings` list when the
  count is positive. The warning links to the run-filtered event log
  (`/actions?run_id=...`) so the individual warnings can be inspected.
  The message is built as `Markup` so the anchor renders correctly under
  Jinja autoescape, matching the existing pattern in this view.

## Design assumption

The issue mentions "the My tests page or the test page itself". This
implements the test page only (the most direct, single-run surface and
the place that already renders a `warnings` banner), keeping the diff
minimal. The same `count_fastchess_warnings` helper can later be reused
for the My tests run-table rows if desired.

Closes #2538
