### PR TITLE
Fix Python 2-style except clauses for Python 3 compatibility

### DIFF
--- a/server/fishtest/http/boundary.py
+++ b/server/fishtest/http/boundary.py
@@ -120,7 +120,7 @@ async def get_json_body(request: Request) -> JsonBodyResult:
     """Parse JSON body, preserving legacy error behavior."""
     try:
         body = await request.json()
-    except JSONDecodeError, TypeError, ValueError:
+    except (JSONDecodeError, TypeError, ValueError):
         return JsonBodyResult(body=None, error=True)
     return JsonBodyResult(body=body, error=False)
 

--- a/server/fishtest/http/middleware.py
+++ b/server/fishtest/http/middleware.py
@@ -175,7 +175,7 @@ class RejectNonPrimaryWorkerApiMiddleware:
 
         try:
             is_primary = bool(rundb.is_primary_instance())
-        except AttributeError, RuntimeError, TypeError:
+        except (AttributeError, RuntimeError, TypeError):
             is_primary = True
 
         if is_primary:

--- a/server/fishtest/http/open_graph.py
+++ b/server/fishtest/http/open_graph.py
@@ -121,7 +121,7 @@ def _metadata_time_label(value: _TimestampInput) -> str:
 
     try:
         return datetime.fromtimestamp(float(value), UTC).strftime("%y-%m-%d %H:%M:%S")
-    except OverflowError, OSError, TypeError, ValueError:
+    except (OverflowError, OSError, TypeError, ValueError):
         return ""
 
 

--- a/server/fishtest/http/session_middleware.py
+++ b/server/fishtest/http/session_middleware.py
@@ -75,7 +75,7 @@ class FishtestSessionMiddleware:
                     unsigned = signer.unsign(raw, max_age=self.max_age)
                 session = json.loads(b64decode(unsigned))
                 initial_session_was_empty = False
-            except BadSignature, ValueError, TypeError, json.JSONDecodeError:
+            except (BadSignature, ValueError, TypeError, json.JSONDecodeError):
                 session = {}
 
         if not isinstance(session, dict):

--- a/server/fishtest/http/template_helpers.py
+++ b/server/fishtest/http/template_helpers.py
@@ -39,7 +39,7 @@ def run_tables_prefix(username: object | None) -> str:
         if username is None:
             return ""
         text = str(username)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return ""
     token = binascii.hexlify(text.encode()).decode()
     return f"user{token}_"

--- a/server/fishtest/spsa_workflow.py
+++ b/server/fishtest/spsa_workflow.py
@@ -22,7 +22,7 @@ _SPSA_PARAM_FIELDS = 6
 def _as_float(value: object, fallback: float | None = None) -> float | None:
     try:
         return float(value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return fallback
 
 
@@ -549,7 +549,7 @@ def build_spsa_chart_payload(spsa: Mapping[str, Any] | None) -> dict[str, Any]:
         if base_c is not None:
             try:
                 live_c = _finite_float(base_c / iter_local**gamma)
-            except ArithmeticError, OverflowError, ValueError:
+            except (ArithmeticError, OverflowError, ValueError):
                 live_c = None
         live_point.append(
             {

--- a/server/fishtest/util.py
+++ b/server/fishtest/util.py
@@ -367,7 +367,7 @@ def get_tc_ratio(tc, threads=1, base="10+0.1"):
     Example: standard LTC is 6x, SMP-STC is 4x."""
     try:
         threads_value = float(threads)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         print(f"Invalid threads value in get_tc_ratio: {threads!r}; defaulting to 1.0")
         threads_value = 1.0
 

--- a/server/fishtest/views.py
+++ b/server/fishtest/views.py
@@ -255,7 +255,7 @@ def _classify_active_run_filters(run: dict) -> dict[str, str]:
     )
     try:
         threads = int(args.get("threads", 1))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         threads = 1
     thread_group = "smp" if threads > 1 else "st"
     return {
@@ -775,7 +775,7 @@ def signup(request: _ViewContext) -> dict[str, Any] | RedirectResponse:  # noqa:
             data=payload,
             timeout=HTTP_TIMEOUT,
         ).json()
-    except requests.RequestException, ValueError:
+    except (requests.RequestException, ValueError):
         request.session.flash("Captcha verification failed", "error")
         return signup_context
 
@@ -1829,7 +1829,7 @@ def _contributors_sort_value(user: dict[str, Any], sort_key: str) -> Any:  # noq
         return 0
     try:
         return int(user.get(sort_key, 0))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return 0
 
 

--- a/server/fishtest/views_helpers.py
+++ b/server/fishtest/views_helpers.py
@@ -108,7 +108,7 @@ def _positive_int_param(
         return None
     try:
         value = int(raw_value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None
     if value <= 0:
         return None
@@ -122,7 +122,7 @@ def _float_param(raw_value: Any) -> float | None:  # noqa: ANN401
         return None
     try:
         return float(raw_value)
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None
 
 

--- a/server/fishtest/views_machines.py
+++ b/server/fishtest/views_machines.py
@@ -83,7 +83,7 @@ def _machines_version_parts(values: list[Any] | None) -> tuple[int, ...]:
     for value in values or []:
         try:
             parts.append(int(value))
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             break
     return tuple(parts)
 
@@ -225,7 +225,7 @@ def _machines_sort_value(  # noqa: PLR0911
         return value.timestamp() if isinstance(value, datetime) else 0
     try:
         return int(machine_row.get(sort_key, 0))
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return 0
 
 

--- a/server/fishtest/views_run.py
+++ b/server/fishtest/views_run.py
@@ -87,7 +87,7 @@ def get_master_info(  # noqa: C901
     for commit in commits:
         try:
             raw_message = commit["commit"]["message"]
-        except KeyError, TypeError:
+        except (KeyError, TypeError):
             # Be tolerant to partial payload corruption in later entries.
             continue
         if not isinstance(raw_message, str):


### PR DESCRIPTION
Several server modules use Python 2-style `except A, B:` clauses, which are a `SyntaxError` under Python 3 and prevent the affected modules from importing. This converts all of them to the parenthesized `except (A, B):` form across the server tree (16 clauses in 11 files).

Notably this unblocks `server/fishtest/views_helpers.py`, whose import failure broke the finished-runs pagination helper referenced in #1679 — the pagination logic itself already renders the last-page link correctly once the module imports.

Relates to #1679.