### PR TITLE
Make highlighted active contributor row permanently green

### DIFF
--- a/server/fishtest/static/css/application.css
+++ b/server/fishtest/static/css/application.css
@@ -815,17 +815,9 @@ td {
   opacity: 1;
 }
 
-@keyframes contributor-highlight-fade {
-  0% {
-    background-color: palegreen;
-  }
-  100% {
-    background-color: transparent;
-  }
-}
-
-tr.highlight-row > td {
-  animation: contributor-highlight-fade 3s ease-out;
+/* Keep active contributor row green in light mode */
+.table tbody tr.table-active.highlight-row > td {
+  background-color: palegreen;
 }
 
 /* Pagination links */

--- a/server/fishtest/static/css/theme.dark.css
+++ b/server/fishtest/static/css/theme.dark.css
@@ -248,19 +248,9 @@ div#tasks thead {
   background-color: #800080;
 }
 
-/* Keep active contributor row slightly lighter in dark mode. */
+/* Keep active contributor row green in dark mode. */
 .table tbody tr.table-active.highlight-row > td {
-  background-color: #2a2f36;
-  animation: contributor-highlight-fade-dark 3s ease-out;
-}
-
-@keyframes contributor-highlight-fade-dark {
-  0% {
-    background-color: palegreen;
-  }
-  100% {
-    background-color: #2a2f36;
-  }
+  background-color: #1a3f1c; /* A deep green to keep the white text readable */
 }
 
 /* Override - test tasks table - purged tasks red background */


### PR DESCRIPTION
Make highlighted active contributor row permanently green

Currently, when using the "Jump to my rank" feature on the Contributors page, the row highlights green for 3 seconds before fading out to standard grey. The resulting grey background is very subtle and can be difficult to distinguish from standard alternating table row colors.

This PR changes the behavior to keep the active contributor's row highlighted green permanently.
The fade-out animations and associated keyframes have been removed to keep the styling simple and consistent.