### PR TITLE
fix: consistent 'diff' links between test view and overview

### DIFF
--- a/server/fishtest/templates/tests_view.html.j2
+++ b/server/fishtest/templates/tests_view.html.j2
@@ -76,7 +76,7 @@
 <div id="enclosure"{% if show_task >= 0 %} style="visibility:hidden;"{% endif %}>
   <h2>
     <span>{{ page_title }}</span>
-    <a href="{{ diff_url(run, master_check=allow_github_api_calls) }}" target="_blank" rel="noopener noreferrer">diff</a>
+    <a href="{{ diff_url(run, master_check=False) }}" target="_blank" rel="noopener noreferrer">diff</a>
     <span id="run-status-{{ run_id }}">{{ run_status_label }}</span>
   </h2>
 
@@ -106,7 +106,7 @@
           Diff
           <span id="diff-num-comments">(0 comments)</span>
           <a
-            href="{{ diff_url(run, master_check=allow_github_api_calls) }}"
+            href="{{ diff_url(run, master_check=False) }}"
             class="btn btn-primary bg-light-primary border-0 mb-2"
             target="_blank" rel="noopener noreferrer"
           >
@@ -766,7 +766,7 @@
       copyDiffBtn.addEventListener("click", () => {
         const textarea = document.createElement("textarea");
         textarea.style.position = "fixed";
-        textarea.textContent = "curl -s {{ diff_url(run, master_check=allow_github_api_calls) }}.diff | git apply";
+        textarea.textContent = "curl -s {{ diff_url(run, master_check=False) }}.diff | git apply";
         document.body.append(textarea);
         textarea.select();
         try {
@@ -782,7 +782,7 @@
       copyDiffBtn = null;
     }
 
-    const diffApiUrl = {{ diff_url(run, master_check=allow_github_api_calls) | tojson }}.replace(
+    const diffApiUrl = {{ diff_url(run, master_check=False) | tojson }}.replace(
       "//github.com/",
       "//api.github.com/repos/"
     );

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -3695,7 +3695,6 @@ def tests_view(request: _ViewContext) -> dict[str, Any] | RedirectResponse:  # n
         "theme_color": theme_color,
         "warnings": warnings,
         "use_3dot_diff": use_3dot_diff,
-        "allow_github_api_calls": allow_github_api_calls(),
     }
 
 


### PR DESCRIPTION
### Problem

The `diff` button generates different GitHub compare URLs depending on where it is rendered:

- Test detail page: `diff_url(run, master_check=allow_github_api_calls)` — for approvers / recently updated runs this runs `is_master()` and rewrites the compare to the **official-stockfish** repository context.
- Run tables / overview: `diff_url(run, master_check=False)` — leaves the compare anchored to the **user (fork)** repository context.

GitHub commit comments are repository-scoped, so the same run could send users to two different compare contexts. A commit comment visible through one `diff` link was invisible through the other, which is exactly the symptom reported in #2494:

- Detail link -> `official-stockfish/Stockfish/compare/...` (comment visible)
- Overview link -> `<user>/Stockfish/compare/...` (comment not visible)

### Fix

Make the detail page use `master_check=False`, matching the overview tables. Now every `diff` link (detail header link, "View on GitHub" button, the copy `apply-diff` command, and the comment-count fetch) resolves to the user repository, so comments live in one consistent context — as requested in the issue ("it should always [be] the user repo because the comments belong there").

Notes:
- The inline diff content is unaffected: the 2-dot path fetches via `tests_repo` (already the user repo), and the 3-dot / spsa paths never depended on the official-stockfish rewrite (they only rewrite a side when it is part of master, which is not the case for those paths).
- This also avoids the extra GitHub API calls (`is_master`) that the `master_check` path incurred on the detail page.
- Removed the now-unused `allow_github_api_calls` template context key from `tests_view` (the `allow_github_api_calls()` helper itself is retained — it still drives `use_3dot_diff`).

Closes #2494
